### PR TITLE
Standardize install commands to @forgecat namespace

### DIFF
--- a/profiles/agency-agents/agency-academic/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-academic/for-forgecat/README.md
@@ -12,7 +12,7 @@ Academic division from The Agency — 5 specialized academic agent personalities
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-academic
+npx forgecat install @forgecat/agency-academic
 ```
 
 ## Agents

--- a/profiles/agency-agents/agency-design/README.md
+++ b/profiles/agency-agents/agency-design/README.md
@@ -10,7 +10,7 @@ Design division from The Agency — 8 specialized agent personalities from msita
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-design
+npx forgecat install @forgecat/agency-design
 ```
 
 ## Agents

--- a/profiles/agency-agents/agency-design/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-design/for-forgecat/README.md
@@ -12,7 +12,7 @@ Design division from The Agency — 8 specialized agent personalities from msita
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-design
+npx forgecat install @forgecat/agency-design
 ```
 
 ## Agents

--- a/profiles/agency-agents/agency-engineering/README.md
+++ b/profiles/agency-agents/agency-engineering/README.md
@@ -10,7 +10,7 @@ Engineering division from The Agency — 23 specialized agent personalities from
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-engineering
+npx forgecat install @forgecat/agency-engineering
 ```
 
 ## Agents

--- a/profiles/agency-agents/agency-engineering/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-engineering/for-forgecat/README.md
@@ -12,7 +12,7 @@ Engineering division from The Agency — 23 specialized agent personalities from
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-engineering
+npx forgecat install @forgecat/agency-engineering
 ```
 
 ## Agents

--- a/profiles/agency-agents/agency-game-development/README.md
+++ b/profiles/agency-agents/agency-game-development/README.md
@@ -10,7 +10,7 @@ Game Development division from The Agency — 20 specialized agent personalities
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-game-development
+npx forgecat install @forgecat/agency-game-development
 ```
 
 ## Agents

--- a/profiles/agency-agents/agency-game-development/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-game-development/for-forgecat/README.md
@@ -12,7 +12,7 @@ Game Development division from The Agency — 20 specialized agent personalities
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-game-development
+npx forgecat install @forgecat/agency-game-development
 ```
 
 ## Agents

--- a/profiles/agency-agents/agency-marketing/README.md
+++ b/profiles/agency-agents/agency-marketing/README.md
@@ -10,7 +10,7 @@ Marketing division from The Agency — 27 specialized agent personalities from m
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-marketing
+npx forgecat install @forgecat/agency-marketing
 ```
 
 ## Agents

--- a/profiles/agency-agents/agency-marketing/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-marketing/for-forgecat/README.md
@@ -12,7 +12,7 @@ Marketing division from The Agency — 27 specialized agent personalities from m
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-marketing
+npx forgecat install @forgecat/agency-marketing
 ```
 
 ## Agents

--- a/profiles/agency-agents/agency-paid-media/README.md
+++ b/profiles/agency-agents/agency-paid-media/README.md
@@ -10,7 +10,7 @@ Paid Media division from The Agency — 7 specialized agent personalities from m
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-paid-media
+npx forgecat install @forgecat/agency-paid-media
 ```
 
 ## Agents

--- a/profiles/agency-agents/agency-paid-media/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-paid-media/for-forgecat/README.md
@@ -12,7 +12,7 @@ Paid Media division from The Agency — 7 specialized agent personalities from m
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-paid-media
+npx forgecat install @forgecat/agency-paid-media
 ```
 
 ## Agents

--- a/profiles/agency-agents/agency-product/README.md
+++ b/profiles/agency-agents/agency-product/README.md
@@ -10,7 +10,7 @@ Product division from The Agency — 5 specialized agent personalities from msit
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-product
+npx forgecat install @forgecat/agency-product
 ```
 
 ## Agents

--- a/profiles/agency-agents/agency-product/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-product/for-forgecat/README.md
@@ -12,7 +12,7 @@ Product division from The Agency — 5 specialized agent personalities from msit
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-product
+npx forgecat install @forgecat/agency-product
 ```
 
 ## Agents

--- a/profiles/agency-agents/agency-project-management/README.md
+++ b/profiles/agency-agents/agency-project-management/README.md
@@ -10,7 +10,7 @@ Project Management division from The Agency — 6 specialized agent personalitie
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-project-management
+npx forgecat install @forgecat/agency-project-management
 ```
 
 ## Agents

--- a/profiles/agency-agents/agency-project-management/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-project-management/for-forgecat/README.md
@@ -12,7 +12,7 @@ Project Management division from The Agency — 6 specialized agent personalitie
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-project-management
+npx forgecat install @forgecat/agency-project-management
 ```
 
 ## Agents

--- a/profiles/agency-agents/agency-sales/README.md
+++ b/profiles/agency-agents/agency-sales/README.md
@@ -10,7 +10,7 @@ Sales division from The Agency — 8 specialized agent personalities from msitar
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-sales
+npx forgecat install @forgecat/agency-sales
 ```
 
 ## Agents

--- a/profiles/agency-agents/agency-sales/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-sales/for-forgecat/README.md
@@ -12,7 +12,7 @@ Sales division from The Agency — 8 specialized agent personalities from msitar
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-sales
+npx forgecat install @forgecat/agency-sales
 ```
 
 ## Agents

--- a/profiles/agency-agents/agency-spatial-computing/README.md
+++ b/profiles/agency-agents/agency-spatial-computing/README.md
@@ -10,7 +10,7 @@ Spatial Computing division from The Agency — 6 specialized agent personalities
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-spatial-computing
+npx forgecat install @forgecat/agency-spatial-computing
 ```
 
 ## Agents

--- a/profiles/agency-agents/agency-spatial-computing/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-spatial-computing/for-forgecat/README.md
@@ -12,7 +12,7 @@ Spatial Computing division from The Agency — 6 specialized agent personalities
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-spatial-computing
+npx forgecat install @forgecat/agency-spatial-computing
 ```
 
 ## Agents

--- a/profiles/agency-agents/agency-specialized/README.md
+++ b/profiles/agency-agents/agency-specialized/README.md
@@ -10,7 +10,7 @@ Specialized division from The Agency — 27 specialized agent personalities from
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-specialized
+npx forgecat install @forgecat/agency-specialized
 ```
 
 ## Agents

