### PR TITLE
fix: platform coverage — all profiles now cover claude-code, codex, cursor (2026-04-01)

### DIFF
--- a/agency-agents/agency-agents-agency-design/README.md
+++ b/agency-agents/agency-agents-agency-design/README.md
@@ -28,7 +28,7 @@ npx hephai install @hephai-nota/agency-design
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -38,6 +38,7 @@ npx hephai install @hephai-nota/agency-design
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/agency-agents/agency-agents-agency-design/for-hephai/README.md
+++ b/agency-agents/agency-agents-agency-design/for-hephai/README.md
@@ -30,7 +30,7 @@ npx hephai install @hephai-nota/agency-design
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -40,6 +40,7 @@ npx hephai install @hephai-nota/agency-design
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/agency-agents/agency-agents-agency-design/for-hephai/profile.yml
+++ b/agency-agents/agency-agents-agency-design/for-hephai/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-design"
-version: "0.0.2"
+version: "0.0.3"
 description: >-
   Design division from The Agency — 8 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,
@@ -14,7 +14,7 @@ sourcePlatform: claude-code
 compatibility:
   platforms:
     tested: [claude-code]
-    partial: [cursor]
+    partial: [codex, cursor]
 
   models:
     recommended: [claude-4-opus]

--- a/agency-agents/agency-agents-agency-engineering/README.md
+++ b/agency-agents/agency-agents-agency-engineering/README.md
@@ -43,7 +43,7 @@ npx hephai install @hephai-nota/agency-engineering
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -53,6 +53,7 @@ npx hephai install @hephai-nota/agency-engineering
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/agency-agents/agency-agents-agency-engineering/for-hephai/README.md
+++ b/agency-agents/agency-agents-agency-engineering/for-hephai/README.md
@@ -45,7 +45,7 @@ npx hephai install @hephai-nota/agency-engineering
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -55,6 +55,7 @@ npx hephai install @hephai-nota/agency-engineering
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/agency-agents/agency-agents-agency-engineering/for-hephai/profile.yml
+++ b/agency-agents/agency-agents-agency-engineering/for-hephai/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-engineering"
-version: "0.0.2"
+version: "0.0.3"
 description: >-
   Engineering division from The Agency — 23 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,
@@ -14,7 +14,7 @@ sourcePlatform: claude-code
 compatibility:
   platforms:
     tested: [claude-code]
-    partial: [cursor]
+    partial: [codex, cursor]
 
   models:
     recommended: [claude-4-opus]

--- a/agency-agents/agency-agents-agency-game-development/README.md
+++ b/agency-agents/agency-agents-agency-game-development/README.md
@@ -40,7 +40,7 @@ npx hephai install @hephai-nota/agency-game-development
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -50,6 +50,7 @@ npx hephai install @hephai-nota/agency-game-development
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/agency-agents/agency-agents-agency-game-development/for-hephai/README.md
+++ b/agency-agents/agency-agents-agency-game-development/for-hephai/README.md
@@ -42,7 +42,7 @@ npx hephai install @hephai-nota/agency-game-development
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -52,6 +52,7 @@ npx hephai install @hephai-nota/agency-game-development
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/agency-agents/agency-agents-agency-game-development/for-hephai/profile.yml
+++ b/agency-agents/agency-agents-agency-game-development/for-hephai/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-game-development"
-version: "0.0.2"
+version: "0.0.3"
 description: >-
   Game Development division from The Agency — 20 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,
@@ -14,7 +14,7 @@ sourcePlatform: claude-code
 compatibility:
   platforms:
     tested: [claude-code]
-    partial: [cursor]
+    partial: [codex, cursor]
 
   models:
     recommended: [claude-4-opus]

--- a/agency-agents/agency-agents-agency-marketing/README.md
+++ b/agency-agents/agency-agents-agency-marketing/README.md
@@ -47,7 +47,7 @@ npx hephai install @hephai-nota/agency-marketing
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -57,6 +57,7 @@ npx hephai install @hephai-nota/agency-marketing
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/agency-agents/agency-agents-agency-marketing/for-hephai/README.md
+++ b/agency-agents/agency-agents-agency-marketing/for-hephai/README.md
@@ -49,7 +49,7 @@ npx hephai install @hephai-nota/agency-marketing
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -59,6 +59,7 @@ npx hephai install @hephai-nota/agency-marketing
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/agency-agents/agency-agents-agency-marketing/for-hephai/profile.yml
+++ b/agency-agents/agency-agents-agency-marketing/for-hephai/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-marketing"
-version: "0.0.2"
+version: "0.0.3"
 description: >-
   Marketing division from The Agency — 27 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,
@@ -14,7 +14,7 @@ sourcePlatform: claude-code
 compatibility:
   platforms:
     tested: [claude-code]
-    partial: [cursor]
+    partial: [codex, cursor]
 
   models:
     recommended: [claude-4-opus]

--- a/agency-agents/agency-agents-agency-paid-media/README.md
+++ b/agency-agents/agency-agents-agency-paid-media/README.md
@@ -27,7 +27,7 @@ npx hephai install @hephai-nota/agency-paid-media
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -37,6 +37,7 @@ npx hephai install @hephai-nota/agency-paid-media
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/agency-agents/agency-agents-agency-paid-media/for-hephai/README.md
+++ b/agency-agents/agency-agents-agency-paid-media/for-hephai/README.md
@@ -29,7 +29,7 @@ npx hephai install @hephai-nota/agency-paid-media
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -39,6 +39,7 @@ npx hephai install @hephai-nota/agency-paid-media
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/agency-agents/agency-agents-agency-paid-media/for-hephai/profile.yml
+++ b/agency-agents/agency-agents-agency-paid-media/for-hephai/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-paid-media"
-version: "0.0.2"
+version: "0.0.3"
 description: >-
   Paid Media division from The Agency — 7 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,
@@ -14,7 +14,7 @@ sourcePlatform: claude-code
 compatibility:
   platforms:
     tested: [claude-code]
-    partial: [cursor]
+    partial: [codex, cursor]
 
   models:
     recommended: [claude-4-opus]

--- a/agency-agents/agency-agents-agency-product/README.md
+++ b/agency-agents/agency-agents-agency-product/README.md
@@ -25,7 +25,7 @@ npx hephai install @hephai-nota/agency-product
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -35,6 +35,7 @@ npx hephai install @hephai-nota/agency-product
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/agency-agents/agency-agents-agency-product/for-hephai/README.md
+++ b/agency-agents/agency-agents-agency-product/for-hephai/README.md
@@ -27,7 +27,7 @@ npx hephai install @hephai-nota/agency-product
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -37,6 +37,7 @@ npx hephai install @hephai-nota/agency-product
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/agency-agents/agency-agents-agency-product/for-hephai/profile.yml
+++ b/agency-agents/agency-agents-agency-product/for-hephai/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-product"
-version: "0.0.2"
+version: "0.0.3"
 description: >-
   Product division from The Agency — 5 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,
@@ -14,7 +14,7 @@ sourcePlatform: claude-code
 compatibility:
   platforms:
     tested: [claude-code]
-    partial: [cursor]
+    partial: [codex, cursor]
 
   models:
     recommended: [claude-4-opus]

--- a/agency-agents/agency-agents-agency-project-management/README.md
+++ b/agency-agents/agency-agents-agency-project-management/README.md
@@ -26,7 +26,7 @@ npx hephai install @hephai-nota/agency-project-management
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -36,6 +36,7 @@ npx hephai install @hephai-nota/agency-project-management
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/agency-agents/agency-agents-agency-project-management/for-hephai/README.md
+++ b/agency-agents/agency-agents-agency-project-management/for-hephai/README.md
@@ -28,7 +28,7 @@ npx hephai install @hephai-nota/agency-project-management
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -38,6 +38,7 @@ npx hephai install @hephai-nota/agency-project-management
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/agency-agents/agency-agents-agency-project-management/for-hephai/profile.yml
+++ b/agency-agents/agency-agents-agency-project-management/for-hephai/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-project-management"
-version: "0.0.2"
+version: "0.0.3"
 description: >-
   Project Management division from The Agency — 6 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,
@@ -14,7 +14,7 @@ sourcePlatform: claude-code
 compatibility:
   platforms:
     tested: [claude-code]
-    partial: [cursor]
+    partial: [codex, cursor]
 
   models:
     recommended: [claude-4-opus]

--- a/agency-agents/agency-agents-agency-sales/README.md
+++ b/agency-agents/agency-agents-agency-sales/README.md
@@ -28,7 +28,7 @@ npx hephai install @hephai-nota/agency-sales
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -38,6 +38,7 @@ npx hephai install @hephai-nota/agency-sales
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/agency-agents/agency-agents-agency-sales/for-hephai/README.md
+++ b/agency-agents/agency-agents-agency-sales/for-hephai/README.md
@@ -30,7 +30,7 @@ npx hephai install @hephai-nota/agency-sales
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -40,6 +40,7 @@ npx hephai install @hephai-nota/agency-sales
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/agency-agents/agency-agents-agency-sales/for-hephai/profile.yml
+++ b/agency-agents/agency-agents-agency-sales/for-hephai/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-sales"
-version: "0.0.2"
+version: "0.0.3"
 description: >-
   Sales division from The Agency — 8 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,
@@ -14,7 +14,7 @@ sourcePlatform: claude-code
 compatibility:
   platforms:
     tested: [claude-code]
-    partial: [cursor]
+    partial: [codex, cursor]
 
   models:
     recommended: [claude-4-opus]

