### PR TITLE
docs: overhaul root README with ForgeCat branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
-# hephai-agents
+# 🐾 ForgeCat Agent Profiles
+
+Curated collection of AI Agent Profiles — ready to install and use across platforms.
+
+**Forge your agents. Stamp your mark.**
+
+---
+
+## What is this?
+
+This repository hosts a curated set of **AI Agent Profiles** for [ForgeCat](https://forgecat.ai). An Agent Profile is a portable bundle of configuration files — agents, skills, rules, commands, and MCP settings — packaged together so you can supercharge your AI environment with a single command.
+
+---
+
+## Collections
+
+| Collection | Categories | Description |
+|---|---|---|
+| [agency-agents](./agency-agents) | 13 | Team role agents for agencies — design, engineering, marketing, sales, and more |
+| [awesome-codex-subagents](./awesome-codex-subagents) | 10 | Subagents for OpenAI Codex — development, infrastructure, security, research |
+| [context7](./context7) | 1 | Context7 MCP integration for up-to-date documentation lookup |
+| [cursor-team-kit](./cursor-team-kit) | 2 | Team workflows for Cursor — CI, code review, shipping, test reliability |
+| [knowledge-work-plugins](./knowledge-work-plugins) | 14 | Knowledge work plugins — legal, finance, HR, marketing, operations, and more |
+| [openai-skills](./openai-skills) | 45 | Skills for OpenAI platforms — ASP.NET Core, and more |
+
+---
+
+## Quick Start
+
+```bash
+# Install the CLI
+npm install -g forgecat
+
+# Browse profiles
+forgecat search <keyword>
+
+# Install a profile
+forgecat install <@scope/profile>
+```
+
+Visit [forgecat.ai/docs](https://forgecat.ai/docs) for full documentation.
+
+---
+
+## Links
+
+- **Website**: [forgecat.ai](https://forgecat.ai)
+- **Docs**: [forgecat.ai/docs](https://forgecat.ai/docs)
+- **CLI**: `npm install -g forgecat`
+
+---
+
+## Contributing
+
+Contribution guidelines are coming soon. Stay tuned! 🐾
+
+---
+
+## License
+
+This repository is licensed under Apache License 2.0.
+
+Individual profiles may carry their own licenses. See each profile directory for details.


### PR DESCRIPTION
## Pre-flight Checklist
- [x] Merge 대상 브랜치가 올바른지 확인했습니다.
- [ ] 적절한 Reviewer가 할당되었습니다.
- [ ] 관련 Issue가 있다면 연결했습니다.

---

## What changed *
루트 README.md를 ForgeCat 브랜딩에 맞게 전면 개편했습니다.

- 기존: `# hephai-agents` (한 줄)
- 변경: ForgeCat 브랜딩 적용된 전체 README
  - What is this? — Agent Profiles 레포 설명
  - Collections 테이블 — 6개 컬렉션 (총 85+ 카테고리)
  - Quick Start — CLI 설치 및 사용법
  - Links — 웹사이트, 문서, CLI
  - Contributing — Coming soon
  - License — Apache 2.0 명시 (LICENSE 파일은 별도 추가 예정)

---

## Type of change *
- [x] **docs**: 문서 추가/수정

---

## Scope
- [x] Frontend

---

## Linked Issues
- N/A

---

## Test Checklist *
- [x] README 마크다운 렌더링 확인
- [x] 테이블 링크 경로 확인
- [x] 추가 테스트 없음 / 불필요 (문서 변경만)

---

## Screenshots (Optional)
<!--
GitHub에서 README 렌더링 확인
-->