--- a/profiles/agency-agents/agency-specialized/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-specialized/for-forgecat/README.md
@@ -12,7 +12,7 @@ Specialized division from The Agency — 27 specialized agent personalities from
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-specialized
+npx forgecat install @forgecat/agency-specialized
 ```
 
 ## Agents

--- a/profiles/agency-agents/agency-support/README.md
+++ b/profiles/agency-agents/agency-support/README.md
@@ -10,7 +10,7 @@ Support division from The Agency — 6 specialized agent personalities from msit
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-support
+npx forgecat install @forgecat/agency-support
 ```
 
 ## Agents

--- a/profiles/agency-agents/agency-support/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-support/for-forgecat/README.md
@@ -12,7 +12,7 @@ Support division from The Agency — 6 specialized agent personalities from msit
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-support
+npx forgecat install @forgecat/agency-support
 ```
 
 ## Agents

--- a/profiles/agency-agents/agency-testing/README.md
+++ b/profiles/agency-agents/agency-testing/README.md
@@ -10,7 +10,7 @@ Testing division from The Agency — 8 specialized agent personalities from msit
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-testing
+npx forgecat install @forgecat/agency-testing
 ```
 
 ## Agents

--- a/profiles/agency-agents/agency-testing/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-testing/for-forgecat/README.md
@@ -12,7 +12,7 @@ Testing division from The Agency — 8 specialized agent personalities from msit
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/agency-testing
+npx forgecat install @forgecat/agency-testing
 ```
 
 ## Agents

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-business-product/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-business-product/README.md
@@ -9,7 +9,7 @@ Support agents for requirements, UX, and engineering-adjacent writing tasks.
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/awesome-codex-subagents-business-product
+npx forgecat install @forgecat/awesome-codex-subagents-business-product
 ```
 
 ## Agents

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-business-product/for-forgecat/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-business-product/for-forgecat/README.md
@@ -11,7 +11,7 @@ Support agents for requirements, UX, and engineering-adjacent writing tasks.
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/awesome-codex-subagents-business-product
+npx forgecat install @forgecat/awesome-codex-subagents-business-product
 ```
 
 ## Agents

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-core-development/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-core-development/README.md
@@ -9,7 +9,7 @@ Core agents for application architecture, cross-layer implementation, UI work, a
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/awesome-codex-subagents-core-development
+npx forgecat install @forgecat/awesome-codex-subagents-core-development
 ```
 
 ## Agents

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-core-development/for-forgecat/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-core-development/for-forgecat/README.md
@@ -11,7 +11,7 @@ Core agents for application architecture, cross-layer implementation, UI work, a
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/awesome-codex-subagents-core-development
+npx forgecat install @forgecat/awesome-codex-subagents-core-development
 ```
 
 ## Agents

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-data-ai/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-data-ai/README.md
@@ -9,7 +9,7 @@ Agents for data pipelines, LLM integrations, and database behavior.
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/awesome-codex-subagents-data-ai
+npx forgecat install @forgecat/awesome-codex-subagents-data-ai
 ```
 
 ## Agents

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-data-ai/for-forgecat/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-data-ai/for-forgecat/README.md
@@ -11,7 +11,7 @@ Agents for data pipelines, LLM integrations, and database behavior.
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/awesome-codex-subagents-data-ai
+npx forgecat install @forgecat/awesome-codex-subagents-data-ai
 ```
 
 ## Agents

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-developer-experience/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-developer-experience/README.md
@@ -9,7 +9,7 @@ Agents for builds, developer tooling, documentation, MCP integrations, and refac
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/awesome-codex-subagents-developer-experience
+npx forgecat install @forgecat/awesome-codex-subagents-developer-experience
 ```
 
 ## Agents

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-developer-experience/for-forgecat/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-developer-experience/for-forgecat/README.md
@@ -11,7 +11,7 @@ Agents for builds, developer tooling, documentation, MCP integrations, and refac
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/awesome-codex-subagents-developer-experience
+npx forgecat install @forgecat/awesome-codex-subagents-developer-experience
 ```
 
 ## Agents

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-infrastructure/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-infrastructure/README.md
@@ -9,7 +9,7 @@ Infrastructure-focused agents for deployment, containerization, orchestration, a
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/awesome-codex-subagents-infrastructure
+npx forgecat install @forgecat/awesome-codex-subagents-infrastructure
 ```
 
 ## Agents

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-infrastructure/for-forgecat/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-infrastructure/for-forgecat/README.md
@@ -11,7 +11,7 @@ Infrastructure-focused agents for deployment, containerization, orchestration, a
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/awesome-codex-subagents-infrastructure
+npx forgecat install @forgecat/awesome-codex-subagents-infrastructure
 ```
 
 ## Agents

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-language-specialists/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-language-specialists/README.md
@@ -9,7 +9,7 @@ Language and framework specialists for ecosystem-specific implementation, debugg
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/awesome-codex-subagents-language-specialists
+npx forgecat install @forgecat/awesome-codex-subagents-language-specialists
 ```
 
 ## Agents

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-language-specialists/for-forgecat/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-language-specialists/for-forgecat/README.md
@@ -11,7 +11,7 @@ Language and framework specialists for ecosystem-specific implementation, debugg
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/awesome-codex-subagents-language-specialists
+npx forgecat install @forgecat/awesome-codex-subagents-language-specialists
 ```
 
 ## Agents

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-meta-orchestration/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-meta-orchestration/README.md
@@ -9,7 +9,7 @@ Agents that help plan or coordinate multi-agent Codex workflows without inventin
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/awesome-codex-subagents-meta-orchestration
+npx forgecat install @forgecat/awesome-codex-subagents-meta-orchestration
 ```
 
 ## Agents

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-meta-orchestration/for-forgecat/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-meta-orchestration/for-forgecat/README.md
@@ -11,7 +11,7 @@ Agents that help plan or coordinate multi-agent Codex workflows without inventin
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/awesome-codex-subagents-meta-orchestration
+npx forgecat install @forgecat/awesome-codex-subagents-meta-orchestration
 ```
 
 ## Agents

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-quality-security/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-quality-security/README.md
@@ -9,7 +9,7 @@ Review and verification agents that work especially well as read-heavy Codex sub
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/awesome-codex-subagents-quality-security
+npx forgecat install @forgecat/awesome-codex-subagents-quality-security
 ```
 
 ## Agents

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-quality-security/for-forgecat/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-quality-security/for-forgecat/README.md
@@ -11,7 +11,7 @@ Review and verification agents that work especially well as read-heavy Codex sub
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/awesome-codex-subagents-quality-security
+npx forgecat install @forgecat/awesome-codex-subagents-quality-security
 ```
 
 ## Agents

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-research-analysis/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-research-analysis/README.md
@@ -9,7 +9,7 @@ Read-heavy research agents for searching, validating, comparing, and synthesizin
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/awesome-codex-subagents-research-analysis
+npx forgecat install @forgecat/awesome-codex-subagents-research-analysis
 ```
 
 ## Agents

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-research-analysis/for-forgecat/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-research-analysis/for-forgecat/README.md
@@ -11,7 +11,7 @@ Read-heavy research agents for searching, validating, comparing, and synthesizin
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/awesome-codex-subagents-research-analysis
+npx forgecat install @forgecat/awesome-codex-subagents-research-analysis
 ```
 
 ## Agents

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-specialized-domains/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-specialized-domains/README.md
@@ -9,7 +9,7 @@ Focused domain agents that still have a clear implementation or verification bou
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/awesome-codex-subagents-specialized-domains
+npx forgecat install @forgecat/awesome-codex-subagents-specialized-domains
 ```
 
 ## Agents

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-specialized-domains/for-forgecat/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-specialized-domains/for-forgecat/README.md
@@ -11,7 +11,7 @@ Focused domain agents that still have a clear implementation or verification bou
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/awesome-codex-subagents-specialized-domains
+npx forgecat install @forgecat/awesome-codex-subagents-specialized-domains
 ```
 
 ## Agents

--- a/profiles/context7/README.md
+++ b/profiles/context7/README.md
@@ -9,7 +9,7 @@ Up-to-date documentation lookup via Context7 MCP. Pull version-specific document
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/context7
+npx forgecat install @forgecat/context7
 ```
 
 ## Agents