--- a/agency-agents/agency-agents-agency-spatial-computing/README.md
+++ b/agency-agents/agency-agents-agency-spatial-computing/README.md
@@ -26,7 +26,7 @@ npx hephai install @hephai-nota/agency-spatial-computing
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -36,6 +36,7 @@ npx hephai install @hephai-nota/agency-spatial-computing
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/agency-agents/agency-agents-agency-spatial-computing/for-hephai/README.md
+++ b/agency-agents/agency-agents-agency-spatial-computing/for-hephai/README.md
@@ -28,7 +28,7 @@ npx hephai install @hephai-nota/agency-spatial-computing
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -38,6 +38,7 @@ npx hephai install @hephai-nota/agency-spatial-computing
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/agency-agents/agency-agents-agency-spatial-computing/for-hephai/profile.yml
+++ b/agency-agents/agency-agents-agency-spatial-computing/for-hephai/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-spatial-computing"
-version: "0.0.2"
+version: "0.0.3"
 description: >-
   Spatial Computing division from The Agency — 6 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,
@@ -14,7 +14,7 @@ sourcePlatform: claude-code
 compatibility:
   platforms:
     tested: [claude-code]
-    partial: [cursor]
+    partial: [codex, cursor]
 
   models:
     recommended: [claude-4-opus]

--- a/agency-agents/agency-agents-agency-specialized/README.md
+++ b/agency-agents/agency-agents-agency-specialized/README.md
@@ -47,7 +47,7 @@ npx hephai install @hephai-nota/agency-specialized
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -57,6 +57,7 @@ npx hephai install @hephai-nota/agency-specialized
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/agency-agents/agency-agents-agency-specialized/for-hephai/README.md
+++ b/agency-agents/agency-agents-agency-specialized/for-hephai/README.md
@@ -49,7 +49,7 @@ npx hephai install @hephai-nota/agency-specialized
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -59,6 +59,7 @@ npx hephai install @hephai-nota/agency-specialized
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/agency-agents/agency-agents-agency-specialized/for-hephai/profile.yml
+++ b/agency-agents/agency-agents-agency-specialized/for-hephai/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-specialized"
-version: "0.0.2"
+version: "0.0.3"
 description: >-
   Specialized division from The Agency — 27 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,
@@ -14,7 +14,7 @@ sourcePlatform: claude-code
 compatibility:
   platforms:
     tested: [claude-code]
-    partial: [cursor]
+    partial: [codex, cursor]
 
   models:
     recommended: [claude-4-opus]

--- a/agency-agents/agency-agents-agency-support/README.md
+++ b/agency-agents/agency-agents-agency-support/README.md
@@ -26,7 +26,7 @@ npx hephai install @hephai-nota/agency-support
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -36,6 +36,7 @@ npx hephai install @hephai-nota/agency-support
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/agency-agents/agency-agents-agency-support/for-hephai/README.md
+++ b/agency-agents/agency-agents-agency-support/for-hephai/README.md
@@ -28,7 +28,7 @@ npx hephai install @hephai-nota/agency-support
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -38,6 +38,7 @@ npx hephai install @hephai-nota/agency-support
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/agency-agents/agency-agents-agency-support/for-hephai/profile.yml
+++ b/agency-agents/agency-agents-agency-support/for-hephai/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-support"
-version: "0.0.2"
+version: "0.0.3"
 description: >-
   Support division from The Agency — 6 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,
@@ -14,7 +14,7 @@ sourcePlatform: claude-code
 compatibility:
   platforms:
     tested: [claude-code]
-    partial: [cursor]
+    partial: [codex, cursor]
 
   models:
     recommended: [claude-4-opus]

--- a/agency-agents/agency-agents-agency-testing/README.md
+++ b/agency-agents/agency-agents-agency-testing/README.md
@@ -28,7 +28,7 @@ npx hephai install @hephai-nota/agency-testing
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -38,6 +38,7 @@ npx hephai install @hephai-nota/agency-testing
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/agency-agents/agency-agents-agency-testing/for-hephai/README.md
+++ b/agency-agents/agency-agents-agency-testing/for-hephai/README.md
@@ -30,7 +30,7 @@ npx hephai install @hephai-nota/agency-testing
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -40,6 +40,7 @@ npx hephai install @hephai-nota/agency-testing
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/agency-agents/agency-agents-agency-testing/for-hephai/profile.yml
+++ b/agency-agents/agency-agents-agency-testing/for-hephai/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-testing"
-version: "0.0.2"
+version: "0.0.3"
 description: >-
   Testing division from The Agency — 8 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,
@@ -14,7 +14,7 @@ sourcePlatform: claude-code
 compatibility:
   platforms:
     tested: [claude-code]
-    partial: [cursor]
+    partial: [codex, cursor]
 
   models:
     recommended: [claude-4-opus]

--- a/awesome-codex-subagents/awesome-codex-subagents-business-product/README.md
+++ b/awesome-codex-subagents/awesome-codex-subagents-business-product/README.md
@@ -30,7 +30,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-business-product
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -41,6 +41,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-business-product
 |---|---|
 | Codex | Tested |
 | Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/awesome-codex-subagents/awesome-codex-subagents-business-product/for-hephai/README.md
+++ b/awesome-codex-subagents/awesome-codex-subagents-business-product/for-hephai/README.md
@@ -32,7 +32,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-business-product
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -43,6 +43,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-business-product
 |---|---|
 | Codex | Tested |
 | Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/awesome-codex-subagents/awesome-codex-subagents-business-product/for-hephai/profile.yml
+++ b/awesome-codex-subagents/awesome-codex-subagents-business-product/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: awesome-codex-subagents-business-product
-version: "0.0.2"
+version: "0.0.3"
 description: >-
   Support agents for requirements, UX, and engineering-adjacent writing tasks. Includes 11 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 
@@ -11,7 +11,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: [claude-code]
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-5.3-codex-spark]

--- a/awesome-codex-subagents/awesome-codex-subagents-core-development/README.md
+++ b/awesome-codex-subagents/awesome-codex-subagents-core-development/README.md
@@ -31,7 +31,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-core-development
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -41,6 +41,8 @@ npx hephai install @hephai-nota/awesome-codex-subagents-core-development
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/awesome-codex-subagents/awesome-codex-subagents-core-development/for-hephai/README.md
+++ b/awesome-codex-subagents/awesome-codex-subagents-core-development/for-hephai/README.md
@@ -33,7 +33,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-core-development
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -43,6 +43,8 @@ npx hephai install @hephai-nota/awesome-codex-subagents-core-development
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/awesome-codex-subagents/awesome-codex-subagents-core-development/for-hephai/profile.yml
+++ b/awesome-codex-subagents/awesome-codex-subagents-core-development/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: awesome-codex-subagents-core-development
-version: "0.0.4"
+version: "0.0.5"
 description: >-
   Core agents for application architecture, cross-layer implementation, UI work, and protocol-specific development. Includes 12 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 
@@ -11,6 +11,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-5.3-codex-spark]

--- a/awesome-codex-subagents/awesome-codex-subagents-data-ai/README.md
+++ b/awesome-codex-subagents/awesome-codex-subagents-data-ai/README.md
@@ -31,7 +31,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-data-ai
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -42,6 +42,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-data-ai
 |---|---|
 | Codex | Tested |
 | Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/awesome-codex-subagents/awesome-codex-subagents-data-ai/for-hephai/README.md
+++ b/awesome-codex-subagents/awesome-codex-subagents-data-ai/for-hephai/README.md
@@ -33,7 +33,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-data-ai
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -44,6 +44,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-data-ai
 |---|---|
 | Codex | Tested |
 | Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/awesome-codex-subagents/awesome-codex-subagents-data-ai/for-hephai/profile.yml
+++ b/awesome-codex-subagents/awesome-codex-subagents-data-ai/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: awesome-codex-subagents-data-ai
-version: "0.0.2"
+version: "0.0.3"
 description: >-
   Agents for data pipelines, LLM integrations, and database behavior. Includes 12 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 
@@ -11,7 +11,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: [claude-code]
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-5.3-codex-spark]

--- a/awesome-codex-subagents/awesome-codex-subagents-developer-experience/README.md
+++ b/awesome-codex-subagents/awesome-codex-subagents-developer-experience/README.md
@@ -32,7 +32,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-developer-experience
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -43,6 +43,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-developer-experience
 |---|---|
 | Codex | Tested |
 | Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/awesome-codex-subagents/awesome-codex-subagents-developer-experience/for-hephai/README.md
+++ b/awesome-codex-subagents/awesome-codex-subagents-developer-experience/for-hephai/README.md
@@ -34,7 +34,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-developer-experience
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -45,6 +45,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-developer-experience
 |---|---|
 | Codex | Tested |
 | Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/awesome-codex-subagents/awesome-codex-subagents-developer-experience/for-hephai/profile.yml
+++ b/awesome-codex-subagents/awesome-codex-subagents-developer-experience/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: awesome-codex-subagents-developer-experience
-version: "0.0.2"
+version: "0.0.3"
 description: >-
   Agents for builds, developer tooling, documentation, MCP integrations, and refactors. Includes 13 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 
@@ -11,7 +11,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: [claude-code]
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-5.3-codex-spark]

--- a/awesome-codex-subagents/awesome-codex-subagents-infrastructure/README.md
+++ b/awesome-codex-subagents/awesome-codex-subagents-infrastructure/README.md
@@ -35,7 +35,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-infrastructure
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -46,6 +46,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-infrastructure
 |---|---|
 | Codex | Tested |
 | Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/awesome-codex-subagents/awesome-codex-subagents-infrastructure/for-hephai/README.md
+++ b/awesome-codex-subagents/awesome-codex-subagents-infrastructure/for-hephai/README.md
@@ -37,7 +37,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-infrastructure
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -48,6 +48,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-infrastructure
 |---|---|
 | Codex | Tested |
 | Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/awesome-codex-subagents/awesome-codex-subagents-infrastructure/for-hephai/profile.yml
