### PR TITLE
docs: rename README banner alt text to Forgecat

### DIFF
--- a/profiles/agency-agents/agency-design/README.md
+++ b/profiles/agency-agents/agency-design/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Agency Design
 

--- a/profiles/agency-agents/agency-design/for-hephai/README.md
+++ b/profiles/agency-agents/agency-design/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Agency Design
 

--- a/profiles/agency-agents/agency-engineering/README.md
+++ b/profiles/agency-agents/agency-engineering/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Agency Engineering
 

--- a/profiles/agency-agents/agency-engineering/for-hephai/README.md
+++ b/profiles/agency-agents/agency-engineering/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Agency Engineering
 

--- a/profiles/agency-agents/agency-game-development/README.md
+++ b/profiles/agency-agents/agency-game-development/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Agency Game Development
 

--- a/profiles/agency-agents/agency-game-development/for-hephai/README.md
+++ b/profiles/agency-agents/agency-game-development/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Agency Game Development
 

--- a/profiles/agency-agents/agency-marketing/README.md
+++ b/profiles/agency-agents/agency-marketing/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Agency Marketing
 

--- a/profiles/agency-agents/agency-marketing/for-hephai/README.md
+++ b/profiles/agency-agents/agency-marketing/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Agency Marketing
 

--- a/profiles/agency-agents/agency-paid-media/README.md
+++ b/profiles/agency-agents/agency-paid-media/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Agency Paid Media
 

--- a/profiles/agency-agents/agency-paid-media/for-hephai/README.md
+++ b/profiles/agency-agents/agency-paid-media/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Agency Paid Media
 

--- a/profiles/agency-agents/agency-product/README.md
+++ b/profiles/agency-agents/agency-product/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Agency Product
 

--- a/profiles/agency-agents/agency-product/for-hephai/README.md
+++ b/profiles/agency-agents/agency-product/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Agency Product
 

--- a/profiles/agency-agents/agency-project-management/README.md
+++ b/profiles/agency-agents/agency-project-management/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Agency Project Management
 

--- a/profiles/agency-agents/agency-project-management/for-hephai/README.md
+++ b/profiles/agency-agents/agency-project-management/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Agency Project Management
 

--- a/profiles/agency-agents/agency-sales/README.md
+++ b/profiles/agency-agents/agency-sales/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Agency Sales
 

--- a/profiles/agency-agents/agency-sales/for-hephai/README.md
+++ b/profiles/agency-agents/agency-sales/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Agency Sales
 

--- a/profiles/agency-agents/agency-spatial-computing/README.md
+++ b/profiles/agency-agents/agency-spatial-computing/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Agency Spatial Computing
 

--- a/profiles/agency-agents/agency-spatial-computing/for-hephai/README.md
+++ b/profiles/agency-agents/agency-spatial-computing/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Agency Spatial Computing
 

--- a/profiles/agency-agents/agency-specialized/README.md
+++ b/profiles/agency-agents/agency-specialized/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Agency Specialized
 

--- a/profiles/agency-agents/agency-specialized/for-hephai/README.md
+++ b/profiles/agency-agents/agency-specialized/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Agency Specialized
 

--- a/profiles/agency-agents/agency-support/README.md
+++ b/profiles/agency-agents/agency-support/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Agency Support
 

--- a/profiles/agency-agents/agency-support/for-hephai/README.md
+++ b/profiles/agency-agents/agency-support/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Agency Support
 

--- a/profiles/agency-agents/agency-testing/README.md
+++ b/profiles/agency-agents/agency-testing/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Agency Testing
 