--- a/profiles/context7/for-forgecat/README.md
+++ b/profiles/context7/for-forgecat/README.md
@@ -11,7 +11,7 @@ Up-to-date documentation lookup via Context7 MCP. Pull version-specific document
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/context7
+npx forgecat install @forgecat/context7
 ```
 
 ## Agents

--- a/profiles/cursor-plugins/cursor-plugins-cursor-team-kit/README.md
+++ b/profiles/cursor-plugins/cursor-plugins-cursor-team-kit/README.md
@@ -12,7 +12,7 @@ Internal-style workflows for CI, code review, shipping, and test reliability.
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/cursor-team-kit
+npx forgecat install @forgecat/cursor-team-kit
 ```
 
 ## Agents

--- a/profiles/cursor-plugins/cursor-plugins-cursor-team-kit/for-forgecat/README.md
+++ b/profiles/cursor-plugins/cursor-plugins-cursor-team-kit/for-forgecat/README.md
@@ -14,7 +14,7 @@ Internal-style workflows for CI, code review, shipping, and test reliability.
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/cursor-team-kit
+npx forgecat install @forgecat/cursor-team-kit
 ```
 
 ## Agents

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-bio-research/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-bio-research/README.md
@@ -16,7 +16,7 @@ AI-powered research assistant for the life sciences. Connects Claude to 10 precl
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-bio-research
+npx forgecat install @forgecat/knowledge-work-plugins-bio-research
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-bio-research/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-bio-research/for-forgecat/README.md
@@ -18,7 +18,7 @@ AI-powered research assistant for the life sciences. Connects Claude to 10 precl
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-bio-research
+npx forgecat install @forgecat/knowledge-work-plugins-bio-research
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-customer-support/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-customer-support/README.md
@@ -15,7 +15,7 @@ A customer support co-pilot that handles ticket triage, response drafting, escal
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-customer-support
+npx forgecat install @forgecat/knowledge-work-plugins-customer-support
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-customer-support/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-customer-support/for-forgecat/README.md
@@ -17,7 +17,7 @@ A customer support co-pilot that handles ticket triage, response drafting, escal
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-customer-support
+npx forgecat install @forgecat/knowledge-work-plugins-customer-support
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-data/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-data/README.md
@@ -16,7 +16,7 @@ Query, visualize, and interpret datasets with Claude. Write SQL across all major
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-data
+npx forgecat install @forgecat/knowledge-work-plugins-data
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-data/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-data/for-forgecat/README.md
@@ -18,7 +18,7 @@ Query, visualize, and interpret datasets with Claude. Write SQL across all major
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-data
+npx forgecat install @forgecat/knowledge-work-plugins-data
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-design/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-design/README.md
@@ -16,7 +16,7 @@ Accelerate design workflows with Claude. Covers design critique, design system m
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-design
+npx forgecat install @forgecat/knowledge-work-plugins-design
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-design/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-design/for-forgecat/README.md
@@ -18,7 +18,7 @@ Accelerate design workflows with Claude. Covers design critique, design system m
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-design
+npx forgecat install @forgecat/knowledge-work-plugins-design
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-engineering/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-engineering/README.md
@@ -16,7 +16,7 @@ Streamline engineering workflows with Claude. Covers standups, code review, arch
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-engineering
+npx forgecat install @forgecat/knowledge-work-plugins-engineering
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-engineering/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-engineering/for-forgecat/README.md
@@ -18,7 +18,7 @@ Streamline engineering workflows with Claude. Covers standups, code review, arch
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-engineering
+npx forgecat install @forgecat/knowledge-work-plugins-engineering
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-enterprise-search/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-enterprise-search/README.md
@@ -15,7 +15,7 @@ Search across all of your company's tools in one query — email, chat, document
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-enterprise-search
+npx forgecat install @forgecat/knowledge-work-plugins-enterprise-search
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-enterprise-search/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-enterprise-search/for-forgecat/README.md
@@ -17,7 +17,7 @@ Search across all of your company's tools in one query — email, chat, document
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-enterprise-search
+npx forgecat install @forgecat/knowledge-work-plugins-enterprise-search
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-finance/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-finance/README.md
@@ -16,7 +16,7 @@ Streamline finance and accounting workflows with Claude. Covers journal entries,
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-finance
+npx forgecat install @forgecat/knowledge-work-plugins-finance
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-finance/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-finance/for-forgecat/README.md
@@ -18,7 +18,7 @@ Streamline finance and accounting workflows with Claude. Covers journal entries,
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-finance
+npx forgecat install @forgecat/knowledge-work-plugins-finance
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-human-resources/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-human-resources/README.md
@@ -16,7 +16,7 @@ Streamline people operations with Claude. Covers the full employee lifecycle —
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-human-resources
+npx forgecat install @forgecat/knowledge-work-plugins-human-resources
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-human-resources/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-human-resources/for-forgecat/README.md
@@ -18,7 +18,7 @@ Streamline people operations with Claude. Covers the full employee lifecycle —
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-human-resources
+npx forgecat install @forgecat/knowledge-work-plugins-human-resources
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-legal/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-legal/README.md
@@ -16,7 +16,7 @@ Speed up contract review, NDA triage, and compliance workflows for in-house lega
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-legal
+npx forgecat install @forgecat/knowledge-work-plugins-legal
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-legal/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-legal/for-forgecat/README.md
@@ -18,7 +18,7 @@ Speed up contract review, NDA triage, and compliance workflows for in-house lega
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-legal
+npx forgecat install @forgecat/knowledge-work-plugins-legal
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-marketing/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-marketing/README.md
@@ -16,7 +16,7 @@ Create content, plan campaigns, and analyze performance across marketing channel
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-marketing
+npx forgecat install @forgecat/knowledge-work-plugins-marketing
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-marketing/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-marketing/for-forgecat/README.md
@@ -18,7 +18,7 @@ Create content, plan campaigns, and analyze performance across marketing channel
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-marketing
+npx forgecat install @forgecat/knowledge-work-plugins-marketing
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-operations/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-operations/README.md
@@ -16,7 +16,7 @@ Optimize business operations with Claude. Covers process documentation, process 
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-operations
+npx forgecat install @forgecat/knowledge-work-plugins-operations
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-operations/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-operations/for-forgecat/README.md
@@ -18,7 +18,7 @@ Optimize business operations with Claude. Covers process documentation, process 
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-operations
+npx forgecat install @forgecat/knowledge-work-plugins-operations
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-product-management/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-product-management/README.md
@@ -16,7 +16,7 @@ Write feature specs, plan roadmaps, and synthesize user research faster with Cla
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-product-management
+npx forgecat install @forgecat/knowledge-work-plugins-product-management
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-product-management/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-product-management/for-forgecat/README.md
@@ -18,7 +18,7 @@ Write feature specs, plan roadmaps, and synthesize user research faster with Cla
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-product-management
+npx forgecat install @forgecat/knowledge-work-plugins-product-management
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-productivity/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-productivity/README.md
@@ -16,7 +16,7 @@ Manage tasks, plan your day, and give Claude persistent memory of your work cont
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-productivity
+npx forgecat install @forgecat/knowledge-work-plugins-productivity
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-productivity/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-productivity/for-forgecat/README.md
@@ -18,7 +18,7 @@ Manage tasks, plan your day, and give Claude persistent memory of your work cont
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-productivity
+npx forgecat install @forgecat/knowledge-work-plugins-productivity
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-sales/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-sales/README.md
@@ -16,7 +16,7 @@ Prospect, craft outreach, and build deal strategy faster with Claude. Covers acc
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-sales
+npx forgecat install @forgecat/knowledge-work-plugins-sales
 ```
 
 ## Skills

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-sales/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-sales/for-forgecat/README.md
@@ -18,7 +18,7 @@ Prospect, craft outreach, and build deal strategy faster with Claude. Covers acc
 ## Installation
 
 ```
-npx forgecat install @hephai-nota/knowledge-work-plugins-sales
+npx forgecat install @forgecat/knowledge-work-plugins-sales
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-aspnet-core/README.md
+++ b/profiles/openai-skills/openai-skills-aspnet-core/README.md
@@ -10,7 +10,7 @@ Build, review, refactor, or architect ASP.NET Core web applications using curren
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-aspnet-core
+npx forgecat install @forgecat/openai-skills-aspnet-core
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-aspnet-core/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-aspnet-core/for-forgecat/README.md
@@ -12,7 +12,7 @@ Build, review, refactor, or architect ASP.NET Core web applications using curren
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-aspnet-core
+npx forgecat install @forgecat/openai-skills-aspnet-core
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-chatgpt-apps/README.md
+++ b/profiles/openai-skills/openai-skills-chatgpt-apps/README.md
@@ -10,7 +10,7 @@ Build, scaffold, refactor, and troubleshoot ChatGPT Apps SDK applications that c
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-chatgpt-apps
+npx forgecat install @forgecat/openai-skills-chatgpt-apps
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-chatgpt-apps/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-chatgpt-apps/for-forgecat/README.md
@@ -12,7 +12,7 @@ Build, scaffold, refactor, and troubleshoot ChatGPT Apps SDK applications that c
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-chatgpt-apps
+npx forgecat install @forgecat/openai-skills-chatgpt-apps
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-cloudflare-deploy/README.md
+++ b/profiles/openai-skills/openai-skills-cloudflare-deploy/README.md
@@ -10,7 +10,7 @@ Deploy applications and infrastructure to Cloudflare using Workers, Pages, and r
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-cloudflare-deploy
+npx forgecat install @forgecat/openai-skills-cloudflare-deploy
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-cloudflare-deploy/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-cloudflare-deploy/for-forgecat/README.md
@@ -12,7 +12,7 @@ Deploy applications and infrastructure to Cloudflare using Workers, Pages, and r
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-cloudflare-deploy
+npx forgecat install @forgecat/openai-skills-cloudflare-deploy
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-develop-web-game/README.md
+++ b/profiles/openai-skills/openai-skills-develop-web-game/README.md
@@ -10,7 +10,7 @@ Use when Codex is building or iterating on a web game (HTML/JS) and needs a reli
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-develop-web-game
+npx forgecat install @forgecat/openai-skills-develop-web-game
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-develop-web-game/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-develop-web-game/for-forgecat/README.md
@@ -12,7 +12,7 @@ Use when Codex is building or iterating on a web game (HTML/JS) and needs a reli
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-develop-web-game
+npx forgecat install @forgecat/openai-skills-develop-web-game
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-doc/README.md
+++ b/profiles/openai-skills/openai-skills-doc/README.md
@@ -10,7 +10,7 @@ Use when the task involves reading, creating, or editing `.docx` documents, espe
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-doc
+npx forgecat install @forgecat/openai-skills-doc
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-doc/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-doc/for-forgecat/README.md
@@ -12,7 +12,7 @@ Use when the task involves reading, creating, or editing `.docx` documents, espe
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-doc
+npx forgecat install @forgecat/openai-skills-doc
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-figma-code-connect-components/README.md
+++ b/profiles/openai-skills/openai-skills-figma-code-connect-components/README.md
@@ -10,7 +10,7 @@ Connects Figma design components to code components using Code Connect mapping t
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-figma-code-connect-components
+npx forgecat install @forgecat/openai-skills-figma-code-connect-components
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-figma-code-connect-components/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-figma-code-connect-components/for-forgecat/README.md
@@ -12,7 +12,7 @@ Connects Figma design components to code components using Code Connect mapping t
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-figma-code-connect-components
+npx forgecat install @forgecat/openai-skills-figma-code-connect-components
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-figma-create-design-system-rules/README.md
+++ b/profiles/openai-skills/openai-skills-figma-create-design-system-rules/README.md
@@ -10,7 +10,7 @@ Generates custom design system rules for the user's codebase. Use when user says
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-figma-create-design-system-rules
+npx forgecat install @forgecat/openai-skills-figma-create-design-system-rules
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-figma-create-design-system-rules/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-figma-create-design-system-rules/for-forgecat/README.md
@@ -12,7 +12,7 @@ Generates custom design system rules for the user's codebase. Use when user says
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-figma-create-design-system-rules
+npx forgecat install @forgecat/openai-skills-figma-create-design-system-rules
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-figma-create-new-file/README.md
+++ b/profiles/openai-skills/openai-skills-figma-create-new-file/README.md
@@ -10,7 +10,7 @@ Create a new blank Figma file. Use when the user wants to create a new Figma des
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-figma-create-new-file
+npx forgecat install @forgecat/openai-skills-figma-create-new-file
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-figma-create-new-file/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-figma-create-new-file/for-forgecat/README.md
@@ -12,7 +12,7 @@ Create a new blank Figma file. Use when the user wants to create a new Figma des
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-figma-create-new-file
+npx forgecat install @forgecat/openai-skills-figma-create-new-file
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-figma-generate-design/README.md
+++ b/profiles/openai-skills/openai-skills-figma-generate-design/README.md
@@ -10,7 +10,7 @@ Use this skill alongside figma-use when the task involves translating an applica
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-figma-generate-design
+npx forgecat install @forgecat/openai-skills-figma-generate-design
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-figma-generate-design/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-figma-generate-design/for-forgecat/README.md
@@ -12,7 +12,7 @@ Use this skill alongside figma-use when the task involves translating an applica
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-figma-generate-design
+npx forgecat install @forgecat/openai-skills-figma-generate-design
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-figma-generate-library/README.md
+++ b/profiles/openai-skills/openai-skills-figma-generate-library/README.md
@@ -10,7 +10,7 @@ Build or update a professional-grade design system in Figma from a codebase. Use
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-figma-generate-library
+npx forgecat install @forgecat/openai-skills-figma-generate-library
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-figma-generate-library/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-figma-generate-library/for-forgecat/README.md
@@ -12,7 +12,7 @@ Build or update a professional-grade design system in Figma from a codebase. Use
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-figma-generate-library
+npx forgecat install @forgecat/openai-skills-figma-generate-library
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-figma-implement-design/README.md
+++ b/profiles/openai-skills/openai-skills-figma-implement-design/README.md
@@ -10,7 +10,7 @@ Translates Figma designs into production-ready application code with 1:1 visual 
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-figma-implement-design
+npx forgecat install @forgecat/openai-skills-figma-implement-design
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-figma-implement-design/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-figma-implement-design/for-forgecat/README.md
@@ -12,7 +12,7 @@ Translates Figma designs into production-ready application code with 1:1 visual 
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-figma-implement-design
+npx forgecat install @forgecat/openai-skills-figma-implement-design
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-figma-use/README.md
+++ b/profiles/openai-skills/openai-skills-figma-use/README.md
@@ -10,7 +10,7 @@
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-figma-use
+npx forgecat install @forgecat/openai-skills-figma-use
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-figma-use/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-figma-use/for-forgecat/README.md
@@ -12,7 +12,7 @@
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-figma-use
+npx forgecat install @forgecat/openai-skills-figma-use
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-figma/README.md
+++ b/profiles/openai-skills/openai-skills-figma/README.md
@@ -10,7 +10,7 @@ Use the Figma MCP server to fetch design context, screenshots, variables, and as
 ## Installation
 
 ```bash