+++ b/awesome-codex-subagents/awesome-codex-subagents-infrastructure/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: awesome-codex-subagents-infrastructure
-version: "0.0.2"
+version: "0.0.3"
 description: >-
   Infrastructure-focused agents for deployment, containerization, orchestration, and IaC work. Includes 16 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 
@@ -11,7 +11,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: [claude-code]
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-5.3-codex-spark]

--- a/awesome-codex-subagents/awesome-codex-subagents-language-specialists/README.md
+++ b/awesome-codex-subagents/awesome-codex-subagents-language-specialists/README.md
@@ -45,7 +45,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-language-specialists
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -56,6 +56,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-language-specialists
 |---|---|
 | Codex | Tested |
 | Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/awesome-codex-subagents/awesome-codex-subagents-language-specialists/for-hephai/README.md
+++ b/awesome-codex-subagents/awesome-codex-subagents-language-specialists/for-hephai/README.md
@@ -47,7 +47,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-language-specialists
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -58,6 +58,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-language-specialists
 |---|---|
 | Codex | Tested |
 | Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/awesome-codex-subagents/awesome-codex-subagents-language-specialists/for-hephai/profile.yml
+++ b/awesome-codex-subagents/awesome-codex-subagents-language-specialists/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: awesome-codex-subagents-language-specialists
-version: "0.0.2"
+version: "0.0.3"
 description: >-
   Language and framework specialists for ecosystem-specific implementation, debugging, and architectural guidance. Includes 26 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 
@@ -11,7 +11,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: [claude-code]
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-5.3-codex-spark]

--- a/awesome-codex-subagents/awesome-codex-subagents-meta-orchestration/README.md
+++ b/awesome-codex-subagents/awesome-codex-subagents-meta-orchestration/README.md
@@ -29,7 +29,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-meta-orchestration
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -40,6 +40,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-meta-orchestration
 |---|---|
 | Codex | Tested |
 | Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/awesome-codex-subagents/awesome-codex-subagents-meta-orchestration/for-hephai/README.md
+++ b/awesome-codex-subagents/awesome-codex-subagents-meta-orchestration/for-hephai/README.md
@@ -31,7 +31,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-meta-orchestration
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -42,6 +42,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-meta-orchestration
 |---|---|
 | Codex | Tested |
 | Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/awesome-codex-subagents/awesome-codex-subagents-meta-orchestration/for-hephai/profile.yml
+++ b/awesome-codex-subagents/awesome-codex-subagents-meta-orchestration/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: awesome-codex-subagents-meta-orchestration
-version: "0.0.2"
+version: "0.0.3"
 description: >-
   Agents that help plan or coordinate multi-agent Codex workflows without inventing unsupported mechanics. Includes 10 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 
@@ -11,7 +11,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: [claude-code]
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-5.3-codex-spark]

--- a/awesome-codex-subagents/awesome-codex-subagents-quality-security/README.md
+++ b/awesome-codex-subagents/awesome-codex-subagents-quality-security/README.md
@@ -35,7 +35,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-quality-security
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -46,6 +46,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-quality-security
 |---|---|
 | Codex | Tested |
 | Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/awesome-codex-subagents/awesome-codex-subagents-quality-security/for-hephai/README.md
+++ b/awesome-codex-subagents/awesome-codex-subagents-quality-security/for-hephai/README.md
@@ -37,7 +37,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-quality-security
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -48,6 +48,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-quality-security
 |---|---|
 | Codex | Tested |
 | Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/awesome-codex-subagents/awesome-codex-subagents-quality-security/for-hephai/profile.yml
+++ b/awesome-codex-subagents/awesome-codex-subagents-quality-security/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: awesome-codex-subagents-quality-security
-version: "0.0.2"
+version: "0.0.3"
 description: >-
   Review and verification agents that work especially well as read-heavy Codex subagents. Includes 16 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 
@@ -11,7 +11,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: [claude-code]
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-5.3-codex-spark]

--- a/awesome-codex-subagents/awesome-codex-subagents-research-analysis/README.md
+++ b/awesome-codex-subagents/awesome-codex-subagents-research-analysis/README.md
@@ -26,7 +26,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-research-analysis
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -37,6 +37,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-research-analysis
 |---|---|
 | Codex | Tested |
 | Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/awesome-codex-subagents/awesome-codex-subagents-research-analysis/for-hephai/README.md
+++ b/awesome-codex-subagents/awesome-codex-subagents-research-analysis/for-hephai/README.md
@@ -28,7 +28,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-research-analysis
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -39,6 +39,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-research-analysis
 |---|---|
 | Codex | Tested |
 | Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/awesome-codex-subagents/awesome-codex-subagents-research-analysis/for-hephai/profile.yml
+++ b/awesome-codex-subagents/awesome-codex-subagents-research-analysis/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: awesome-codex-subagents-research-analysis
-version: "0.0.2"
+version: "0.0.3"
 description: >-
   Read-heavy research agents for searching, validating, comparing, and synthesizing information. Includes 7 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 
@@ -11,7 +11,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: [claude-code]
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-5.3-codex-spark]

--- a/awesome-codex-subagents/awesome-codex-subagents-specialized-domains/README.md
+++ b/awesome-codex-subagents/awesome-codex-subagents-specialized-domains/README.md
@@ -31,7 +31,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-specialized-domains
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -42,6 +42,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-specialized-domains
 |---|---|
 | Codex | Tested |
 | Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/awesome-codex-subagents/awesome-codex-subagents-specialized-domains/for-hephai/README.md
+++ b/awesome-codex-subagents/awesome-codex-subagents-specialized-domains/for-hephai/README.md
@@ -33,7 +33,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-specialized-domains
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -44,6 +44,7 @@ npx hephai install @hephai-nota/awesome-codex-subagents-specialized-domains
 |---|---|
 | Codex | Tested |
 | Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/awesome-codex-subagents/awesome-codex-subagents-specialized-domains/for-hephai/profile.yml
+++ b/awesome-codex-subagents/awesome-codex-subagents-specialized-domains/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: awesome-codex-subagents-specialized-domains
-version: "0.0.2"
+version: "0.0.3"
 description: >-
   Focused domain agents that still have a clear implementation or verification boundary. Includes 12 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 
@@ -11,7 +11,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: [claude-code]
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-5.3-codex-spark]

--- a/context7/README.md
+++ b/context7/README.md
@@ -29,7 +29,7 @@ npx hephai install @hephai-nota/context7
 |---|---|
 | Author | `Upstash` |
 | Original repository | `https://github.com/upstash/context7` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `383e127` (2026-03-16) |
 | Converted path | `plugins/claude/context7/` |
 | License | `MIT` |
@@ -40,6 +40,7 @@ npx hephai install @hephai-nota/context7
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/context7/for-hephai/README.md
+++ b/context7/for-hephai/README.md
@@ -31,7 +31,7 @@ npx hephai install @hephai-nota/context7
 |---|---|
 | Author | `Upstash` |
 | Original repository | `https://github.com/upstash/context7` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `383e127` (2026-03-16) |
 | Converted path | `plugins/claude/context7/` |
 | License | `MIT` |
@@ -42,6 +42,7 @@ npx hephai install @hephai-nota/context7
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Codex | Partial |
 | Cursor | Partial |
 
 ### Models

--- a/context7/for-hephai/profile.yml
+++ b/context7/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: context7
-version: "0.0.2"
+version: "0.0.3"
 description: >-
   Up-to-date documentation lookup via Context7 MCP. Pull version-specific
   documentation and code examples directly from source repositories into
@@ -12,7 +12,7 @@ sourcePlatform: claude-code
 compatibility:
   platforms:
     tested: [claude-code]
-    partial: [cursor]
+    partial: [codex, cursor]
   models:
     recommended: [claude-4-opus]
     minimum: [claude-4-sonnet]

--- a/cursor-team-kit/README.md
+++ b/cursor-team-kit/README.md
@@ -37,7 +37,7 @@ npx hephai install @hephai-nota/cursor-team-kit
 |---|---|
 | Author | `Cursor` |
 | Original repository | `https://github.com/cursor/plugins` |
-| Version | `0.0.1` |
+| Version | `0.0.2` |
 | Original commit | `9c39b57` (2026-03-13) |
 | License | `MIT` |
 | Source platform | `cursor` |
@@ -47,6 +47,8 @@ npx hephai install @hephai-nota/cursor-team-kit
 | Platform | Status |
 |---|---|
 | Cursor | Tested |
+| Claude Code | Partial |
+| Codex | Partial |
 
 ### Models
 | Model | Role |

--- a/cursor-team-kit/for-hephai/README.md
+++ b/cursor-team-kit/for-hephai/README.md
@@ -39,7 +39,7 @@ npx hephai install @hephai-nota/cursor-team-kit
 |---|---|
 | Author | `Cursor` |
 | Original repository | `https://github.com/cursor/plugins` |
-| Version | `0.0.1` |
+| Version | `0.0.2` |
 | Original commit | `9c39b57` (2026-03-13) |
 | License | `MIT` |
 | Source platform | `cursor` |
@@ -49,6 +49,8 @@ npx hephai install @hephai-nota/cursor-team-kit
 | Platform | Status |
 |---|---|
 | Cursor | Tested |
+| Claude Code | Partial |
+| Codex | Partial |
 
 ### Models
 | Model | Role |