--- a/profiles/agency-agents/agency-testing/for-hephai/README.md
+++ b/profiles/agency-agents/agency-testing/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Agency Testing
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-business-product/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-business-product/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # 08. Business & Product
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-business-product/for-hephai/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-business-product/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # 08. Business & Product
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-core-development/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-core-development/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # 01. Core Development
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-core-development/for-hephai/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-core-development/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # 01. Core Development
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-data-ai/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-data-ai/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # 05. Data & AI
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-data-ai/for-hephai/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-data-ai/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # 05. Data & AI
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-developer-experience/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-developer-experience/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # 06. Developer Experience
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-developer-experience/for-hephai/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-developer-experience/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # 06. Developer Experience
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-infrastructure/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-infrastructure/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # 03. Infrastructure
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-infrastructure/for-hephai/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-infrastructure/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # 03. Infrastructure
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-language-specialists/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-language-specialists/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # 02. Language Specialists
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-language-specialists/for-hephai/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-language-specialists/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # 02. Language Specialists
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-meta-orchestration/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-meta-orchestration/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # 09. Meta & Orchestration
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-meta-orchestration/for-hephai/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-meta-orchestration/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # 09. Meta & Orchestration
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-quality-security/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-quality-security/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # 04. Quality & Security
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-quality-security/for-hephai/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-quality-security/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # 04. Quality & Security
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-research-analysis/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-research-analysis/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # 10. Research & Analysis
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-research-analysis/for-hephai/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-research-analysis/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # 10. Research & Analysis
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-specialized-domains/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-specialized-domains/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # 07. Specialized Domains
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-specialized-domains/for-hephai/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-specialized-domains/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # 07. Specialized Domains
 

--- a/profiles/context7/README.md
+++ b/profiles/context7/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Context7
 

--- a/profiles/context7/for-hephai/README.md
+++ b/profiles/context7/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Context7
 

--- a/profiles/cursor-team-kit/README.md
+++ b/profiles/cursor-team-kit/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Cursor Team Kit
 

--- a/profiles/cursor-team-kit/for-hephai/README.md
+++ b/profiles/cursor-team-kit/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Cursor Team Kit
 

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-bio-research/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-bio-research/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Bio-Research

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-bio-research/for-hephai/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-bio-research/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Bio-Research

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-customer-support/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-customer-support/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Customer Support

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-customer-support/for-hephai/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-customer-support/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Customer Support

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-data/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-data/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Data

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-data/for-hephai/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-data/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Data

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-design/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-design/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Design

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-design/for-hephai/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-design/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Design

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-engineering/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-engineering/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Engineering

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-engineering/for-hephai/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-engineering/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Engineering

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-enterprise-search/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-enterprise-search/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Enterprise Search

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-enterprise-search/for-hephai/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-enterprise-search/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Enterprise Search

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-finance/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-finance/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Finance

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-finance/for-hephai/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-finance/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Finance

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-human-resources/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-human-resources/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Human Resources

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-human-resources/for-hephai/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-human-resources/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Human Resources

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-legal/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-legal/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Legal

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-legal/for-hephai/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-legal/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Legal

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-marketing/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-marketing/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Marketing

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-marketing/for-hephai/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-marketing/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Marketing

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-operations/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-operations/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Operations

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-operations/for-hephai/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-operations/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Operations

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-product-management/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-product-management/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Product Management

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-product-management/for-hephai/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-product-management/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Product Management

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-productivity/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-productivity/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Productivity

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-productivity/for-hephai/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-productivity/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Productivity

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-sales/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-sales/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Sales

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-sales/for-hephai/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-sales/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Sales

--- a/profiles/openai-skills/openai-skills-aspnet-core/README.md
+++ b/profiles/openai-skills/openai-skills-aspnet-core/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # aspnet-core
 

--- a/profiles/openai-skills/openai-skills-aspnet-core/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-aspnet-core/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # aspnet-core
 

--- a/profiles/openai-skills/openai-skills-chatgpt-apps/README.md
+++ b/profiles/openai-skills/openai-skills-chatgpt-apps/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # chatgpt-apps
 

--- a/profiles/openai-skills/openai-skills-chatgpt-apps/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-chatgpt-apps/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # chatgpt-apps
 

--- a/profiles/openai-skills/openai-skills-cloudflare-deploy/README.md
+++ b/profiles/openai-skills/openai-skills-cloudflare-deploy/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # cloudflare-deploy
 

--- a/profiles/openai-skills/openai-skills-cloudflare-deploy/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-cloudflare-deploy/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # cloudflare-deploy
 

--- a/profiles/openai-skills/openai-skills-develop-web-game/README.md
+++ b/profiles/openai-skills/openai-skills-develop-web-game/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # develop-web-game
 