-npx forgecat install @hephai-nota/openai-skills-figma
+npx forgecat install @forgecat/openai-skills-figma
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-figma/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-figma/for-forgecat/README.md
@@ -12,7 +12,7 @@ Use the Figma MCP server to fetch design context, screenshots, variables, and as
 ## Installation
 
 ```bash
-npx forgecat install @hephai-nota/openai-skills-figma
+npx forgecat install @forgecat/openai-skills-figma
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-frontend-skill/README.md
+++ b/profiles/openai-skills/openai-skills-frontend-skill/README.md
@@ -10,7 +10,7 @@ Use when the task asks for a visually strong landing page, website, app, prototy
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-frontend-skill
+npx forgecat install @forgecat/openai-skills-frontend-skill
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-frontend-skill/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-frontend-skill/for-forgecat/README.md
@@ -12,7 +12,7 @@ Use when the task asks for a visually strong landing page, website, app, prototy
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-frontend-skill
+npx forgecat install @forgecat/openai-skills-frontend-skill
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-gh-address-comments/README.md
+++ b/profiles/openai-skills/openai-skills-gh-address-comments/README.md
@@ -10,7 +10,7 @@ Help address review/issue comments on the open GitHub PR for the current branch 
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-gh-address-comments
+npx forgecat install @forgecat/openai-skills-gh-address-comments
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-gh-address-comments/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-gh-address-comments/for-forgecat/README.md
@@ -12,7 +12,7 @@ Help address review/issue comments on the open GitHub PR for the current branch 
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-gh-address-comments
+npx forgecat install @forgecat/openai-skills-gh-address-comments
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-gh-fix-ci/README.md
+++ b/profiles/openai-skills/openai-skills-gh-fix-ci/README.md
@@ -10,7 +10,7 @@ Use when a user asks to debug or fix failing GitHub PR checks that run in GitHub
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-gh-fix-ci
+npx forgecat install @forgecat/openai-skills-gh-fix-ci
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-gh-fix-ci/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-gh-fix-ci/for-forgecat/README.md
@@ -12,7 +12,7 @@ Use when a user asks to debug or fix failing GitHub PR checks that run in GitHub
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-gh-fix-ci
+npx forgecat install @forgecat/openai-skills-gh-fix-ci
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-imagegen/README.md
+++ b/profiles/openai-skills/openai-skills-imagegen/README.md
@@ -10,7 +10,7 @@ Generate or edit raster images when the task benefits from AI-created bitmap vis
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-imagegen
+npx forgecat install @forgecat/openai-skills-imagegen
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-imagegen/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-imagegen/for-forgecat/README.md
@@ -12,7 +12,7 @@ Generate or edit raster images when the task benefits from AI-created bitmap vis
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-imagegen
+npx forgecat install @forgecat/openai-skills-imagegen
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-jupyter-notebook/README.md
+++ b/profiles/openai-skills/openai-skills-jupyter-notebook/README.md
@@ -10,7 +10,7 @@ Use when the user asks to create, scaffold, or edit Jupyter notebooks (`.ipynb`)
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-jupyter-notebook
+npx forgecat install @forgecat/openai-skills-jupyter-notebook
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-jupyter-notebook/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-jupyter-notebook/for-forgecat/README.md
@@ -12,7 +12,7 @@ Use when the user asks to create, scaffold, or edit Jupyter notebooks (`.ipynb`)
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-jupyter-notebook
+npx forgecat install @forgecat/openai-skills-jupyter-notebook
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-linear/README.md
+++ b/profiles/openai-skills/openai-skills-linear/README.md
@@ -10,7 +10,7 @@ Manage issues, projects & team workflows in Linear. Use when the user wants to r
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-linear
+npx forgecat install @forgecat/openai-skills-linear
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-linear/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-linear/for-forgecat/README.md
@@ -12,7 +12,7 @@ Manage issues, projects & team workflows in Linear. Use when the user wants to r
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-linear
+npx forgecat install @forgecat/openai-skills-linear
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-netlify-deploy/README.md
+++ b/profiles/openai-skills/openai-skills-netlify-deploy/README.md
@@ -10,7 +10,7 @@ Deploy web projects to Netlify using the Netlify CLI (`npx netlify`). Use when t
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-netlify-deploy
+npx forgecat install @forgecat/openai-skills-netlify-deploy
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-netlify-deploy/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-netlify-deploy/for-forgecat/README.md
@@ -12,7 +12,7 @@ Deploy web projects to Netlify using the Netlify CLI (`npx netlify`). Use when t
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-netlify-deploy
+npx forgecat install @forgecat/openai-skills-netlify-deploy
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-notion-knowledge-capture/README.md
+++ b/profiles/openai-skills/openai-skills-notion-knowledge-capture/README.md
@@ -10,7 +10,7 @@ Capture conversations and decisions into structured Notion pages; use when turni
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-notion-knowledge-capture
+npx forgecat install @forgecat/openai-skills-notion-knowledge-capture
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-notion-knowledge-capture/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-notion-knowledge-capture/for-forgecat/README.md
@@ -12,7 +12,7 @@ Capture conversations and decisions into structured Notion pages; use when turni
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-notion-knowledge-capture
+npx forgecat install @forgecat/openai-skills-notion-knowledge-capture
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-notion-meeting-intelligence/README.md
+++ b/profiles/openai-skills/openai-skills-notion-meeting-intelligence/README.md
@@ -10,7 +10,7 @@ Prepare meeting materials with Notion context and Codex research; use when gathe
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-notion-meeting-intelligence
+npx forgecat install @forgecat/openai-skills-notion-meeting-intelligence
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-notion-meeting-intelligence/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-notion-meeting-intelligence/for-forgecat/README.md
@@ -12,7 +12,7 @@ Prepare meeting materials with Notion context and Codex research; use when gathe
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-notion-meeting-intelligence
+npx forgecat install @forgecat/openai-skills-notion-meeting-intelligence
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-notion-research-documentation/README.md
+++ b/profiles/openai-skills/openai-skills-notion-research-documentation/README.md
@@ -10,7 +10,7 @@ Research across Notion and synthesize into structured documentation; use when ga
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-notion-research-documentation
+npx forgecat install @forgecat/openai-skills-notion-research-documentation
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-notion-research-documentation/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-notion-research-documentation/for-forgecat/README.md
@@ -12,7 +12,7 @@ Research across Notion and synthesize into structured documentation; use when ga
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-notion-research-documentation
+npx forgecat install @forgecat/openai-skills-notion-research-documentation
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-notion-spec-to-implementation/README.md
+++ b/profiles/openai-skills/openai-skills-notion-spec-to-implementation/README.md
@@ -10,7 +10,7 @@ Turn Notion specs into implementation plans, tasks, and progress tracking; use w
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-notion-spec-to-implementation
+npx forgecat install @forgecat/openai-skills-notion-spec-to-implementation
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-notion-spec-to-implementation/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-notion-spec-to-implementation/for-forgecat/README.md
@@ -12,7 +12,7 @@ Turn Notion specs into implementation plans, tasks, and progress tracking; use w
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-notion-spec-to-implementation
+npx forgecat install @forgecat/openai-skills-notion-spec-to-implementation
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-openai-docs/README.md
+++ b/profiles/openai-skills/openai-skills-openai-docs/README.md
@@ -10,7 +10,7 @@ Use when the user asks how to build with OpenAI products or APIs and needs up-to
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-openai-docs
+npx forgecat install @forgecat/openai-skills-openai-docs
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-openai-docs/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-openai-docs/for-forgecat/README.md
@@ -12,7 +12,7 @@ Use when the user asks how to build with OpenAI products or APIs and needs up-to
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-openai-docs
+npx forgecat install @forgecat/openai-skills-openai-docs
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-pdf/README.md
+++ b/profiles/openai-skills/openai-skills-pdf/README.md
@@ -10,7 +10,7 @@ Use when tasks involve reading, creating, or reviewing PDF files where rendering
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-pdf
+npx forgecat install @forgecat/openai-skills-pdf
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-pdf/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-pdf/for-forgecat/README.md
@@ -12,7 +12,7 @@ Use when tasks involve reading, creating, or reviewing PDF files where rendering
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-pdf
+npx forgecat install @forgecat/openai-skills-pdf
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-playwright-interactive/README.md
+++ b/profiles/openai-skills/openai-skills-playwright-interactive/README.md
@@ -10,7 +10,7 @@ Persistent browser and Electron interaction through `js_repl` for fast iterative
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-playwright-interactive
+npx forgecat install @forgecat/openai-skills-playwright-interactive
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-playwright-interactive/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-playwright-interactive/for-forgecat/README.md
@@ -12,7 +12,7 @@ Persistent browser and Electron interaction through `js_repl` for fast iterative
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-playwright-interactive
+npx forgecat install @forgecat/openai-skills-playwright-interactive
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-playwright/README.md
+++ b/profiles/openai-skills/openai-skills-playwright/README.md
@@ -10,7 +10,7 @@ Use when the task requires automating a real browser from the terminal (navigati
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-playwright
+npx forgecat install @forgecat/openai-skills-playwright
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-playwright/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-playwright/for-forgecat/README.md
@@ -12,7 +12,7 @@ Use when the task requires automating a real browser from the terminal (navigati
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-playwright
+npx forgecat install @forgecat/openai-skills-playwright
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-render-deploy/README.md
+++ b/profiles/openai-skills/openai-skills-render-deploy/README.md
@@ -10,7 +10,7 @@ Deploy applications to Render by analyzing codebases, generating render.yaml Blu
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-render-deploy
+npx forgecat install @forgecat/openai-skills-render-deploy
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-render-deploy/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-render-deploy/for-forgecat/README.md
@@ -12,7 +12,7 @@ Deploy applications to Render by analyzing codebases, generating render.yaml Blu
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-render-deploy
+npx forgecat install @forgecat/openai-skills-render-deploy
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-screenshot/README.md
+++ b/profiles/openai-skills/openai-skills-screenshot/README.md
@@ -10,7 +10,7 @@ Use when the user explicitly asks for a desktop or system screenshot (full scree
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-screenshot
+npx forgecat install @forgecat/openai-skills-screenshot
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-screenshot/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-screenshot/for-forgecat/README.md
@@ -12,7 +12,7 @@ Use when the user explicitly asks for a desktop or system screenshot (full scree
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-screenshot
+npx forgecat install @forgecat/openai-skills-screenshot
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-security-best-practices/README.md
+++ b/profiles/openai-skills/openai-skills-security-best-practices/README.md
@@ -10,7 +10,7 @@ Perform language and framework specific security best-practice reviews and sugge
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-security-best-practices
+npx forgecat install @forgecat/openai-skills-security-best-practices
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-security-best-practices/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-security-best-practices/for-forgecat/README.md
@@ -12,7 +12,7 @@ Perform language and framework specific security best-practice reviews and sugge
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-security-best-practices
+npx forgecat install @forgecat/openai-skills-security-best-practices
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-security-ownership-map/README.md
+++ b/profiles/openai-skills/openai-skills-security-ownership-map/README.md
@@ -10,7 +10,7 @@ Analyze git repositories to build a security ownership topology (people-to-file)
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-security-ownership-map
+npx forgecat install @forgecat/openai-skills-security-ownership-map
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-security-ownership-map/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-security-ownership-map/for-forgecat/README.md
@@ -12,7 +12,7 @@ Analyze git repositories to build a security ownership topology (people-to-file)
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-security-ownership-map
+npx forgecat install @forgecat/openai-skills-security-ownership-map
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-security-threat-model/README.md
+++ b/profiles/openai-skills/openai-skills-security-threat-model/README.md
@@ -10,7 +10,7 @@ Repository-grounded threat modeling that enumerates trust boundaries, assets, at
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-security-threat-model
+npx forgecat install @forgecat/openai-skills-security-threat-model
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-security-threat-model/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-security-threat-model/for-forgecat/README.md
@@ -12,7 +12,7 @@ Repository-grounded threat modeling that enumerates trust boundaries, assets, at
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-security-threat-model
+npx forgecat install @forgecat/openai-skills-security-threat-model
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-sentry/README.md
+++ b/profiles/openai-skills/openai-skills-sentry/README.md
@@ -10,7 +10,7 @@ Use when the user asks to inspect Sentry issues or events, summarize recent prod
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-sentry
+npx forgecat install @forgecat/openai-skills-sentry
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-sentry/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-sentry/for-forgecat/README.md
@@ -12,7 +12,7 @@ Use when the user asks to inspect Sentry issues or events, summarize recent prod
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-sentry
+npx forgecat install @forgecat/openai-skills-sentry
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-slides/README.md
+++ b/profiles/openai-skills/openai-skills-slides/README.md
@@ -10,7 +10,7 @@ Create and edit presentation slide decks (`.pptx`) with PptxGenJS, bundled layou
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-slides
+npx forgecat install @forgecat/openai-skills-slides
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-slides/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-slides/for-forgecat/README.md
@@ -12,7 +12,7 @@ Create and edit presentation slide decks (`.pptx`) with PptxGenJS, bundled layou
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-slides
+npx forgecat install @forgecat/openai-skills-slides
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-sora/README.md
+++ b/profiles/openai-skills/openai-skills-sora/README.md
@@ -10,7 +10,7 @@ Use when the user asks to generate, edit, extend, poll, list, download, or delet
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-sora
+npx forgecat install @forgecat/openai-skills-sora
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-sora/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-sora/for-forgecat/README.md
@@ -12,7 +12,7 @@ Use when the user asks to generate, edit, extend, poll, list, download, or delet
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-sora
+npx forgecat install @forgecat/openai-skills-sora
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-speech/README.md
+++ b/profiles/openai-skills/openai-skills-speech/README.md
@@ -10,7 +10,7 @@ Use when the user asks for text-to-speech narration or voiceover, accessibility 
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-speech
+npx forgecat install @forgecat/openai-skills-speech
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-speech/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-speech/for-forgecat/README.md
@@ -12,7 +12,7 @@ Use when the user asks for text-to-speech narration or voiceover, accessibility 
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-speech
+npx forgecat install @forgecat/openai-skills-speech
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-spreadsheet/README.md
+++ b/profiles/openai-skills/openai-skills-spreadsheet/README.md
@@ -10,7 +10,7 @@ Use when tasks involve creating, editing, analyzing, or formatting spreadsheets 
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-spreadsheet
+npx forgecat install @forgecat/openai-skills-spreadsheet
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-spreadsheet/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-spreadsheet/for-forgecat/README.md
@@ -12,7 +12,7 @@ Use when tasks involve creating, editing, analyzing, or formatting spreadsheets 
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-spreadsheet
+npx forgecat install @forgecat/openai-skills-spreadsheet
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-system-openai-docs/README.md
+++ b/profiles/openai-skills/openai-skills-system-openai-docs/README.md
@@ -10,7 +10,7 @@ Use when the user asks how to build with OpenAI products or APIs and needs up-to
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-system-openai-docs
+npx forgecat install @forgecat/openai-skills-system-openai-docs
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-system-openai-docs/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-system-openai-docs/for-forgecat/README.md
@@ -12,7 +12,7 @@ Use when the user asks how to build with OpenAI products or APIs and needs up-to
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-system-openai-docs
+npx forgecat install @forgecat/openai-skills-system-openai-docs
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-system-skill-creator/README.md
+++ b/profiles/openai-skills/openai-skills-system-skill-creator/README.md
@@ -10,7 +10,7 @@ Guide for creating effective skills. This skill should be used when users want t
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-system-skill-creator
+npx forgecat install @forgecat/openai-skills-system-skill-creator
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-system-skill-creator/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-system-skill-creator/for-forgecat/README.md
@@ -12,7 +12,7 @@ Guide for creating effective skills. This skill should be used when users want t
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-system-skill-creator
+npx forgecat install @forgecat/openai-skills-system-skill-creator
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-system-skill-installer/README.md
+++ b/profiles/openai-skills/openai-skills-system-skill-installer/README.md
@@ -10,7 +10,7 @@ Install Codex skills into $CODEX_HOME/skills from a curated list or a GitHub rep
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-system-skill-installer
+npx forgecat install @forgecat/openai-skills-system-skill-installer
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-system-skill-installer/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-system-skill-installer/for-forgecat/README.md
@@ -12,7 +12,7 @@ Install Codex skills into $CODEX_HOME/skills from a curated list or a GitHub rep
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-system-skill-installer
+npx forgecat install @forgecat/openai-skills-system-skill-installer
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-transcribe/README.md
+++ b/profiles/openai-skills/openai-skills-transcribe/README.md
@@ -10,7 +10,7 @@ Transcribe audio files to text with optional diarization and known-speaker hints
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-transcribe
+npx forgecat install @forgecat/openai-skills-transcribe
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-transcribe/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-transcribe/for-forgecat/README.md
@@ -12,7 +12,7 @@ Transcribe audio files to text with optional diarization and known-speaker hints
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-transcribe
+npx forgecat install @forgecat/openai-skills-transcribe
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-vercel-deploy/README.md
+++ b/profiles/openai-skills/openai-skills-vercel-deploy/README.md
@@ -10,7 +10,7 @@ Deploy applications and websites to Vercel. Use when the user requests deploymen
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-vercel-deploy
+npx forgecat install @forgecat/openai-skills-vercel-deploy
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-vercel-deploy/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-vercel-deploy/for-forgecat/README.md
@@ -12,7 +12,7 @@ Deploy applications and websites to Vercel. Use when the user requests deploymen
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-vercel-deploy
+npx forgecat install @forgecat/openai-skills-vercel-deploy
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-winui-app/README.md
+++ b/profiles/openai-skills/openai-skills-winui-app/README.md
@@ -10,7 +10,7 @@ Bootstrap, develop, and design modern WinUI 3 desktop applications with C# and t
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-winui-app
+npx forgecat install @forgecat/openai-skills-winui-app
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-winui-app/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-winui-app/for-forgecat/README.md
@@ -12,7 +12,7 @@ Bootstrap, develop, and design modern WinUI 3 desktop applications with C# and t
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-winui-app
+npx forgecat install @forgecat/openai-skills-winui-app
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-yeet/README.md
+++ b/profiles/openai-skills/openai-skills-yeet/README.md
@@ -10,7 +10,7 @@ Use only when the user explicitly asks to stage, commit, push, and open a GitHub
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-yeet
+npx forgecat install @forgecat/openai-skills-yeet
 ```
 
 ## Skills

--- a/profiles/openai-skills/openai-skills-yeet/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-yeet/for-forgecat/README.md
@@ -12,7 +12,7 @@ Use only when the user explicitly asks to stage, commit, push, and open a GitHub
 
 ## Installation
 ```bash
-npx forgecat install @hephai-nota/openai-skills-yeet
+npx forgecat install @forgecat/openai-skills-yeet
 ```
 
 ## Skills


### PR DESCRIPTION
## Summary

Updates all profile install commands to use the correct `@forgecat` namespace.

## Changes
- Updated 167 README files across all profile groups
- All install commands now reference `@forgecat/profile-name`
- Matches current registry state

## Files Changed
- 167 README files (root + for-forgecat directories)