--- a/cursor-team-kit/for-hephai/profile.yml
+++ b/cursor-team-kit/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: cursor-team-kit
-version: "0.0.1"
+version: "0.0.2"
 description: >-
   Internal workflows used by Cursor developers for CI, code review, and shipping. Covers the full dev loop: CI monitoring and fixing, PR creation, merge conflicts, smoke tests, compiler checks, code cleanup, and work summaries.
 repository: "https://github.com/cursor/plugins"
@@ -10,7 +10,7 @@ sourcePlatform: cursor
 compatibility:
   platforms:
     tested: [cursor]
-    partial: []
+    partial: [claude-code, codex]
   models:
     recommended: []
     minimum: []

--- a/knowledge-work-plugins/knowledge-work-plugins-bio-research/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-bio-research/README.md
@@ -51,7 +51,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-bio-research
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/bio-research |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -63,8 +63,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-bio-research
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-bio-research/for-hephai/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-bio-research/for-hephai/README.md
@@ -53,7 +53,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-bio-research
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/bio-research |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -65,8 +65,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-bio-research
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-bio-research/for-hephai/profile.yml
+++ b/knowledge-work-plugins/knowledge-work-plugins-bio-research/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-bio-research"
-version: "0.0.0"
+version: "0.0.1"
 description: Connect to preclinical research tools and databases (literature search, genomics analysis, target prioritization) to accelerate early-stage life sciences R&D.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/bio-research
 license: Apache-2.0

--- a/knowledge-work-plugins/knowledge-work-plugins-customer-support/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-customer-support/README.md
@@ -48,7 +48,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-customer-support
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/customer-support |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -60,8 +60,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-customer-support
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-customer-support/for-hephai/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-customer-support/for-hephai/README.md
@@ -50,7 +50,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-customer-support
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/customer-support |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -62,8 +62,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-customer-support
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-customer-support/for-hephai/profile.yml
+++ b/knowledge-work-plugins/knowledge-work-plugins-customer-support/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-customer-support"
-version: "0.0.0"
+version: "0.0.1"
 description: Triage tickets, draft responses, escalate issues, and build your knowledge base. Research customer context and turn resolved issues into self-service content.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/customer-support
 license: Apache-2.0

--- a/knowledge-work-plugins/knowledge-work-plugins-data/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-data/README.md
@@ -53,7 +53,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-data
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/data |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -65,8 +65,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-data
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-data/for-hephai/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-data/for-hephai/README.md
@@ -55,7 +55,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-data
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/data |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -67,8 +67,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-data
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-data/for-hephai/profile.yml
+++ b/knowledge-work-plugins/knowledge-work-plugins-data/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-data"
-version: "0.0.0"
+version: "0.0.1"
 description: Write SQL, explore datasets, and generate insights faster. Build visualizations and dashboards, and turn raw data into clear stories for stakeholders.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/data
 license: Apache-2.0

--- a/knowledge-work-plugins/knowledge-work-plugins-design/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-design/README.md
@@ -51,7 +51,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-design
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/design |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -63,8 +63,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-design
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-design/for-hephai/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-design/for-hephai/README.md
@@ -53,7 +53,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-design
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/design |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -65,8 +65,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-design
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-design/for-hephai/profile.yml
+++ b/knowledge-work-plugins/knowledge-work-plugins-design/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-design"
-version: "0.0.0"
+version: "0.0.1"
 description: Accelerate design workflows — critique, design system management, UX writing, accessibility audits, research synthesis, and dev handoff. From exploration to pixel-perfect specs.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/design
 license: Apache-2.0

--- a/knowledge-work-plugins/knowledge-work-plugins-engineering/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-engineering/README.md
@@ -55,7 +55,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-engineering
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/engineering |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -67,8 +67,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-engineering
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-engineering/for-hephai/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-engineering/for-hephai/README.md
@@ -57,7 +57,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-engineering
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/engineering |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -69,8 +69,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-engineering
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-engineering/for-hephai/profile.yml
+++ b/knowledge-work-plugins/knowledge-work-plugins-engineering/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-engineering"
-version: "0.0.0"
+version: "0.0.1"
 description: Streamline engineering workflows — standups, code review, architecture decisions, incident response, and technical documentation. Works with your existing tools or standalone.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/engineering
 license: Apache-2.0

--- a/knowledge-work-plugins/knowledge-work-plugins-enterprise-search/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-enterprise-search/README.md
@@ -47,7 +47,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-enterprise-search
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/enterprise-search |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -59,8 +59,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-enterprise-search
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-enterprise-search/for-hephai/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-enterprise-search/for-hephai/README.md
@@ -49,7 +49,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-enterprise-search
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/enterprise-search |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -61,8 +61,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-enterprise-search
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-enterprise-search/for-hephai/profile.yml
+++ b/knowledge-work-plugins/knowledge-work-plugins-enterprise-search/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-enterprise-search"
-version: "0.0.0"
+version: "0.0.1"
 description: Search across all of your company's tools in one place. Find anything across email, chat, documents, and wikis without switching between apps.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/enterprise-search
 license: Apache-2.0

--- a/knowledge-work-plugins/knowledge-work-plugins-finance/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-finance/README.md
@@ -50,7 +50,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-finance
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/finance |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -62,8 +62,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-finance
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-finance/for-hephai/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-finance/for-hephai/README.md
@@ -52,7 +52,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-finance
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/finance |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -64,8 +64,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-finance
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-finance/for-hephai/profile.yml
+++ b/knowledge-work-plugins/knowledge-work-plugins-finance/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-finance"
-version: "0.0.0"
+version: "0.0.1"
 description: Streamline finance and accounting workflows, from journal entries and reconciliation to financial statements and variance analysis. Speed up audit prep, month-end close, and keeping your books clean.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/finance
 license: Apache-2.0

--- a/knowledge-work-plugins/knowledge-work-plugins-human-resources/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-human-resources/README.md
@@ -50,7 +50,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-human-resources
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/human-resources |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -62,8 +62,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-human-resources
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-human-resources/for-hephai/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-human-resources/for-hephai/README.md
@@ -52,7 +52,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-human-resources
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/human-resources |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -64,8 +64,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-human-resources
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-human-resources/for-hephai/profile.yml
+++ b/knowledge-work-plugins/knowledge-work-plugins-human-resources/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-human-resources"
-version: "0.0.0"
+version: "0.0.1"
 description: Streamline people operations — recruiting, onboarding, performance reviews, compensation analysis, and policy guidance. Maintain compliance and keep your team running smoothly.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/human-resources
 license: Apache-2.0

--- a/knowledge-work-plugins/knowledge-work-plugins-legal/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-legal/README.md
@@ -52,7 +52,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-legal
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/legal |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -64,8 +64,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-legal
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-legal/for-hephai/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-legal/for-hephai/README.md
@@ -54,7 +54,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-legal
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/legal |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -66,8 +66,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-legal
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-legal/for-hephai/profile.yml
+++ b/knowledge-work-plugins/knowledge-work-plugins-legal/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-legal"
-version: "0.0.0"
+version: "0.0.1"
 description: Speed up contract review, NDA triage, and compliance workflows for in-house legal teams. Draft legal briefs, organize precedent research, and manage institutional knowledge.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/legal
 license: Apache-2.0

--- a/knowledge-work-plugins/knowledge-work-plugins-marketing/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-marketing/README.md
@@ -56,7 +56,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-marketing
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/marketing |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -68,8 +68,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-marketing
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-marketing/for-hephai/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-marketing/for-hephai/README.md
@@ -58,7 +58,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-marketing
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/marketing |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -70,8 +70,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-marketing
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-marketing/for-hephai/profile.yml
+++ b/knowledge-work-plugins/knowledge-work-plugins-marketing/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-marketing"
-version: "0.0.0"
+version: "0.0.1"
 description: Create content, plan campaigns, and analyze performance across marketing channels. Maintain brand voice consistency, track competitors, and report on what's working.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/marketing
 license: Apache-2.0

--- a/knowledge-work-plugins/knowledge-work-plugins-operations/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-operations/README.md
@@ -52,7 +52,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-operations
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/operations |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -64,8 +64,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-operations
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-operations/for-hephai/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-operations/for-hephai/README.md
@@ -54,7 +54,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-operations
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/operations |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -66,8 +66,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-operations
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-operations/for-hephai/profile.yml
+++ b/knowledge-work-plugins/knowledge-work-plugins-operations/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-operations"
-version: "0.0.0"
+version: "0.0.1"
 description: Optimize business operations — vendor management, process documentation, change management, capacity planning, and compliance tracking. Keep your organization running efficiently.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/operations
 license: Apache-2.0

--- a/knowledge-work-plugins/knowledge-work-plugins-product-management/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-product-management/README.md
@@ -65,7 +65,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-product-management
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/product-management |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -77,8 +77,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-product-management
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-product-management/for-hephai/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-product-management/for-hephai/README.md
@@ -67,7 +67,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-product-management
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/product-management |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -79,8 +79,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-product-management
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-product-management/for-hephai/profile.yml
+++ b/knowledge-work-plugins/knowledge-work-plugins-product-management/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-product-management"
-version: "0.0.0"
+version: "0.0.1"
 description: Write feature specs, plan roadmaps, and synthesize user research faster. Keep stakeholders updated and stay ahead of the competitive landscape.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/product-management
 license: Apache-2.0

--- a/knowledge-work-plugins/knowledge-work-plugins-productivity/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-productivity/README.md
@@ -49,7 +49,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-productivity
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/productivity |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -61,8 +61,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-productivity
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-productivity/for-hephai/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-productivity/for-hephai/README.md
@@ -51,7 +51,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-productivity
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/productivity |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -63,8 +63,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-productivity
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-productivity/for-hephai/profile.yml
+++ b/knowledge-work-plugins/knowledge-work-plugins-productivity/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-productivity"
-version: "0.0.0"
+version: "0.0.1"
 description: Manage tasks, plan your day, and build up memory of important context about your work. Syncs with your calendar, email, and chat to keep everything organized and on track.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/productivity
 license: Apache-2.0