--- a/profiles/openai-skills/openai-skills-develop-web-game/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-develop-web-game/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # develop-web-game
 

--- a/profiles/openai-skills/openai-skills-doc/README.md
+++ b/profiles/openai-skills/openai-skills-doc/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # doc
 

--- a/profiles/openai-skills/openai-skills-doc/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-doc/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # doc
 

--- a/profiles/openai-skills/openai-skills-figma-code-connect-components/README.md
+++ b/profiles/openai-skills/openai-skills-figma-code-connect-components/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # figma-code-connect-components
 

--- a/profiles/openai-skills/openai-skills-figma-code-connect-components/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-figma-code-connect-components/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # figma-code-connect-components
 

--- a/profiles/openai-skills/openai-skills-figma-create-design-system-rules/README.md
+++ b/profiles/openai-skills/openai-skills-figma-create-design-system-rules/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # figma-create-design-system-rules
 

--- a/profiles/openai-skills/openai-skills-figma-create-design-system-rules/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-figma-create-design-system-rules/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # figma-create-design-system-rules
 

--- a/profiles/openai-skills/openai-skills-figma-create-new-file/README.md
+++ b/profiles/openai-skills/openai-skills-figma-create-new-file/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # figma-create-new-file
 

--- a/profiles/openai-skills/openai-skills-figma-create-new-file/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-figma-create-new-file/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # figma-create-new-file
 

--- a/profiles/openai-skills/openai-skills-figma-generate-design/README.md
+++ b/profiles/openai-skills/openai-skills-figma-generate-design/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # figma-generate-design
 

--- a/profiles/openai-skills/openai-skills-figma-generate-design/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-figma-generate-design/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # figma-generate-design
 

--- a/profiles/openai-skills/openai-skills-figma-generate-library/README.md
+++ b/profiles/openai-skills/openai-skills-figma-generate-library/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # figma-generate-library
 

--- a/profiles/openai-skills/openai-skills-figma-generate-library/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-figma-generate-library/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # figma-generate-library
 

--- a/profiles/openai-skills/openai-skills-figma-implement-design/README.md
+++ b/profiles/openai-skills/openai-skills-figma-implement-design/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # figma-implement-design
 

--- a/profiles/openai-skills/openai-skills-figma-implement-design/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-figma-implement-design/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # figma-implement-design
 

--- a/profiles/openai-skills/openai-skills-figma-use/README.md
+++ b/profiles/openai-skills/openai-skills-figma-use/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # figma-use
 

--- a/profiles/openai-skills/openai-skills-figma-use/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-figma-use/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # figma-use
 

--- a/profiles/openai-skills/openai-skills-figma/README.md
+++ b/profiles/openai-skills/openai-skills-figma/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Figma
 

--- a/profiles/openai-skills/openai-skills-figma/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-figma/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Figma
 

--- a/profiles/openai-skills/openai-skills-frontend-skill/README.md
+++ b/profiles/openai-skills/openai-skills-frontend-skill/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # frontend-skill
 

--- a/profiles/openai-skills/openai-skills-frontend-skill/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-frontend-skill/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # frontend-skill
 

--- a/profiles/openai-skills/openai-skills-gh-address-comments/README.md
+++ b/profiles/openai-skills/openai-skills-gh-address-comments/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # gh-address-comments
 

--- a/profiles/openai-skills/openai-skills-gh-address-comments/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-gh-address-comments/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # gh-address-comments
 

--- a/profiles/openai-skills/openai-skills-gh-fix-ci/README.md
+++ b/profiles/openai-skills/openai-skills-gh-fix-ci/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # gh-fix-ci
 

--- a/profiles/openai-skills/openai-skills-gh-fix-ci/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-gh-fix-ci/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # gh-fix-ci
 

--- a/profiles/openai-skills/openai-skills-imagegen/README.md
+++ b/profiles/openai-skills/openai-skills-imagegen/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # imagegen
 

--- a/profiles/openai-skills/openai-skills-imagegen/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-imagegen/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # imagegen
 

--- a/profiles/openai-skills/openai-skills-jupyter-notebook/README.md
+++ b/profiles/openai-skills/openai-skills-jupyter-notebook/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # jupyter-notebook
 