--- a/knowledge-work-plugins/knowledge-work-plugins-sales/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-sales/README.md
@@ -58,7 +58,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-sales
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/sales |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -70,8 +70,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-sales
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-sales/for-hephai/README.md
+++ b/knowledge-work-plugins/knowledge-work-plugins-sales/for-hephai/README.md
@@ -60,7 +60,7 @@ npx hephai install @hephai-nota/knowledge-work-plugins-sales
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/sales |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -72,8 +72,8 @@ npx hephai install @hephai-nota/knowledge-work-plugins-sales
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
 | Codex | Partial |
+| Cursor | Partial |
 
 ## Dependencies
 

--- a/knowledge-work-plugins/knowledge-work-plugins-sales/for-hephai/profile.yml
+++ b/knowledge-work-plugins/knowledge-work-plugins-sales/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-sales"
-version: "0.0.0"
+version: "0.0.1"
 description: Prospect, craft outreach, and build deal strategy faster. Prep for calls, manage your pipeline, and write personalized messaging that moves deals forward.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/sales
 license: Apache-2.0

--- a/openai-skills/openai-skills-aspnet-core/README.md
+++ b/openai-skills/openai-skills-aspnet-core/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-aspnet-core
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-aspnet-core
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-aspnet-core/for-hephai/README.md
+++ b/openai-skills/openai-skills-aspnet-core/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-aspnet-core
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-aspnet-core
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-aspnet-core/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-aspnet-core/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-aspnet-core
-version: "0.0.2"
+version: "0.0.3"
 description: "Build, review, refactor, or architect ASP.NET Core web applications using current official guidance for .NET web development. Use when working on Blazor Web Apps, Razor Pages, MVC, Minimal APIs, controller-based Web APIs, SignalR, gRPC, middleware, dependency injection, configuration, authentication, authorization, testing, performance, deployment, or ASP.NET Core upgrades."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-chatgpt-apps/README.md
+++ b/openai-skills/openai-skills-chatgpt-apps/README.md
@@ -24,7 +24,7 @@ npx hephai install @hephai-nota/openai-skills-chatgpt-apps
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx hephai install @hephai-nota/openai-skills-chatgpt-apps
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-chatgpt-apps/for-hephai/README.md
+++ b/openai-skills/openai-skills-chatgpt-apps/for-hephai/README.md
@@ -26,7 +26,7 @@ npx hephai install @hephai-nota/openai-skills-chatgpt-apps
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx hephai install @hephai-nota/openai-skills-chatgpt-apps
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-chatgpt-apps/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-chatgpt-apps/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-chatgpt-apps
-version: "0.0.2"
+version: "0.0.3"
 description: "Build, scaffold, refactor, and troubleshoot ChatGPT Apps SDK applications that combine an MCP server and widget UI. Use when Codex needs to design tools, register UI resources, wire the MCP Apps bridge or ChatGPT compatibility APIs, apply Apps SDK metadata or CSP or domain settings, or produce a docs-aligned project scaffold. Prefer a docs-first workflow by invoking the openai-docs skill or OpenAI developer docs MCP tools before generating code."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-cloudflare-deploy/README.md
+++ b/openai-skills/openai-skills-cloudflare-deploy/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-cloudflare-deploy
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-cloudflare-deploy
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-cloudflare-deploy/for-hephai/README.md
+++ b/openai-skills/openai-skills-cloudflare-deploy/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-cloudflare-deploy
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-cloudflare-deploy
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-cloudflare-deploy/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-cloudflare-deploy/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-cloudflare-deploy
-version: "0.0.2"
+version: "0.0.3"
 description: "Deploy applications and infrastructure to Cloudflare using Workers, Pages, and related platform services. Use when the user asks to deploy, host, publish, or set up a project on Cloudflare."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-develop-web-game/README.md
+++ b/openai-skills/openai-skills-develop-web-game/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-develop-web-game
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-develop-web-game
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-develop-web-game/for-hephai/README.md
+++ b/openai-skills/openai-skills-develop-web-game/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-develop-web-game
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-develop-web-game
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-develop-web-game/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-develop-web-game/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-develop-web-game
-version: "0.0.2"
+version: "0.0.3"
 description: "Use when Codex is building or iterating on a web game (HTML/JS) and needs a reliable development + testing loop: implement small changes, run a Playwright-based test script with short input bursts and intentional pauses, inspect screenshots/text, and review console errors with render_game_to_text."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-doc/README.md
+++ b/openai-skills/openai-skills-doc/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-doc
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-doc
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-doc/for-hephai/README.md
+++ b/openai-skills/openai-skills-doc/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-doc
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-doc
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-doc/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-doc/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-doc
-version: "0.0.2"
+version: "0.0.3"
 description: "Use when the task involves reading, creating, or editing `.docx` documents, especially when formatting or layout fidelity matters; prefer `python-docx` plus the bundled `scripts/render_docx.py` for visual checks."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-figma-code-connect-components/README.md
+++ b/openai-skills/openai-skills-figma-code-connect-components/README.md
@@ -24,7 +24,7 @@ npx hephai install @hephai-nota/openai-skills-figma-code-connect-components
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx hephai install @hephai-nota/openai-skills-figma-code-connect-components
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-figma-code-connect-components/for-hephai/README.md
+++ b/openai-skills/openai-skills-figma-code-connect-components/for-hephai/README.md
@@ -26,7 +26,7 @@ npx hephai install @hephai-nota/openai-skills-figma-code-connect-components
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx hephai install @hephai-nota/openai-skills-figma-code-connect-components
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-figma-code-connect-components/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-figma-code-connect-components/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-figma-code-connect-components
-version: "0.0.2"
+version: "0.0.3"
 description: "Connects Figma design components to code components using Code Connect mapping tools. Use when user says 'code connect', 'connect this component to code', 'map this component', 'link component to code', 'create code connect mapping', or wants to establish mappings between Figma designs and code implementations. For canvas writes via `use_figma`, use `figma-use`."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-figma-create-design-system-rules/README.md
+++ b/openai-skills/openai-skills-figma-create-design-system-rules/README.md
@@ -24,7 +24,7 @@ npx hephai install @hephai-nota/openai-skills-figma-create-design-system-rules
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx hephai install @hephai-nota/openai-skills-figma-create-design-system-rules
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-figma-create-design-system-rules/for-hephai/README.md
+++ b/openai-skills/openai-skills-figma-create-design-system-rules/for-hephai/README.md
@@ -26,7 +26,7 @@ npx hephai install @hephai-nota/openai-skills-figma-create-design-system-rules
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx hephai install @hephai-nota/openai-skills-figma-create-design-system-rules
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-figma-create-design-system-rules/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-figma-create-design-system-rules/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-figma-create-design-system-rules
-version: "0.0.2"
+version: "0.0.3"
 description: "Generates custom design system rules for the user's codebase. Use when user says 'create design system rules', 'generate rules for my project', 'set up design rules', 'customize design system guidelines', or wants to establish project-specific conventions for Figma-to-code workflows. Requires Figma MCP server connection."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-figma-create-new-file/README.md
+++ b/openai-skills/openai-skills-figma-create-new-file/README.md
@@ -24,7 +24,7 @@ npx hephai install @hephai-nota/openai-skills-figma-create-new-file
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx hephai install @hephai-nota/openai-skills-figma-create-new-file
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-figma-create-new-file/for-hephai/README.md
+++ b/openai-skills/openai-skills-figma-create-new-file/for-hephai/README.md
@@ -26,7 +26,7 @@ npx hephai install @hephai-nota/openai-skills-figma-create-new-file
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx hephai install @hephai-nota/openai-skills-figma-create-new-file
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-figma-create-new-file/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-figma-create-new-file/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-figma-create-new-file
-version: "0.0.2"
+version: "0.0.3"
 description: "Create a new blank Figma file. Use when the user wants to create a new Figma design or FigJam file, or when you need a new file before calling use_figma. Handles plan resolution via whoami if needed. Usage — /figma-create-new-file [editorType] [fileName] (e.g. /figma-create-new-file figjam My Whiteboard)"
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-figma-generate-design/README.md
+++ b/openai-skills/openai-skills-figma-generate-design/README.md
@@ -24,7 +24,7 @@ npx hephai install @hephai-nota/openai-skills-figma-generate-design
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx hephai install @hephai-nota/openai-skills-figma-generate-design
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-figma-generate-design/for-hephai/README.md
+++ b/openai-skills/openai-skills-figma-generate-design/for-hephai/README.md
@@ -26,7 +26,7 @@ npx hephai install @hephai-nota/openai-skills-figma-generate-design
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx hephai install @hephai-nota/openai-skills-figma-generate-design
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-figma-generate-design/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-figma-generate-design/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-figma-generate-design
-version: "0.0.2"
+version: "0.0.3"
 description: "Use this skill alongside figma-use when the task involves translating an application page, view, or multi-section layout into Figma. Triggers: 'write to Figma', 'create in Figma from code', 'push page to Figma', 'take this app/page and build it in Figma', 'create a screen', 'build a landing page in Figma', 'update the Figma screen to match code'. This is the preferred workflow skill whenever the user wants to build or update a full page, screen, or view in Figma from code or a description. Discovers design system components, variables, and styles via search_design_system, imports them, and assembles screens incrementally section-by-section using design system tokens instead of hardcoded values."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-figma-generate-library/README.md
+++ b/openai-skills/openai-skills-figma-generate-library/README.md
@@ -24,7 +24,7 @@ npx hephai install @hephai-nota/openai-skills-figma-generate-library
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx hephai install @hephai-nota/openai-skills-figma-generate-library
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-figma-generate-library/for-hephai/README.md
+++ b/openai-skills/openai-skills-figma-generate-library/for-hephai/README.md
@@ -26,7 +26,7 @@ npx hephai install @hephai-nota/openai-skills-figma-generate-library
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx hephai install @hephai-nota/openai-skills-figma-generate-library
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-figma-generate-library/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-figma-generate-library/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-figma-generate-library
-version: "0.0.2"
+version: "0.0.3"
 description: "Build or update a professional-grade design system in Figma from a codebase. Use when the user wants to create variables/tokens, build component libraries, set up theming (light/dark modes), document foundations, or reconcile gaps between code and Figma. This skill teaches WHAT to build and in WHAT ORDER — it complements the `figma-use` skill which teaches HOW to call the Plugin API. Both skills should be loaded together."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-figma-implement-design/README.md
+++ b/openai-skills/openai-skills-figma-implement-design/README.md
@@ -24,7 +24,7 @@ npx hephai install @hephai-nota/openai-skills-figma-implement-design
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx hephai install @hephai-nota/openai-skills-figma-implement-design
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-figma-implement-design/for-hephai/README.md
+++ b/openai-skills/openai-skills-figma-implement-design/for-hephai/README.md
@@ -26,7 +26,7 @@ npx hephai install @hephai-nota/openai-skills-figma-implement-design
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx hephai install @hephai-nota/openai-skills-figma-implement-design
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-figma-implement-design/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-figma-implement-design/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-figma-implement-design
-version: "0.0.2"
+version: "0.0.3"
 description: "Translates Figma designs into production-ready application code with 1:1 visual fidelity. Use when implementing UI code from Figma files, when user mentions 'implement design', 'generate code', 'implement component', provides Figma URLs, or asks to build components matching Figma specs. For Figma canvas writes via `use_figma`, use `figma-use`."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-figma-use/README.md
+++ b/openai-skills/openai-skills-figma-use/README.md
@@ -24,7 +24,7 @@ npx hephai install @hephai-nota/openai-skills-figma-use
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx hephai install @hephai-nota/openai-skills-figma-use
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-figma-use/for-hephai/README.md
+++ b/openai-skills/openai-skills-figma-use/for-hephai/README.md
@@ -26,7 +26,7 @@ npx hephai install @hephai-nota/openai-skills-figma-use
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx hephai install @hephai-nota/openai-skills-figma-use
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-figma-use/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-figma-use/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-figma-use
-version: "0.0.2"
+version: "0.0.3"
 description: "**MANDATORY prerequisite** — you MUST invoke this skill BEFORE every `use_figma` tool call. NEVER call `use_figma` directly without loading this skill first. Skipping it causes common, hard-to-debug failures. Trigger whenever the user wants to perform a write action or a unique read action that requires JavaScript execution in the Figma file context — e.g. create/edit/delete nodes, set up variables or tokens, build components and variants, modify auto-layout or fills, bind variables to properties, or inspect file structure programmatically."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-figma/README.md
+++ b/openai-skills/openai-skills-figma/README.md
@@ -27,7 +27,7 @@ npx hephai install @hephai-nota/openai-skills-figma
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | `dc48aff` (2026-03-17) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -39,6 +39,8 @@ npx hephai install @hephai-nota/openai-skills-figma
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 

--- a/openai-skills/openai-skills-figma/for-hephai/README.md
+++ b/openai-skills/openai-skills-figma/for-hephai/README.md
@@ -29,7 +29,7 @@ npx hephai install @hephai-nota/openai-skills-figma
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | `dc48aff` (2026-03-17) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -41,6 +41,8 @@ npx hephai install @hephai-nota/openai-skills-figma
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 

--- a/openai-skills/openai-skills-figma/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-figma/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: "openai-skills-figma"
-version: "0.0.0"
+version: "0.0.1"
 description: >-
   Use the Figma MCP server to fetch design context, screenshots, variables,
   and assets from Figma, and to translate Figma nodes into production code.
@@ -14,7 +14,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-frontend-skill/README.md
+++ b/openai-skills/openai-skills-frontend-skill/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-frontend-skill
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-frontend-skill
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-frontend-skill/for-hephai/README.md
+++ b/openai-skills/openai-skills-frontend-skill/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-frontend-skill
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-frontend-skill
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-frontend-skill/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-frontend-skill/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-frontend-skill
-version: "0.0.2"
+version: "0.0.3"
 description: "Use when the task asks for a visually strong landing page, website, app, prototype, demo, or game UI. This skill enforces restrained composition, image-led hierarchy, cohesive content structure, and tasteful motion while avoiding generic cards, weak branding, and UI clutter."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-gh-address-comments/README.md
+++ b/openai-skills/openai-skills-gh-address-comments/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-gh-address-comments
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-gh-address-comments
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-gh-address-comments/for-hephai/README.md
+++ b/openai-skills/openai-skills-gh-address-comments/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-gh-address-comments
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-gh-address-comments
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-gh-address-comments/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-gh-address-comments/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-gh-address-comments
-version: "0.0.2"
+version: "0.0.3"
 description: "Help address review/issue comments on the open GitHub PR for the current branch using gh CLI; verify gh auth first and prompt the user to authenticate if not logged in."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-gh-fix-ci/README.md
+++ b/openai-skills/openai-skills-gh-fix-ci/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-gh-fix-ci
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-gh-fix-ci
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-gh-fix-ci/for-hephai/README.md
+++ b/openai-skills/openai-skills-gh-fix-ci/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-gh-fix-ci
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-gh-fix-ci
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-gh-fix-ci/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-gh-fix-ci/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-gh-fix-ci
-version: "0.0.2"
+version: "0.0.3"
 description: "Use when a user asks to debug or fix failing GitHub PR checks that run in GitHub Actions; use `gh` to inspect checks and logs, summarize failure context, draft a fix plan, and implement only after explicit approval. Treat external providers (for example Buildkite) as out of scope and report only the details URL."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-imagegen/README.md
+++ b/openai-skills/openai-skills-imagegen/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-imagegen
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-imagegen
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-imagegen/for-hephai/README.md
+++ b/openai-skills/openai-skills-imagegen/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-imagegen
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-imagegen
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-imagegen/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-imagegen/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-imagegen
-version: "0.0.2"
+version: "0.0.3"
 description: "Generate or edit raster images when the task benefits from AI-created bitmap visuals such as photos, illustrations, textures, sprites, mockups, or transparent-background cutouts. Use when Codex should create a brand-new image, transform an existing image, or derive visual variants from references, and the output should be a bitmap asset rather than repo-native code or vector. Do not use when the task is better handled by editing existing SVG/vector/code-native assets, extending an established icon or logo system, or building the visual directly in HTML/CSS/canvas."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-jupyter-notebook/README.md
+++ b/openai-skills/openai-skills-jupyter-notebook/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-jupyter-notebook
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-jupyter-notebook
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-jupyter-notebook/for-hephai/README.md
+++ b/openai-skills/openai-skills-jupyter-notebook/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-jupyter-notebook
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-jupyter-notebook
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-jupyter-notebook/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-jupyter-notebook/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-jupyter-notebook
-version: "0.0.2"
+version: "0.0.3"
 description: "Use when the user asks to create, scaffold, or edit Jupyter notebooks (`.ipynb`) for experiments, explorations, or tutorials; prefer the bundled templates and run the helper script `new_notebook.py` to generate a clean starting notebook."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-linear/README.md
+++ b/openai-skills/openai-skills-linear/README.md
@@ -24,7 +24,7 @@ npx hephai install @hephai-nota/openai-skills-linear
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx hephai install @hephai-nota/openai-skills-linear
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-linear/for-hephai/README.md
+++ b/openai-skills/openai-skills-linear/for-hephai/README.md
@@ -26,7 +26,7 @@ npx hephai install @hephai-nota/openai-skills-linear
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx hephai install @hephai-nota/openai-skills-linear
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-linear/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-linear/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-linear
-version: "0.0.2"
+version: "0.0.3"
 description: "Manage issues, projects & team workflows in Linear. Use when the user wants to read, create or updates tickets in Linear."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-netlify-deploy/README.md
+++ b/openai-skills/openai-skills-netlify-deploy/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-netlify-deploy
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-netlify-deploy
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-netlify-deploy/for-hephai/README.md
+++ b/openai-skills/openai-skills-netlify-deploy/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-netlify-deploy
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-netlify-deploy
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-netlify-deploy/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-netlify-deploy/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-netlify-deploy
-version: "0.0.2"
+version: "0.0.3"
 description: "Deploy web projects to Netlify using the Netlify CLI (`npx netlify`). Use when the user asks to deploy, host, publish, or link a site/repo on Netlify, including preview and production deploys."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-notion-knowledge-capture/README.md
+++ b/openai-skills/openai-skills-notion-knowledge-capture/README.md
@@ -24,7 +24,7 @@ npx hephai install @hephai-nota/openai-skills-notion-knowledge-capture
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx hephai install @hephai-nota/openai-skills-notion-knowledge-capture
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-notion-knowledge-capture/for-hephai/README.md
+++ b/openai-skills/openai-skills-notion-knowledge-capture/for-hephai/README.md
@@ -26,7 +26,7 @@ npx hephai install @hephai-nota/openai-skills-notion-knowledge-capture
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx hephai install @hephai-nota/openai-skills-notion-knowledge-capture
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-notion-knowledge-capture/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-notion-knowledge-capture/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-notion-knowledge-capture
-version: "0.0.2"
+version: "0.0.3"
 description: "Capture conversations and decisions into structured Notion pages; use when turning chats/notes into wiki entries, how-tos, decisions, or FAQs with proper linking."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-notion-meeting-intelligence/README.md