--- a/profiles/openai-skills/openai-skills-jupyter-notebook/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-jupyter-notebook/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # jupyter-notebook
 

--- a/profiles/openai-skills/openai-skills-linear/README.md
+++ b/profiles/openai-skills/openai-skills-linear/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # linear
 

--- a/profiles/openai-skills/openai-skills-linear/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-linear/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # linear
 

--- a/profiles/openai-skills/openai-skills-netlify-deploy/README.md
+++ b/profiles/openai-skills/openai-skills-netlify-deploy/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # netlify-deploy
 

--- a/profiles/openai-skills/openai-skills-netlify-deploy/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-netlify-deploy/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # netlify-deploy
 

--- a/profiles/openai-skills/openai-skills-notion-knowledge-capture/README.md
+++ b/profiles/openai-skills/openai-skills-notion-knowledge-capture/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # notion-knowledge-capture
 

--- a/profiles/openai-skills/openai-skills-notion-knowledge-capture/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-notion-knowledge-capture/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # notion-knowledge-capture
 

--- a/profiles/openai-skills/openai-skills-notion-meeting-intelligence/README.md
+++ b/profiles/openai-skills/openai-skills-notion-meeting-intelligence/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # notion-meeting-intelligence
 

--- a/profiles/openai-skills/openai-skills-notion-meeting-intelligence/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-notion-meeting-intelligence/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # notion-meeting-intelligence
 

--- a/profiles/openai-skills/openai-skills-notion-research-documentation/README.md
+++ b/profiles/openai-skills/openai-skills-notion-research-documentation/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # notion-research-documentation
 

--- a/profiles/openai-skills/openai-skills-notion-research-documentation/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-notion-research-documentation/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # notion-research-documentation
 

--- a/profiles/openai-skills/openai-skills-notion-spec-to-implementation/README.md
+++ b/profiles/openai-skills/openai-skills-notion-spec-to-implementation/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # notion-spec-to-implementation
 

--- a/profiles/openai-skills/openai-skills-notion-spec-to-implementation/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-notion-spec-to-implementation/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # notion-spec-to-implementation
 

--- a/profiles/openai-skills/openai-skills-openai-docs/README.md
+++ b/profiles/openai-skills/openai-skills-openai-docs/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # openai-docs
 

--- a/profiles/openai-skills/openai-skills-openai-docs/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-openai-docs/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # openai-docs
 

--- a/profiles/openai-skills/openai-skills-pdf/README.md
+++ b/profiles/openai-skills/openai-skills-pdf/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # pdf
 

--- a/profiles/openai-skills/openai-skills-pdf/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-pdf/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # pdf
 

--- a/profiles/openai-skills/openai-skills-playwright-interactive/README.md
+++ b/profiles/openai-skills/openai-skills-playwright-interactive/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # playwright-interactive
 

--- a/profiles/openai-skills/openai-skills-playwright-interactive/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-playwright-interactive/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # playwright-interactive
 

--- a/profiles/openai-skills/openai-skills-playwright/README.md
+++ b/profiles/openai-skills/openai-skills-playwright/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # playwright
 

--- a/profiles/openai-skills/openai-skills-playwright/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-playwright/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # playwright
 

--- a/profiles/openai-skills/openai-skills-render-deploy/README.md
+++ b/profiles/openai-skills/openai-skills-render-deploy/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # render-deploy
 

--- a/profiles/openai-skills/openai-skills-render-deploy/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-render-deploy/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # render-deploy
 

--- a/profiles/openai-skills/openai-skills-screenshot/README.md
+++ b/profiles/openai-skills/openai-skills-screenshot/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # screenshot
 

--- a/profiles/openai-skills/openai-skills-screenshot/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-screenshot/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # screenshot
 

--- a/profiles/openai-skills/openai-skills-security-best-practices/README.md
+++ b/profiles/openai-skills/openai-skills-security-best-practices/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # security-best-practices
 

--- a/profiles/openai-skills/openai-skills-security-best-practices/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-security-best-practices/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # security-best-practices
 

--- a/profiles/openai-skills/openai-skills-security-ownership-map/README.md
+++ b/profiles/openai-skills/openai-skills-security-ownership-map/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # security-ownership-map
 