+++ b/openai-skills/openai-skills-notion-meeting-intelligence/README.md
@@ -24,7 +24,7 @@ npx hephai install @hephai-nota/openai-skills-notion-meeting-intelligence
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx hephai install @hephai-nota/openai-skills-notion-meeting-intelligence
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-notion-meeting-intelligence/for-hephai/README.md
+++ b/openai-skills/openai-skills-notion-meeting-intelligence/for-hephai/README.md
@@ -26,7 +26,7 @@ npx hephai install @hephai-nota/openai-skills-notion-meeting-intelligence
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx hephai install @hephai-nota/openai-skills-notion-meeting-intelligence
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-notion-meeting-intelligence/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-notion-meeting-intelligence/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-notion-meeting-intelligence
-version: "0.0.2"
+version: "0.0.3"
 description: "Prepare meeting materials with Notion context and Codex research; use when gathering context, drafting agendas/pre-reads, and tailoring materials to attendees."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-notion-research-documentation/README.md
+++ b/openai-skills/openai-skills-notion-research-documentation/README.md
@@ -24,7 +24,7 @@ npx hephai install @hephai-nota/openai-skills-notion-research-documentation
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx hephai install @hephai-nota/openai-skills-notion-research-documentation
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-notion-research-documentation/for-hephai/README.md
+++ b/openai-skills/openai-skills-notion-research-documentation/for-hephai/README.md
@@ -26,7 +26,7 @@ npx hephai install @hephai-nota/openai-skills-notion-research-documentation
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx hephai install @hephai-nota/openai-skills-notion-research-documentation
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-notion-research-documentation/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-notion-research-documentation/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-notion-research-documentation
-version: "0.0.2"
+version: "0.0.3"
 description: "Research across Notion and synthesize into structured documentation; use when gathering info from multiple Notion sources to produce briefs, comparisons, or reports with citations."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-notion-spec-to-implementation/README.md
+++ b/openai-skills/openai-skills-notion-spec-to-implementation/README.md
@@ -24,7 +24,7 @@ npx hephai install @hephai-nota/openai-skills-notion-spec-to-implementation
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx hephai install @hephai-nota/openai-skills-notion-spec-to-implementation
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-notion-spec-to-implementation/for-hephai/README.md
+++ b/openai-skills/openai-skills-notion-spec-to-implementation/for-hephai/README.md
@@ -26,7 +26,7 @@ npx hephai install @hephai-nota/openai-skills-notion-spec-to-implementation
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx hephai install @hephai-nota/openai-skills-notion-spec-to-implementation
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-notion-spec-to-implementation/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-notion-spec-to-implementation/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-notion-spec-to-implementation
-version: "0.0.2"
+version: "0.0.3"
 description: "Turn Notion specs into implementation plans, tasks, and progress tracking; use when implementing PRDs/feature specs and creating Notion plans + tasks from them."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-openai-docs/README.md
+++ b/openai-skills/openai-skills-openai-docs/README.md
@@ -24,7 +24,7 @@ npx hephai install @hephai-nota/openai-skills-openai-docs
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx hephai install @hephai-nota/openai-skills-openai-docs
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-openai-docs/for-hephai/README.md
+++ b/openai-skills/openai-skills-openai-docs/for-hephai/README.md
@@ -26,7 +26,7 @@ npx hephai install @hephai-nota/openai-skills-openai-docs
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx hephai install @hephai-nota/openai-skills-openai-docs
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-openai-docs/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-openai-docs/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-openai-docs
-version: "0.0.2"
+version: "0.0.3"
 description: "Use when the user asks how to build with OpenAI products or APIs and needs up-to-date official documentation with citations, help choosing the latest model for a use case, or explicit GPT-5.4 upgrade and prompt-upgrade guidance; prioritize OpenAI docs MCP tools, use bundled references only as helper context, and restrict any fallback browsing to official OpenAI domains."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-pdf/README.md
+++ b/openai-skills/openai-skills-pdf/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-pdf
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-pdf
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-pdf/for-hephai/README.md
+++ b/openai-skills/openai-skills-pdf/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-pdf
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-pdf
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-pdf/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-pdf/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-pdf
-version: "0.0.2"
+version: "0.0.3"
 description: "Use when tasks involve reading, creating, or reviewing PDF files where rendering and layout matter; prefer visual checks by rendering pages (Poppler) and use Python tools such as `reportlab`, `pdfplumber`, and `pypdf` for generation and extraction."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-playwright-interactive/README.md
+++ b/openai-skills/openai-skills-playwright-interactive/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-playwright-interactive
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-playwright-interactive
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-playwright-interactive/for-hephai/README.md
+++ b/openai-skills/openai-skills-playwright-interactive/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-playwright-interactive
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-playwright-interactive
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-playwright-interactive/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-playwright-interactive/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-playwright-interactive
-version: "0.0.2"
+version: "0.0.3"
 description: "Persistent browser and Electron interaction through `js_repl` for fast iterative UI debugging."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-playwright/README.md
+++ b/openai-skills/openai-skills-playwright/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-playwright
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-playwright
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-playwright/for-hephai/README.md
+++ b/openai-skills/openai-skills-playwright/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-playwright
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-playwright
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-playwright/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-playwright/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-playwright
-version: "0.0.2"
+version: "0.0.3"
 description: "Use when the task requires automating a real browser from the terminal (navigation, form filling, snapshots, screenshots, data extraction, UI-flow debugging) via `playwright-cli` or the bundled wrapper script."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-render-deploy/README.md
+++ b/openai-skills/openai-skills-render-deploy/README.md
@@ -24,7 +24,7 @@ npx hephai install @hephai-nota/openai-skills-render-deploy
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.1` |
+| Version | `0.0.2` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx hephai install @hephai-nota/openai-skills-render-deploy
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-render-deploy/for-hephai/README.md
+++ b/openai-skills/openai-skills-render-deploy/for-hephai/README.md
@@ -26,7 +26,7 @@ npx hephai install @hephai-nota/openai-skills-render-deploy
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.1` |
+| Version | `0.0.2` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx hephai install @hephai-nota/openai-skills-render-deploy
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-render-deploy/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-render-deploy/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-render-deploy
-version: "0.0.1"
+version: "0.0.2"
 description: "Deploy applications to Render by analyzing codebases, generating render.yaml Blueprints, and providing Dashboard deeplinks. Use when the user wants to deploy, host, publish, or set up their application on Render's cloud platform."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-screenshot/README.md
+++ b/openai-skills/openai-skills-screenshot/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-screenshot
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-screenshot
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-screenshot/for-hephai/README.md
+++ b/openai-skills/openai-skills-screenshot/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-screenshot
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-screenshot
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-screenshot/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-screenshot/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-screenshot
-version: "0.0.2"
+version: "0.0.3"
 description: "Use when the user explicitly asks for a desktop or system screenshot (full screen, specific app or window, or a pixel region), or when tool-specific capture capabilities are unavailable and an OS-level capture is needed."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-security-best-practices/README.md
+++ b/openai-skills/openai-skills-security-best-practices/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-security-best-practices
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-security-best-practices
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-security-best-practices/for-hephai/README.md
+++ b/openai-skills/openai-skills-security-best-practices/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-security-best-practices
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-security-best-practices
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-security-best-practices/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-security-best-practices/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-security-best-practices
-version: "0.0.2"
+version: "0.0.3"
 description: "Perform language and framework specific security best-practice reviews and suggest improvements. Trigger only when the user explicitly requests security best practices guidance, a security review/report, or secure-by-default coding help. Trigger only for supported languages (python, javascript/typescript, go). Do not trigger for general code review, debugging, or non-security tasks."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-security-ownership-map/README.md
+++ b/openai-skills/openai-skills-security-ownership-map/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-security-ownership-map
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-security-ownership-map
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-security-ownership-map/for-hephai/README.md
+++ b/openai-skills/openai-skills-security-ownership-map/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-security-ownership-map
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-security-ownership-map
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-security-ownership-map/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-security-ownership-map/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-security-ownership-map
-version: "0.0.2"
+version: "0.0.3"
 description: "Analyze git repositories to build a security ownership topology (people-to-file), compute bus factor and sensitive-code ownership, and export CSV/JSON for graph databases and visualization. Trigger only when the user explicitly wants a security-oriented ownership or bus-factor analysis grounded in git history (for example: orphaned sensitive code, security maintainers, CODEOWNERS reality checks for risk, sensitive hotspots, or ownership clusters). Do not trigger for general maintainer lists or non-security ownership questions."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-security-threat-model/README.md
+++ b/openai-skills/openai-skills-security-threat-model/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-security-threat-model
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-security-threat-model
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-security-threat-model/for-hephai/README.md
+++ b/openai-skills/openai-skills-security-threat-model/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-security-threat-model
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-security-threat-model
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-security-threat-model/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-security-threat-model/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-security-threat-model
-version: "0.0.2"
+version: "0.0.3"
 description: "Repository-grounded threat modeling that enumerates trust boundaries, assets, attacker capabilities, abuse paths, and mitigations, and writes a concise Markdown threat model. Trigger only when the user explicitly asks to threat model a codebase or path, enumerate threats/abuse paths, or perform AppSec threat modeling. Do not trigger for general architecture summaries, code review, or non-security design work."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-sentry/README.md
+++ b/openai-skills/openai-skills-sentry/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-sentry
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-sentry
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-sentry/for-hephai/README.md
+++ b/openai-skills/openai-skills-sentry/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-sentry
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-sentry
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-sentry/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-sentry/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-sentry
-version: "0.0.2"
+version: "0.0.3"
 description: "Use when the user asks to inspect Sentry issues or events, summarize recent production errors, or pull basic Sentry health data via the Sentry API; perform read-only queries with the bundled script and require `SENTRY_AUTH_TOKEN`."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-slides/README.md
+++ b/openai-skills/openai-skills-slides/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-slides
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-slides
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-slides/for-hephai/README.md
+++ b/openai-skills/openai-skills-slides/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-slides
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-slides
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-slides/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-slides/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-slides
-version: "0.0.2"
+version: "0.0.3"
 description: "Create and edit presentation slide decks (`.pptx`) with PptxGenJS, bundled layout helpers, and render/validation utilities. Use when tasks involve building a new PowerPoint deck, recreating slides from screenshots/PDFs/reference decks, modifying slide content while preserving editable output, adding charts/diagrams/visuals, or diagnosing layout issues such as overflow, overlaps, and font substitution."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-sora/README.md
+++ b/openai-skills/openai-skills-sora/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-sora
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-sora
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-sora/for-hephai/README.md
+++ b/openai-skills/openai-skills-sora/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-sora
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-sora
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-sora/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-sora/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-sora
-version: "0.0.2"
+version: "0.0.3"
 description: "Use when the user asks to generate, edit, extend, poll, list, download, or delete Sora videos, create reusable non-human Sora character references, or run local multi-video queues via the bundled CLI (`scripts/sora.py`); includes requests like: (i) generate AI video, (ii) edit this Sora clip, (iii) extend this video, (iv) create a character reference, (v) download video/thumbnail/spritesheet, and (vi) Sora batch planning; requires `OPENAI_API_KEY` and Sora API access."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-speech/README.md
+++ b/openai-skills/openai-skills-speech/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-speech
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-speech
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-speech/for-hephai/README.md
+++ b/openai-skills/openai-skills-speech/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-speech
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-speech
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-speech/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-speech/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-speech
-version: "0.0.2"
+version: "0.0.3"
 description: "Use when the user asks for text-to-speech narration or voiceover, accessibility reads, audio prompts, or batch speech generation via the OpenAI Audio API; run the bundled CLI (`scripts/text_to_speech.py`) with built-in voices and require `OPENAI_API_KEY` for live calls. Custom voice creation is out of scope."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-spreadsheet/README.md
+++ b/openai-skills/openai-skills-spreadsheet/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-spreadsheet
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-spreadsheet
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-spreadsheet/for-hephai/README.md
+++ b/openai-skills/openai-skills-spreadsheet/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-spreadsheet
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-spreadsheet
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-spreadsheet/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-spreadsheet/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-spreadsheet
-version: "0.0.2"
+version: "0.0.3"
 description: "Use when tasks involve creating, editing, analyzing, or formatting spreadsheets (`.xlsx`, `.csv`, `.tsv`) with formula-aware workflows, cached recalculation, and visual review."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-system-openai-docs/README.md
+++ b/openai-skills/openai-skills-system-openai-docs/README.md
@@ -24,7 +24,7 @@ npx hephai install @hephai-nota/openai-skills-system-openai-docs
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx hephai install @hephai-nota/openai-skills-system-openai-docs
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-system-openai-docs/for-hephai/README.md
+++ b/openai-skills/openai-skills-system-openai-docs/for-hephai/README.md
@@ -26,7 +26,7 @@ npx hephai install @hephai-nota/openai-skills-system-openai-docs
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx hephai install @hephai-nota/openai-skills-system-openai-docs
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-system-openai-docs/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-system-openai-docs/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-system-openai-docs
-version: "0.0.2"
+version: "0.0.3"
 description: "Use when the user asks how to build with OpenAI products or APIs and needs up-to-date official documentation with citations, help choosing the latest model for a use case, or explicit GPT-5.4 upgrade and prompt-upgrade guidance; prioritize OpenAI docs MCP tools, use bundled references only as helper context, and restrict any fallback browsing to official OpenAI domains."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-system-skill-creator/README.md
+++ b/openai-skills/openai-skills-system-skill-creator/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-system-skill-creator
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-system-skill-creator
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-system-skill-creator/for-hephai/README.md
+++ b/openai-skills/openai-skills-system-skill-creator/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-system-skill-creator
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-system-skill-creator
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-system-skill-creator/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-system-skill-creator/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-system-skill-creator
-version: "0.0.2"
+version: "0.0.3"
 description: "Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Codex's capabilities with specialized knowledge, workflows, or tool integrations."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-system-skill-installer/README.md
+++ b/openai-skills/openai-skills-system-skill-installer/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-system-skill-installer
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-system-skill-installer
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-system-skill-installer/for-hephai/README.md
+++ b/openai-skills/openai-skills-system-skill-installer/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-system-skill-installer
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-system-skill-installer
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-system-skill-installer/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-system-skill-installer/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-system-skill-installer
-version: "0.0.2"
+version: "0.0.3"
 description: "Install Codex skills into $CODEX_HOME/skills from a curated list or a GitHub repo path. Use when a user asks to list installable skills, install a curated skill, or install a skill from another repo (including private repos)."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-transcribe/README.md
+++ b/openai-skills/openai-skills-transcribe/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-transcribe
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-transcribe
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-transcribe/for-hephai/README.md
+++ b/openai-skills/openai-skills-transcribe/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-transcribe
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-transcribe
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-transcribe/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-transcribe/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-transcribe
-version: "0.0.2"
+version: "0.0.3"
 description: "Transcribe audio files to text with optional diarization and known-speaker hints. Use when a user asks to transcribe speech from audio/video, extract text from recordings, or label speakers in interviews or meetings."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-vercel-deploy/README.md
+++ b/openai-skills/openai-skills-vercel-deploy/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-vercel-deploy
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-vercel-deploy
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-vercel-deploy/for-hephai/README.md
+++ b/openai-skills/openai-skills-vercel-deploy/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-vercel-deploy
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-vercel-deploy
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-vercel-deploy/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-vercel-deploy/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-vercel-deploy
-version: "0.0.2"
+version: "0.0.3"
 description: "Deploy applications and websites to Vercel. Use when the user requests deployment actions like 'deploy my app', 'deploy and give me the link', 'push this live', or 'create a preview deployment'."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-winui-app/README.md
+++ b/openai-skills/openai-skills-winui-app/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-winui-app
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-winui-app
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-winui-app/for-hephai/README.md
+++ b/openai-skills/openai-skills-winui-app/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-winui-app
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-winui-app
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-winui-app/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-winui-app/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-winui-app
-version: "0.0.2"
+version: "0.0.3"
 description: "Bootstrap, develop, and design modern WinUI 3 desktop applications with C# and the Windows App SDK using official Microsoft guidance, WinUI Gallery patterns, Windows App SDK samples, and CommunityToolkit components. Use when creating a brand new app, preparing a machine for WinUI, reviewing, refactoring, planning, troubleshooting, environment-checking, or setting up WinUI 3 XAML, controls, navigation, windowing, theming, accessibility, responsiveness, performance, deployment, or related Windows app design and development work."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]

--- a/openai-skills/openai-skills-yeet/README.md
+++ b/openai-skills/openai-skills-yeet/README.md
@@ -21,7 +21,7 @@ npx hephai install @hephai-nota/openai-skills-yeet
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -31,6 +31,8 @@ npx hephai install @hephai-nota/openai-skills-yeet
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-yeet/for-hephai/README.md
+++ b/openai-skills/openai-skills-yeet/for-hephai/README.md
@@ -23,7 +23,7 @@ npx hephai install @hephai-nota/openai-skills-yeet
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -33,6 +33,8 @@ npx hephai install @hephai-nota/openai-skills-yeet
 | Platform | Status |
 |---|---|
 | Codex | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 
 ### Models
 | Model | Role |

--- a/openai-skills/openai-skills-yeet/for-hephai/profile.yml
+++ b/openai-skills/openai-skills-yeet/for-hephai/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-yeet
-version: "0.0.2"
+version: "0.0.3"
 description: "Use only when the user explicitly asks to stage, commit, push, and open a GitHub pull request in one flow using the GitHub CLI (`gh`)."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"
@@ -10,7 +10,7 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested: [codex]
-    partial: []
+    partial: [claude-code, cursor]
   models:
     recommended: [gpt-5.4]
     minimum: [gpt-4o]


### PR DESCRIPTION
## Summary

Ensures every profile lists all 3 Hephai-supported platforms as either `tested` (original source platform) or `partial` (Hephai-compatible additions). Tested platforms are never changed.

## Rule applied
- `tested:` = original source platform(s) — unchanged
- `partial:` = `{claude-code, codex, cursor} - tested`

## Groups updated

| Group | Profiles | Fix | New version |
|---|---|---|---|
| `agency-agents` | 12 | Added `codex` to partial | `0.0.3` |
| `awesome-codex-subagents` | 10 | Added `cursor` to partial | `0.0.3` / `0.0.5` |
| `context7` | 1 | Added `codex` to partial | `0.0.3` |
| `cursor-team-kit` | 1 | Added `claude-code`, `codex` to partial | `0.0.2` |
| `knowledge-work-plugins` | 13 | Added `cursor`, `codex` to partial | `0.0.1` |
| `nota-git-tools`, `nota-jira` | 2 | Added `cursor`, `codex` to partial | `0.0.3` |
| `openai-skills` | 44 | Added `claude-code`, `cursor` to partial | `0.0.3` / `0.0.1` |

Both `profile.yml` partial fields and README Platforms tables updated throughout.
`nota-internal-plugins` excluded.