--- a/profiles/openai-skills/openai-skills-security-ownership-map/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-security-ownership-map/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # security-ownership-map
 

--- a/profiles/openai-skills/openai-skills-security-threat-model/README.md
+++ b/profiles/openai-skills/openai-skills-security-threat-model/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # security-threat-model
 

--- a/profiles/openai-skills/openai-skills-security-threat-model/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-security-threat-model/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # security-threat-model
 

--- a/profiles/openai-skills/openai-skills-sentry/README.md
+++ b/profiles/openai-skills/openai-skills-sentry/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # sentry
 

--- a/profiles/openai-skills/openai-skills-sentry/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-sentry/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # sentry
 

--- a/profiles/openai-skills/openai-skills-slides/README.md
+++ b/profiles/openai-skills/openai-skills-slides/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # slides
 

--- a/profiles/openai-skills/openai-skills-slides/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-slides/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # slides
 

--- a/profiles/openai-skills/openai-skills-sora/README.md
+++ b/profiles/openai-skills/openai-skills-sora/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # sora
 

--- a/profiles/openai-skills/openai-skills-sora/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-sora/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # sora
 

--- a/profiles/openai-skills/openai-skills-speech/README.md
+++ b/profiles/openai-skills/openai-skills-speech/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # speech
 

--- a/profiles/openai-skills/openai-skills-speech/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-speech/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # speech
 

--- a/profiles/openai-skills/openai-skills-spreadsheet/README.md
+++ b/profiles/openai-skills/openai-skills-spreadsheet/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # spreadsheet
 

--- a/profiles/openai-skills/openai-skills-spreadsheet/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-spreadsheet/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # spreadsheet
 

--- a/profiles/openai-skills/openai-skills-system-openai-docs/README.md
+++ b/profiles/openai-skills/openai-skills-system-openai-docs/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # openai-docs
 

--- a/profiles/openai-skills/openai-skills-system-openai-docs/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-system-openai-docs/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # openai-docs
 

--- a/profiles/openai-skills/openai-skills-system-skill-creator/README.md
+++ b/profiles/openai-skills/openai-skills-system-skill-creator/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # skill-creator
 

--- a/profiles/openai-skills/openai-skills-system-skill-creator/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-system-skill-creator/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # skill-creator
 

--- a/profiles/openai-skills/openai-skills-system-skill-installer/README.md
+++ b/profiles/openai-skills/openai-skills-system-skill-installer/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # skill-installer
 

--- a/profiles/openai-skills/openai-skills-system-skill-installer/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-system-skill-installer/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # skill-installer
 

--- a/profiles/openai-skills/openai-skills-transcribe/README.md
+++ b/profiles/openai-skills/openai-skills-transcribe/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # transcribe
 

--- a/profiles/openai-skills/openai-skills-transcribe/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-transcribe/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # transcribe
 

--- a/profiles/openai-skills/openai-skills-vercel-deploy/README.md
+++ b/profiles/openai-skills/openai-skills-vercel-deploy/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # vercel-deploy
 

--- a/profiles/openai-skills/openai-skills-vercel-deploy/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-vercel-deploy/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # vercel-deploy
 

--- a/profiles/openai-skills/openai-skills-winui-app/README.md
+++ b/profiles/openai-skills/openai-skills-winui-app/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # winui-app
 

--- a/profiles/openai-skills/openai-skills-winui-app/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-winui-app/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # winui-app
 

--- a/profiles/openai-skills/openai-skills-yeet/README.md
+++ b/profiles/openai-skills/openai-skills-yeet/README.md
@@ -1,4 +1,4 @@
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # yeet
 

--- a/profiles/openai-skills/openai-skills-yeet/for-hephai/README.md
+++ b/profiles/openai-skills/openai-skills-yeet/for-hephai/README.md
@@ -1,6 +1,6 @@
 *written by Hephai*
 
-![Hephai](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # yeet
 


### PR DESCRIPTION
Updates README banner alt text across the repo:

- `![Hephai](...)` → `![Forgecat](...)`
- 166 README files updated
- URL paths unchanged (kept as requested)