### PR TITLE
Sync profile versions with registry

### DIFF
--- a/profiles/agency-agents/agency-academic/README.md
+++ b/profiles/agency-agents/agency-academic/README.md
@@ -25,7 +25,7 @@ npx forgecat install @forgecat/agency-academic
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.5` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-academic/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-academic/for-forgecat/README.md
@@ -27,7 +27,7 @@ npx forgecat install @forgecat/agency-academic
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.2` |
+| Version | `0.0.5` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-academic/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-academic/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: "agency-academic"
-version: "0.0.2"
+version: "0.0.5"
 description: >-
   Academic division from The Agency — 5 specialized academic
   agent personalities from msitarzewski/agency-agents.

--- a/profiles/agency-agents/agency-design/README.md
+++ b/profiles/agency-agents/agency-design/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/agency-design
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-design/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-design/for-forgecat/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/agency-design
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-design/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-design/for-forgecat/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-design"
-version: "0.0.3"
+version: "0.0.6"
 description: >-
   Design division from The Agency — 8 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,

--- a/profiles/agency-agents/agency-engineering/README.md
+++ b/profiles/agency-agents/agency-engineering/README.md
@@ -43,7 +43,7 @@ npx forgecat install @forgecat/agency-engineering
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-engineering/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-engineering/for-forgecat/README.md
@@ -45,7 +45,7 @@ npx forgecat install @forgecat/agency-engineering
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-engineering/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-engineering/for-forgecat/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-engineering"
-version: "0.0.3"
+version: "0.0.6"
 description: >-
   Engineering division from The Agency — 23 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,

--- a/profiles/agency-agents/agency-game-development/README.md
+++ b/profiles/agency-agents/agency-game-development/README.md
@@ -40,7 +40,7 @@ npx forgecat install @forgecat/agency-game-development
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-game-development/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-game-development/for-forgecat/README.md
@@ -42,7 +42,7 @@ npx forgecat install @forgecat/agency-game-development
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-game-development/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-game-development/for-forgecat/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-game-development"
-version: "0.0.3"
+version: "0.0.6"
 description: >-
   Game Development division from The Agency — 20 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,

--- a/profiles/agency-agents/agency-marketing/README.md
+++ b/profiles/agency-agents/agency-marketing/README.md
@@ -47,7 +47,7 @@ npx forgecat install @forgecat/agency-marketing
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-marketing/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-marketing/for-forgecat/README.md
@@ -49,7 +49,7 @@ npx forgecat install @forgecat/agency-marketing
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-marketing/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-marketing/for-forgecat/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-marketing"
-version: "0.0.3"
+version: "0.0.6"
 description: >-
   Marketing division from The Agency — 27 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,

--- a/profiles/agency-agents/agency-paid-media/README.md
+++ b/profiles/agency-agents/agency-paid-media/README.md
@@ -27,7 +27,7 @@ npx forgecat install @forgecat/agency-paid-media
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-paid-media/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-paid-media/for-forgecat/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/agency-paid-media
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-paid-media/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-paid-media/for-forgecat/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-paid-media"
-version: "0.0.3"
+version: "0.0.6"
 description: >-
   Paid Media division from The Agency — 7 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,

--- a/profiles/agency-agents/agency-product/README.md
+++ b/profiles/agency-agents/agency-product/README.md
@@ -25,7 +25,7 @@ npx forgecat install @forgecat/agency-product
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-product/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-product/for-forgecat/README.md
@@ -27,7 +27,7 @@ npx forgecat install @forgecat/agency-product
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-product/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-product/for-forgecat/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-product"
-version: "0.0.3"
+version: "0.0.6"
 description: >-
   Product division from The Agency — 5 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,

--- a/profiles/agency-agents/agency-project-management/README.md
+++ b/profiles/agency-agents/agency-project-management/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/agency-project-management
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-project-management/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-project-management/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/agency-project-management
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-project-management/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-project-management/for-forgecat/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-project-management"
-version: "0.0.3"
+version: "0.0.6"
 description: >-
   Project Management division from The Agency — 6 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,

--- a/profiles/agency-agents/agency-sales/README.md
+++ b/profiles/agency-agents/agency-sales/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/agency-sales
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-sales/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-sales/for-forgecat/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/agency-sales
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-sales/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-sales/for-forgecat/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-sales"
-version: "0.0.3"
+version: "0.0.6"
 description: >-
   Sales division from The Agency — 8 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,

--- a/profiles/agency-agents/agency-spatial-computing/README.md
+++ b/profiles/agency-agents/agency-spatial-computing/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/agency-spatial-computing
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-spatial-computing/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-spatial-computing/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/agency-spatial-computing
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-spatial-computing/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-spatial-computing/for-forgecat/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-spatial-computing"
-version: "0.0.3"
+version: "0.0.6"
 description: >-
   Spatial Computing division from The Agency — 6 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,

--- a/profiles/agency-agents/agency-specialized/README.md
+++ b/profiles/agency-agents/agency-specialized/README.md
@@ -47,7 +47,7 @@ npx forgecat install @forgecat/agency-specialized
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-specialized/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-specialized/for-forgecat/README.md
@@ -49,7 +49,7 @@ npx forgecat install @forgecat/agency-specialized
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-specialized/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-specialized/for-forgecat/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-specialized"
-version: "0.0.3"
+version: "0.0.6"
 description: >-
   Specialized division from The Agency — 27 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,

--- a/profiles/agency-agents/agency-support/README.md
+++ b/profiles/agency-agents/agency-support/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/agency-support
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-support/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-support/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/agency-support
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-support/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-support/for-forgecat/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-support"
-version: "0.0.3"
+version: "0.0.6"
 description: >-
   Support division from The Agency — 6 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,

--- a/profiles/agency-agents/agency-testing/README.md
+++ b/profiles/agency-agents/agency-testing/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/agency-testing
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-testing/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-testing/for-forgecat/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/agency-testing
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `source-preserved-in-ori` |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-testing/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-testing/for-forgecat/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-testing"
-version: "0.0.3"
+version: "0.0.6"
 description: >-
   Testing division from The Agency — 8 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-business-product/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-business-product/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/awesome-codex-subagents-business-product
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-business-product/for-forgecat/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-business-product/for-forgecat/README.md
@@ -32,7 +32,7 @@ npx forgecat install @forgecat/awesome-codex-subagents-business-product
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-business-product/for-forgecat/profile.yml
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-business-product/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: awesome-codex-subagents-business-product
-version: "0.0.3"
+version: "0.0.6"
 description: >-
   Support agents for requirements, UX, and engineering-adjacent writing tasks. Includes 11 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-core-development/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-core-development/README.md
@@ -31,7 +31,7 @@ npx forgecat install @forgecat/awesome-codex-subagents-core-development
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.5` |
+| Version | `0.0.8` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-core-development/for-forgecat/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-core-development/for-forgecat/README.md
@@ -33,7 +33,7 @@ npx forgecat install @forgecat/awesome-codex-subagents-core-development
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.5` |
+| Version | `0.0.8` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-core-development/for-forgecat/profile.yml
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-core-development/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: awesome-codex-subagents-core-development
-version: "0.0.5"
+version: "0.0.8"
 description: >-
   Core agents for application architecture, cross-layer implementation, UI work, and protocol-specific development. Includes 12 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-data-ai/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-data-ai/README.md
@@ -31,7 +31,7 @@ npx forgecat install @forgecat/awesome-codex-subagents-data-ai
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-data-ai/for-forgecat/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-data-ai/for-forgecat/README.md
@@ -33,7 +33,7 @@ npx forgecat install @forgecat/awesome-codex-subagents-data-ai
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-data-ai/for-forgecat/profile.yml
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-data-ai/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: awesome-codex-subagents-data-ai
-version: "0.0.3"
+version: "0.0.6"
 description: >-
   Agents for data pipelines, LLM integrations, and database behavior. Includes 12 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-developer-experience/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-developer-experience/README.md
@@ -32,7 +32,7 @@ npx forgecat install @forgecat/awesome-codex-subagents-developer-experience
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-developer-experience/for-forgecat/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-developer-experience/for-forgecat/README.md
@@ -34,7 +34,7 @@ npx forgecat install @forgecat/awesome-codex-subagents-developer-experience
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-developer-experience/for-forgecat/profile.yml
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-developer-experience/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: awesome-codex-subagents-developer-experience
-version: "0.0.3"
+version: "0.0.6"
 description: >-
   Agents for builds, developer tooling, documentation, MCP integrations, and refactors. Includes 13 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-infrastructure/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-infrastructure/README.md
@@ -35,7 +35,7 @@ npx forgecat install @forgecat/awesome-codex-subagents-infrastructure
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-infrastructure/for-forgecat/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-infrastructure/for-forgecat/README.md
@@ -37,7 +37,7 @@ npx forgecat install @forgecat/awesome-codex-subagents-infrastructure
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-infrastructure/for-forgecat/profile.yml
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-infrastructure/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: awesome-codex-subagents-infrastructure
-version: "0.0.3"
+version: "0.0.6"
 description: >-
   Infrastructure-focused agents for deployment, containerization, orchestration, and IaC work. Includes 16 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-language-specialists/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-language-specialists/README.md
@@ -45,7 +45,7 @@ npx forgecat install @forgecat/awesome-codex-subagents-language-specialists
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-language-specialists/for-forgecat/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-language-specialists/for-forgecat/README.md
@@ -47,7 +47,7 @@ npx forgecat install @forgecat/awesome-codex-subagents-language-specialists
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-language-specialists/for-forgecat/profile.yml
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-language-specialists/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: awesome-codex-subagents-language-specialists
-version: "0.0.3"
+version: "0.0.6"
 description: >-
   Language and framework specialists for ecosystem-specific implementation, debugging, and architectural guidance. Includes 26 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-meta-orchestration/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-meta-orchestration/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/awesome-codex-subagents-meta-orchestration
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-meta-orchestration/for-forgecat/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-meta-orchestration/for-forgecat/README.md
@@ -31,7 +31,7 @@ npx forgecat install @forgecat/awesome-codex-subagents-meta-orchestration
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-meta-orchestration/for-forgecat/profile.yml
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-meta-orchestration/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: awesome-codex-subagents-meta-orchestration
-version: "0.0.3"
+version: "0.0.6"
 description: >-
   Agents that help plan or coordinate multi-agent Codex workflows without inventing unsupported mechanics. Includes 10 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-quality-security/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-quality-security/README.md
@@ -35,7 +35,7 @@ npx forgecat install @forgecat/awesome-codex-subagents-quality-security
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-quality-security/for-forgecat/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-quality-security/for-forgecat/README.md
@@ -37,7 +37,7 @@ npx forgecat install @forgecat/awesome-codex-subagents-quality-security
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-quality-security/for-forgecat/profile.yml
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-quality-security/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: awesome-codex-subagents-quality-security
-version: "0.0.3"
+version: "0.0.6"
 description: >-
   Review and verification agents that work especially well as read-heavy Codex subagents. Includes 16 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-research-analysis/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-research-analysis/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/awesome-codex-subagents-research-analysis
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-research-analysis/for-forgecat/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-research-analysis/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/awesome-codex-subagents-research-analysis
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-research-analysis/for-forgecat/profile.yml
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-research-analysis/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: awesome-codex-subagents-research-analysis
-version: "0.0.3"
+version: "0.0.6"
 description: >-
   Read-heavy research agents for searching, validating, comparing, and synthesizing information. Includes 7 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-specialized-domains/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-specialized-domains/README.md
@@ -31,7 +31,7 @@ npx forgecat install @forgecat/awesome-codex-subagents-specialized-domains
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-specialized-domains/for-forgecat/README.md
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-specialized-domains/for-forgecat/README.md
@@ -33,7 +33,7 @@ npx forgecat install @forgecat/awesome-codex-subagents-specialized-domains
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/awesome-codex-subagents/awesome-codex-subagents-specialized-domains/for-forgecat/profile.yml
+++ b/profiles/awesome-codex-subagents/awesome-codex-subagents-specialized-domains/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: awesome-codex-subagents-specialized-domains
-version: "0.0.3"
+version: "0.0.6"
 description: >-
   Focused domain agents that still have a clear implementation or verification boundary. Includes 12 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 

--- a/profiles/context7/README.md
+++ b/profiles/context7/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/context7
 |---|---|
 | Author | `Upstash` |
 | Original repository | `https://github.com/upstash/context7` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `383e127` (2026-03-16) |
 | Converted path | `plugins/claude/context7/` |
 | License | `MIT` |

--- a/profiles/context7/for-forgecat/README.md
+++ b/profiles/context7/for-forgecat/README.md
@@ -31,7 +31,7 @@ npx forgecat install @forgecat/context7
 |---|---|
 | Author | `Upstash` |
 | Original repository | `https://github.com/upstash/context7` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `383e127` (2026-03-16) |
 | Converted path | `plugins/claude/context7/` |
 | License | `MIT` |

--- a/profiles/context7/for-forgecat/profile.yml
+++ b/profiles/context7/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: context7
-version: "0.0.3"
+version: "0.0.6"
 description: >-
   Up-to-date documentation lookup via Context7 MCP. Pull version-specific
   documentation and code examples directly from source repositories into

--- a/profiles/cursor-plugins/cursor-plugins-cursor-team-kit/README.md
+++ b/profiles/cursor-plugins/cursor-plugins-cursor-team-kit/README.md
@@ -37,7 +37,7 @@ npx forgecat install @forgecat/cursor-team-kit
 |---|---|
 | Author | `Cursor` |
 | Original repository | `https://github.com/cursor/plugins` |
-| Version | `0.0.2` |
+| Version | `0.0.5` |
 | Original commit | `9c39b57` (2026-03-13) |
 | License | `MIT` |
 | Source platform | `cursor` |

--- a/profiles/cursor-plugins/cursor-plugins-cursor-team-kit/for-forgecat/README.md
+++ b/profiles/cursor-plugins/cursor-plugins-cursor-team-kit/for-forgecat/README.md
@@ -39,7 +39,7 @@ npx forgecat install @forgecat/cursor-team-kit
 |---|---|
 | Author | `Cursor` |
 | Original repository | `https://github.com/cursor/plugins` |
-| Version | `0.0.2` |
+| Version | `0.0.5` |
 | Original commit | `9c39b57` (2026-03-13) |
 | License | `MIT` |
 | Source platform | `cursor` |

--- a/profiles/cursor-plugins/cursor-plugins-cursor-team-kit/for-forgecat/profile.yml
+++ b/profiles/cursor-plugins/cursor-plugins-cursor-team-kit/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: cursor-plugins-cursor-team-kit
-version: "0.0.2"
+version: "0.0.5"
 description: >-
   Internal workflows used by Cursor developers for CI, code review, and shipping. Covers the full dev loop: CI monitoring and fixing, PR creation, merge conflicts, smoke tests, compiler checks, code cleanup, and work summaries.
 repository: "https://github.com/cursor/plugins"

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-bio-research/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-bio-research/README.md
@@ -51,7 +51,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-bio-research
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/bio-research |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-bio-research/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-bio-research/for-forgecat/README.md
@@ -53,7 +53,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-bio-research
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/bio-research |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-bio-research/for-forgecat/profile.yml
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-bio-research/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-bio-research"
-version: "0.0.1"
+version: "0.0.4"
 description: Connect to preclinical research tools and databases (literature search, genomics analysis, target prioritization) to accelerate early-stage life sciences R&D.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/bio-research
 license: Apache-2.0

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-customer-support/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-customer-support/README.md
@@ -48,7 +48,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-customer-support
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/customer-support |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-customer-support/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-customer-support/for-forgecat/README.md
@@ -50,7 +50,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-customer-support
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/customer-support |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-customer-support/for-forgecat/profile.yml
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-customer-support/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-customer-support"
-version: "0.0.1"
+version: "0.0.4"
 description: Triage tickets, draft responses, escalate issues, and build your knowledge base. Research customer context and turn resolved issues into self-service content.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/customer-support
 license: Apache-2.0

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-data/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-data/README.md
@@ -53,7 +53,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-data
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/data |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-data/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-data/for-forgecat/README.md
@@ -55,7 +55,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-data
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/data |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-data/for-forgecat/profile.yml
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-data/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-data"
-version: "0.0.1"
+version: "0.0.4"
 description: Write SQL, explore datasets, and generate insights faster. Build visualizations and dashboards, and turn raw data into clear stories for stakeholders.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/data
 license: Apache-2.0

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-design/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-design/README.md
@@ -51,7 +51,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-design
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/design |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-design/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-design/for-forgecat/README.md
@@ -53,7 +53,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-design
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/design |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-design/for-forgecat/profile.yml
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-design/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-design"
-version: "0.0.1"
+version: "0.0.4"
 description: Accelerate design workflows — critique, design system management, UX writing, accessibility audits, research synthesis, and dev handoff. From exploration to pixel-perfect specs.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/design
 license: Apache-2.0

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-engineering/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-engineering/README.md
@@ -55,7 +55,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-engineering
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/engineering |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-engineering/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-engineering/for-forgecat/README.md
@@ -57,7 +57,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-engineering
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/engineering |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-engineering/for-forgecat/profile.yml
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-engineering/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-engineering"
-version: "0.0.1"
+version: "0.0.4"
 description: Streamline engineering workflows — standups, code review, architecture decisions, incident response, and technical documentation. Works with your existing tools or standalone.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/engineering
 license: Apache-2.0

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-enterprise-search/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-enterprise-search/README.md
@@ -47,7 +47,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-enterprise-search
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/enterprise-search |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-enterprise-search/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-enterprise-search/for-forgecat/README.md
@@ -49,7 +49,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-enterprise-search
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/enterprise-search |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-enterprise-search/for-forgecat/profile.yml
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-enterprise-search/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-enterprise-search"
-version: "0.0.1"
+version: "0.0.4"
 description: Search across all of your company's tools in one place. Find anything across email, chat, documents, and wikis without switching between apps.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/enterprise-search
 license: Apache-2.0

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-finance/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-finance/README.md
@@ -50,7 +50,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-finance
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/finance |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-finance/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-finance/for-forgecat/README.md
@@ -52,7 +52,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-finance
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/finance |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-finance/for-forgecat/profile.yml
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-finance/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-finance"
-version: "0.0.1"
+version: "0.0.4"
 description: Streamline finance and accounting workflows, from journal entries and reconciliation to financial statements and variance analysis. Speed up audit prep, month-end close, and keeping your books clean.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/finance
 license: Apache-2.0

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-human-resources/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-human-resources/README.md
@@ -50,7 +50,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-human-resources
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/human-resources |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-human-resources/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-human-resources/for-forgecat/README.md
@@ -52,7 +52,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-human-resources
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/human-resources |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-human-resources/for-forgecat/profile.yml
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-human-resources/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-human-resources"
-version: "0.0.1"
+version: "0.0.4"
 description: Streamline people operations — recruiting, onboarding, performance reviews, compensation analysis, and policy guidance. Maintain compliance and keep your team running smoothly.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/human-resources
 license: Apache-2.0

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-legal/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-legal/README.md
@@ -52,7 +52,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-legal
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/legal |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-legal/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-legal/for-forgecat/README.md
@@ -54,7 +54,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-legal
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/legal |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-legal/for-forgecat/profile.yml
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-legal/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-legal"
-version: "0.0.1"
+version: "0.0.4"
 description: Speed up contract review, NDA triage, and compliance workflows for in-house legal teams. Draft legal briefs, organize precedent research, and manage institutional knowledge.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/legal
 license: Apache-2.0

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-marketing/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-marketing/README.md
@@ -56,7 +56,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-marketing
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/marketing |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-marketing/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-marketing/for-forgecat/README.md
@@ -58,7 +58,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-marketing
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/marketing |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-marketing/for-forgecat/profile.yml
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-marketing/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-marketing"
-version: "0.0.1"
+version: "0.0.4"
 description: Create content, plan campaigns, and analyze performance across marketing channels. Maintain brand voice consistency, track competitors, and report on what's working.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/marketing
 license: Apache-2.0

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-operations/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-operations/README.md
@@ -52,7 +52,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-operations
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/operations |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-operations/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-operations/for-forgecat/README.md
@@ -54,7 +54,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-operations
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/operations |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-operations/for-forgecat/profile.yml
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-operations/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-operations"
-version: "0.0.1"
+version: "0.0.4"
 description: Optimize business operations — vendor management, process documentation, change management, capacity planning, and compliance tracking. Keep your organization running efficiently.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/operations
 license: Apache-2.0

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-product-management/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-product-management/README.md
@@ -65,7 +65,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-product-management
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/product-management |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-product-management/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-product-management/for-forgecat/README.md
@@ -67,7 +67,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-product-management
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/product-management |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-product-management/for-forgecat/profile.yml
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-product-management/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-product-management"
-version: "0.0.1"
+version: "0.0.4"
 description: Write feature specs, plan roadmaps, and synthesize user research faster. Keep stakeholders updated and stay ahead of the competitive landscape.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/product-management
 license: Apache-2.0

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-productivity/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-productivity/README.md
@@ -49,7 +49,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-productivity
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/productivity |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-productivity/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-productivity/for-forgecat/README.md
@@ -51,7 +51,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-productivity
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/productivity |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-productivity/for-forgecat/profile.yml
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-productivity/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-productivity"
-version: "0.0.1"
+version: "0.0.4"
 description: Manage tasks, plan your day, and build up memory of important context about your work. Syncs with your calendar, email, and chat to keep everything organized and on track.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/productivity
 license: Apache-2.0

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-sales/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-sales/README.md
@@ -58,7 +58,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-sales
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/sales |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-sales/for-forgecat/README.md
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-sales/for-forgecat/README.md
@@ -60,7 +60,7 @@ npx forgecat install @forgecat/knowledge-work-plugins-sales
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/sales |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/knowledge-work-plugins/knowledge-work-plugins-sales/for-forgecat/profile.yml
+++ b/profiles/knowledge-work-plugins/knowledge-work-plugins-sales/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: "knowledge-work-plugins-sales"
-version: "0.0.1"
+version: "0.0.4"
 description: Prospect, craft outreach, and build deal strategy faster. Prep for calls, manage your pipeline, and write personalized messaging that moves deals forward.
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/sales
 license: Apache-2.0

--- a/profiles/openai-skills/openai-skills-aspnet-core/README.md
+++ b/profiles/openai-skills/openai-skills-aspnet-core/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-aspnet-core
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-aspnet-core/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-aspnet-core/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-aspnet-core
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-aspnet-core/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-aspnet-core/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-aspnet-core
-version: "0.0.3"
+version: "0.0.6"
 description: "Build, review, refactor, or architect ASP.NET Core web applications using current official guidance for .NET web development. Use when working on Blazor Web Apps, Razor Pages, MVC, Minimal APIs, controller-based Web APIs, SignalR, gRPC, middleware, dependency injection, configuration, authentication, authorization, testing, performance, deployment, or ASP.NET Core upgrades."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-chatgpt-apps/README.md
+++ b/profiles/openai-skills/openai-skills-chatgpt-apps/README.md
@@ -24,7 +24,7 @@ npx forgecat install @forgecat/openai-skills-chatgpt-apps
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-chatgpt-apps/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-chatgpt-apps/for-forgecat/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai-skills-chatgpt-apps
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-chatgpt-apps/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-chatgpt-apps/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-chatgpt-apps
-version: "0.0.3"
+version: "0.0.6"
 description: "Build, scaffold, refactor, and troubleshoot ChatGPT Apps SDK applications that combine an MCP server and widget UI. Use when Codex needs to design tools, register UI resources, wire the MCP Apps bridge or ChatGPT compatibility APIs, apply Apps SDK metadata or CSP or domain settings, or produce a docs-aligned project scaffold. Prefer a docs-first workflow by invoking the openai-docs skill or OpenAI developer docs MCP tools before generating code."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-cloudflare-deploy/README.md
+++ b/profiles/openai-skills/openai-skills-cloudflare-deploy/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-cloudflare-deploy
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-cloudflare-deploy/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-cloudflare-deploy/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-cloudflare-deploy
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-cloudflare-deploy/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-cloudflare-deploy/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-cloudflare-deploy
-version: "0.0.3"
+version: "0.0.6"
 description: "Deploy applications and infrastructure to Cloudflare using Workers, Pages, and related platform services. Use when the user asks to deploy, host, publish, or set up a project on Cloudflare."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-develop-web-game/README.md
+++ b/profiles/openai-skills/openai-skills-develop-web-game/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-develop-web-game
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-develop-web-game/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-develop-web-game/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-develop-web-game
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-develop-web-game/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-develop-web-game/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-develop-web-game
-version: "0.0.3"
+version: "0.0.6"
 description: "Use when Codex is building or iterating on a web game (HTML/JS) and needs a reliable development + testing loop: implement small changes, run a Playwright-based test script with short input bursts and intentional pauses, inspect screenshots/text, and review console errors with render_game_to_text."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-doc/README.md
+++ b/profiles/openai-skills/openai-skills-doc/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-doc
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-doc/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-doc/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-doc
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-doc/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-doc/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-doc
-version: "0.0.3"
+version: "0.0.6"
 description: "Use when the task involves reading, creating, or editing `.docx` documents, especially when formatting or layout fidelity matters; prefer `python-docx` plus the bundled `scripts/render_docx.py` for visual checks."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-figma-code-connect-components/README.md
+++ b/profiles/openai-skills/openai-skills-figma-code-connect-components/README.md
@@ -24,7 +24,7 @@ npx forgecat install @forgecat/openai-skills-figma-code-connect-components
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-figma-code-connect-components/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-figma-code-connect-components/for-forgecat/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai-skills-figma-code-connect-components
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-figma-code-connect-components/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-figma-code-connect-components/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-figma-code-connect-components
-version: "0.0.3"
+version: "0.0.6"
 description: "Connects Figma design components to code components using Code Connect mapping tools. Use when user says 'code connect', 'connect this component to code', 'map this component', 'link component to code', 'create code connect mapping', or wants to establish mappings between Figma designs and code implementations. For canvas writes via `use_figma`, use `figma-use`."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-figma-create-design-system-rules/README.md
+++ b/profiles/openai-skills/openai-skills-figma-create-design-system-rules/README.md
@@ -24,7 +24,7 @@ npx forgecat install @forgecat/openai-skills-figma-create-design-system-rules
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-figma-create-design-system-rules/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-figma-create-design-system-rules/for-forgecat/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai-skills-figma-create-design-system-rules
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-figma-create-design-system-rules/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-figma-create-design-system-rules/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-figma-create-design-system-rules
-version: "0.0.3"
+version: "0.0.6"
 description: "Generates custom design system rules for the user's codebase. Use when user says 'create design system rules', 'generate rules for my project', 'set up design rules', 'customize design system guidelines', or wants to establish project-specific conventions for Figma-to-code workflows. Requires Figma MCP server connection."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-figma-create-new-file/README.md
+++ b/profiles/openai-skills/openai-skills-figma-create-new-file/README.md
@@ -24,7 +24,7 @@ npx forgecat install @forgecat/openai-skills-figma-create-new-file
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-figma-create-new-file/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-figma-create-new-file/for-forgecat/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai-skills-figma-create-new-file
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-figma-create-new-file/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-figma-create-new-file/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-figma-create-new-file
-version: "0.0.3"
+version: "0.0.6"
 description: "Create a new blank Figma file. Use when the user wants to create a new Figma design or FigJam file, or when you need a new file before calling use_figma. Handles plan resolution via whoami if needed. Usage — /figma-create-new-file [editorType] [fileName] (e.g. /figma-create-new-file figjam My Whiteboard)"
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-figma-generate-design/README.md
+++ b/profiles/openai-skills/openai-skills-figma-generate-design/README.md
@@ -24,7 +24,7 @@ npx forgecat install @forgecat/openai-skills-figma-generate-design
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-figma-generate-design/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-figma-generate-design/for-forgecat/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai-skills-figma-generate-design
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-figma-generate-design/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-figma-generate-design/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-figma-generate-design
-version: "0.0.3"
+version: "0.0.6"
 description: "Use this skill alongside figma-use when the task involves translating an application page, view, or multi-section layout into Figma. Triggers: 'write to Figma', 'create in Figma from code', 'push page to Figma', 'take this app/page and build it in Figma', 'create a screen', 'build a landing page in Figma', 'update the Figma screen to match code'. This is the preferred workflow skill whenever the user wants to build or update a full page, screen, or view in Figma from code or a description. Discovers design system components, variables, and styles via search_design_system, imports them, and assembles screens incrementally section-by-section using design system tokens instead of hardcoded values."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-figma-generate-library/README.md
+++ b/profiles/openai-skills/openai-skills-figma-generate-library/README.md
@@ -24,7 +24,7 @@ npx forgecat install @forgecat/openai-skills-figma-generate-library
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-figma-generate-library/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-figma-generate-library/for-forgecat/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai-skills-figma-generate-library
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-figma-generate-library/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-figma-generate-library/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-figma-generate-library
-version: "0.0.3"
+version: "0.0.6"
 description: "Build or update a professional-grade design system in Figma from a codebase. Use when the user wants to create variables/tokens, build component libraries, set up theming (light/dark modes), document foundations, or reconcile gaps between code and Figma. This skill teaches WHAT to build and in WHAT ORDER — it complements the `figma-use` skill which teaches HOW to call the Plugin API. Both skills should be loaded together."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-figma-implement-design/README.md
+++ b/profiles/openai-skills/openai-skills-figma-implement-design/README.md
@@ -24,7 +24,7 @@ npx forgecat install @forgecat/openai-skills-figma-implement-design
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-figma-implement-design/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-figma-implement-design/for-forgecat/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai-skills-figma-implement-design
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-figma-implement-design/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-figma-implement-design/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-figma-implement-design
-version: "0.0.3"
+version: "0.0.6"
 description: "Translates Figma designs into production-ready application code with 1:1 visual fidelity. Use when implementing UI code from Figma files, when user mentions 'implement design', 'generate code', 'implement component', provides Figma URLs, or asks to build components matching Figma specs. For Figma canvas writes via `use_figma`, use `figma-use`."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-figma-use/README.md
+++ b/profiles/openai-skills/openai-skills-figma-use/README.md
@@ -24,7 +24,7 @@ npx forgecat install @forgecat/openai-skills-figma-use
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-figma-use/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-figma-use/for-forgecat/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai-skills-figma-use
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-figma-use/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-figma-use/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-figma-use
-version: "0.0.3"
+version: "0.0.6"
 description: "**MANDATORY prerequisite** — you MUST invoke this skill BEFORE every `use_figma` tool call. NEVER call `use_figma` directly without loading this skill first. Skipping it causes common, hard-to-debug failures. Trigger whenever the user wants to perform a write action or a unique read action that requires JavaScript execution in the Figma file context — e.g. create/edit/delete nodes, set up variables or tokens, build components and variants, modify auto-layout or fills, bind variables to properties, or inspect file structure programmatically."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-figma/README.md
+++ b/profiles/openai-skills/openai-skills-figma/README.md
@@ -27,7 +27,7 @@ npx forgecat install @forgecat/openai-skills-figma
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | `dc48aff` (2026-03-17) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-figma/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-figma/for-forgecat/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/openai-skills-figma
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.1` |
+| Version | `0.0.4` |
 | Original commit | `dc48aff` (2026-03-17) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-figma/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-figma/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: "openai-skills-figma"
-version: "0.0.1"
+version: "0.0.4"
 description: >-
   Use the Figma MCP server to fetch design context, screenshots, variables,
   and assets from Figma, and to translate Figma nodes into production code.

--- a/profiles/openai-skills/openai-skills-frontend-skill/README.md
+++ b/profiles/openai-skills/openai-skills-frontend-skill/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-frontend-skill
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-frontend-skill/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-frontend-skill/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-frontend-skill
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-frontend-skill/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-frontend-skill/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-frontend-skill
-version: "0.0.3"
+version: "0.0.6"
 description: "Use when the task asks for a visually strong landing page, website, app, prototype, demo, or game UI. This skill enforces restrained composition, image-led hierarchy, cohesive content structure, and tasteful motion while avoiding generic cards, weak branding, and UI clutter."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-gh-address-comments/README.md
+++ b/profiles/openai-skills/openai-skills-gh-address-comments/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-gh-address-comments
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-gh-address-comments/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-gh-address-comments/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-gh-address-comments
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-gh-address-comments/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-gh-address-comments/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-gh-address-comments
-version: "0.0.3"
+version: "0.0.6"
 description: "Help address review/issue comments on the open GitHub PR for the current branch using gh CLI; verify gh auth first and prompt the user to authenticate if not logged in."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-gh-fix-ci/README.md
+++ b/profiles/openai-skills/openai-skills-gh-fix-ci/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-gh-fix-ci
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-gh-fix-ci/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-gh-fix-ci/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-gh-fix-ci
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-gh-fix-ci/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-gh-fix-ci/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-gh-fix-ci
-version: "0.0.3"
+version: "0.0.6"
 description: "Use when a user asks to debug or fix failing GitHub PR checks that run in GitHub Actions; use `gh` to inspect checks and logs, summarize failure context, draft a fix plan, and implement only after explicit approval. Treat external providers (for example Buildkite) as out of scope and report only the details URL."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-imagegen/README.md
+++ b/profiles/openai-skills/openai-skills-imagegen/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-imagegen
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-imagegen/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-imagegen/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-imagegen
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-imagegen/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-imagegen/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-imagegen
-version: "0.0.3"
+version: "0.0.6"
 description: "Generate or edit raster images when the task benefits from AI-created bitmap visuals such as photos, illustrations, textures, sprites, mockups, or transparent-background cutouts. Use when Codex should create a brand-new image, transform an existing image, or derive visual variants from references, and the output should be a bitmap asset rather than repo-native code or vector. Do not use when the task is better handled by editing existing SVG/vector/code-native assets, extending an established icon or logo system, or building the visual directly in HTML/CSS/canvas."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-jupyter-notebook/README.md
+++ b/profiles/openai-skills/openai-skills-jupyter-notebook/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-jupyter-notebook
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-jupyter-notebook/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-jupyter-notebook/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-jupyter-notebook
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-jupyter-notebook/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-jupyter-notebook/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-jupyter-notebook
-version: "0.0.3"
+version: "0.0.6"
 description: "Use when the user asks to create, scaffold, or edit Jupyter notebooks (`.ipynb`) for experiments, explorations, or tutorials; prefer the bundled templates and run the helper script `new_notebook.py` to generate a clean starting notebook."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-linear/README.md
+++ b/profiles/openai-skills/openai-skills-linear/README.md
@@ -24,7 +24,7 @@ npx forgecat install @forgecat/openai-skills-linear
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-linear/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-linear/for-forgecat/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai-skills-linear
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-linear/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-linear/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-linear
-version: "0.0.3"
+version: "0.0.6"
 description: "Manage issues, projects & team workflows in Linear. Use when the user wants to read, create or updates tickets in Linear."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-netlify-deploy/README.md
+++ b/profiles/openai-skills/openai-skills-netlify-deploy/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-netlify-deploy
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-netlify-deploy/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-netlify-deploy/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-netlify-deploy
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-netlify-deploy/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-netlify-deploy/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-netlify-deploy
-version: "0.0.3"
+version: "0.0.6"
 description: "Deploy web projects to Netlify using the Netlify CLI (`npx netlify`). Use when the user asks to deploy, host, publish, or link a site/repo on Netlify, including preview and production deploys."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-notion-knowledge-capture/README.md
+++ b/profiles/openai-skills/openai-skills-notion-knowledge-capture/README.md
@@ -24,7 +24,7 @@ npx forgecat install @forgecat/openai-skills-notion-knowledge-capture
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-notion-knowledge-capture/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-notion-knowledge-capture/for-forgecat/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai-skills-notion-knowledge-capture
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-notion-knowledge-capture/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-notion-knowledge-capture/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-notion-knowledge-capture
-version: "0.0.3"
+version: "0.0.6"
 description: "Capture conversations and decisions into structured Notion pages; use when turning chats/notes into wiki entries, how-tos, decisions, or FAQs with proper linking."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-notion-meeting-intelligence/README.md
+++ b/profiles/openai-skills/openai-skills-notion-meeting-intelligence/README.md
@@ -24,7 +24,7 @@ npx forgecat install @forgecat/openai-skills-notion-meeting-intelligence
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-notion-meeting-intelligence/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-notion-meeting-intelligence/for-forgecat/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai-skills-notion-meeting-intelligence
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-notion-meeting-intelligence/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-notion-meeting-intelligence/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-notion-meeting-intelligence
-version: "0.0.3"
+version: "0.0.6"
 description: "Prepare meeting materials with Notion context and Codex research; use when gathering context, drafting agendas/pre-reads, and tailoring materials to attendees."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-notion-research-documentation/README.md
+++ b/profiles/openai-skills/openai-skills-notion-research-documentation/README.md
@@ -24,7 +24,7 @@ npx forgecat install @forgecat/openai-skills-notion-research-documentation
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-notion-research-documentation/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-notion-research-documentation/for-forgecat/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai-skills-notion-research-documentation
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-notion-research-documentation/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-notion-research-documentation/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-notion-research-documentation
-version: "0.0.3"
+version: "0.0.6"
 description: "Research across Notion and synthesize into structured documentation; use when gathering info from multiple Notion sources to produce briefs, comparisons, or reports with citations."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-notion-spec-to-implementation/README.md
+++ b/profiles/openai-skills/openai-skills-notion-spec-to-implementation/README.md
@@ -24,7 +24,7 @@ npx forgecat install @forgecat/openai-skills-notion-spec-to-implementation
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-notion-spec-to-implementation/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-notion-spec-to-implementation/for-forgecat/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai-skills-notion-spec-to-implementation
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-notion-spec-to-implementation/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-notion-spec-to-implementation/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-notion-spec-to-implementation
-version: "0.0.3"
+version: "0.0.6"
 description: "Turn Notion specs into implementation plans, tasks, and progress tracking; use when implementing PRDs/feature specs and creating Notion plans + tasks from them."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-openai-docs/README.md
+++ b/profiles/openai-skills/openai-skills-openai-docs/README.md
@@ -24,7 +24,7 @@ npx forgecat install @forgecat/openai-skills-openai-docs
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-openai-docs/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-openai-docs/for-forgecat/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai-skills-openai-docs
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-openai-docs/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-openai-docs/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-openai-docs
-version: "0.0.3"
+version: "0.0.6"
 description: "Use when the user asks how to build with OpenAI products or APIs and needs up-to-date official documentation with citations, help choosing the latest model for a use case, or explicit GPT-5.4 upgrade and prompt-upgrade guidance; prioritize OpenAI docs MCP tools, use bundled references only as helper context, and restrict any fallback browsing to official OpenAI domains."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-pdf/README.md
+++ b/profiles/openai-skills/openai-skills-pdf/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-pdf
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-pdf/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-pdf/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-pdf
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-pdf/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-pdf/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-pdf
-version: "0.0.3"
+version: "0.0.6"
 description: "Use when tasks involve reading, creating, or reviewing PDF files where rendering and layout matter; prefer visual checks by rendering pages (Poppler) and use Python tools such as `reportlab`, `pdfplumber`, and `pypdf` for generation and extraction."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-playwright-interactive/README.md
+++ b/profiles/openai-skills/openai-skills-playwright-interactive/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-playwright-interactive
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-playwright-interactive/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-playwright-interactive/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-playwright-interactive
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-playwright-interactive/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-playwright-interactive/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-playwright-interactive
-version: "0.0.3"
+version: "0.0.6"
 description: "Persistent browser and Electron interaction through `js_repl` for fast iterative UI debugging."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-playwright/README.md
+++ b/profiles/openai-skills/openai-skills-playwright/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-playwright
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-playwright/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-playwright/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-playwright
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-playwright/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-playwright/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-playwright
-version: "0.0.3"
+version: "0.0.6"
 description: "Use when the task requires automating a real browser from the terminal (navigation, form filling, snapshots, screenshots, data extraction, UI-flow debugging) via `playwright-cli` or the bundled wrapper script."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-render-deploy/README.md
+++ b/profiles/openai-skills/openai-skills-render-deploy/README.md
@@ -24,7 +24,7 @@ npx forgecat install @forgecat/openai-skills-render-deploy
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.5` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-render-deploy/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-render-deploy/for-forgecat/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai-skills-render-deploy
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.2` |
+| Version | `0.0.5` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-render-deploy/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-render-deploy/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-render-deploy
-version: "0.0.2"
+version: "0.0.5"
 description: "Deploy applications to Render by analyzing codebases, generating render.yaml Blueprints, and providing Dashboard deeplinks. Use when the user wants to deploy, host, publish, or set up their application on Render's cloud platform."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-screenshot/README.md
+++ b/profiles/openai-skills/openai-skills-screenshot/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-screenshot
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-screenshot/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-screenshot/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-screenshot
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-screenshot/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-screenshot/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-screenshot
-version: "0.0.3"
+version: "0.0.6"
 description: "Use when the user explicitly asks for a desktop or system screenshot (full screen, specific app or window, or a pixel region), or when tool-specific capture capabilities are unavailable and an OS-level capture is needed."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-security-best-practices/README.md
+++ b/profiles/openai-skills/openai-skills-security-best-practices/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-security-best-practices
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-security-best-practices/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-security-best-practices/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-security-best-practices
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-security-best-practices/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-security-best-practices/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-security-best-practices
-version: "0.0.3"
+version: "0.0.6"
 description: "Perform language and framework specific security best-practice reviews and suggest improvements. Trigger only when the user explicitly requests security best practices guidance, a security review/report, or secure-by-default coding help. Trigger only for supported languages (python, javascript/typescript, go). Do not trigger for general code review, debugging, or non-security tasks."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-security-ownership-map/README.md
+++ b/profiles/openai-skills/openai-skills-security-ownership-map/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-security-ownership-map
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-security-ownership-map/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-security-ownership-map/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-security-ownership-map
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-security-ownership-map/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-security-ownership-map/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-security-ownership-map
-version: "0.0.3"
+version: "0.0.6"
 description: "Analyze git repositories to build a security ownership topology (people-to-file), compute bus factor and sensitive-code ownership, and export CSV/JSON for graph databases and visualization. Trigger only when the user explicitly wants a security-oriented ownership or bus-factor analysis grounded in git history (for example: orphaned sensitive code, security maintainers, CODEOWNERS reality checks for risk, sensitive hotspots, or ownership clusters). Do not trigger for general maintainer lists or non-security ownership questions."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-security-threat-model/README.md
+++ b/profiles/openai-skills/openai-skills-security-threat-model/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-security-threat-model
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-security-threat-model/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-security-threat-model/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-security-threat-model
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-security-threat-model/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-security-threat-model/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-security-threat-model
-version: "0.0.3"
+version: "0.0.6"
 description: "Repository-grounded threat modeling that enumerates trust boundaries, assets, attacker capabilities, abuse paths, and mitigations, and writes a concise Markdown threat model. Trigger only when the user explicitly asks to threat model a codebase or path, enumerate threats/abuse paths, or perform AppSec threat modeling. Do not trigger for general architecture summaries, code review, or non-security design work."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-sentry/README.md
+++ b/profiles/openai-skills/openai-skills-sentry/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-sentry
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-sentry/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-sentry/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-sentry
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-sentry/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-sentry/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-sentry
-version: "0.0.3"
+version: "0.0.6"
 description: "Use when the user asks to inspect Sentry issues or events, summarize recent production errors, or pull basic Sentry health data via the Sentry API; perform read-only queries with the bundled script and require `SENTRY_AUTH_TOKEN`."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-slides/README.md
+++ b/profiles/openai-skills/openai-skills-slides/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-slides
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-slides/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-slides/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-slides
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-slides/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-slides/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-slides
-version: "0.0.3"
+version: "0.0.6"
 description: "Create and edit presentation slide decks (`.pptx`) with PptxGenJS, bundled layout helpers, and render/validation utilities. Use when tasks involve building a new PowerPoint deck, recreating slides from screenshots/PDFs/reference decks, modifying slide content while preserving editable output, adding charts/diagrams/visuals, or diagnosing layout issues such as overflow, overlaps, and font substitution."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-sora/README.md
+++ b/profiles/openai-skills/openai-skills-sora/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-sora
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-sora/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-sora/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-sora
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-sora/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-sora/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-sora
-version: "0.0.3"
+version: "0.0.6"
 description: "Use when the user asks to generate, edit, extend, poll, list, download, or delete Sora videos, create reusable non-human Sora character references, or run local multi-video queues via the bundled CLI (`scripts/sora.py`); includes requests like: (i) generate AI video, (ii) edit this Sora clip, (iii) extend this video, (iv) create a character reference, (v) download video/thumbnail/spritesheet, and (vi) Sora batch planning; requires `OPENAI_API_KEY` and Sora API access."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-speech/README.md
+++ b/profiles/openai-skills/openai-skills-speech/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-speech
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-speech/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-speech/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-speech
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-speech/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-speech/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-speech
-version: "0.0.3"
+version: "0.0.6"
 description: "Use when the user asks for text-to-speech narration or voiceover, accessibility reads, audio prompts, or batch speech generation via the OpenAI Audio API; run the bundled CLI (`scripts/text_to_speech.py`) with built-in voices and require `OPENAI_API_KEY` for live calls. Custom voice creation is out of scope."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-spreadsheet/README.md
+++ b/profiles/openai-skills/openai-skills-spreadsheet/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-spreadsheet
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-spreadsheet/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-spreadsheet/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-spreadsheet
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-spreadsheet/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-spreadsheet/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-spreadsheet
-version: "0.0.3"
+version: "0.0.6"
 description: "Use when tasks involve creating, editing, analyzing, or formatting spreadsheets (`.xlsx`, `.csv`, `.tsv`) with formula-aware workflows, cached recalculation, and visual review."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-system-openai-docs/README.md
+++ b/profiles/openai-skills/openai-skills-system-openai-docs/README.md
@@ -24,7 +24,7 @@ npx forgecat install @forgecat/openai-skills-system-openai-docs
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-system-openai-docs/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-system-openai-docs/for-forgecat/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai-skills-system-openai-docs
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-system-openai-docs/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-system-openai-docs/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-system-openai-docs
-version: "0.0.3"
+version: "0.0.6"
 description: "Use when the user asks how to build with OpenAI products or APIs and needs up-to-date official documentation with citations, help choosing the latest model for a use case, or explicit GPT-5.4 upgrade and prompt-upgrade guidance; prioritize OpenAI docs MCP tools, use bundled references only as helper context, and restrict any fallback browsing to official OpenAI domains."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-system-skill-creator/README.md
+++ b/profiles/openai-skills/openai-skills-system-skill-creator/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-system-skill-creator
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-system-skill-creator/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-system-skill-creator/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-system-skill-creator
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-system-skill-creator/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-system-skill-creator/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-system-skill-creator
-version: "0.0.3"
+version: "0.0.6"
 description: "Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Codex's capabilities with specialized knowledge, workflows, or tool integrations."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-system-skill-installer/README.md
+++ b/profiles/openai-skills/openai-skills-system-skill-installer/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-system-skill-installer
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-system-skill-installer/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-system-skill-installer/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-system-skill-installer
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-system-skill-installer/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-system-skill-installer/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-system-skill-installer
-version: "0.0.3"
+version: "0.0.6"
 description: "Install Codex skills into $CODEX_HOME/skills from a curated list or a GitHub repo path. Use when a user asks to list installable skills, install a curated skill, or install a skill from another repo (including private repos)."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-transcribe/README.md
+++ b/profiles/openai-skills/openai-skills-transcribe/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-transcribe
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-transcribe/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-transcribe/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-transcribe
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-transcribe/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-transcribe/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-transcribe
-version: "0.0.3"
+version: "0.0.6"
 description: "Transcribe audio files to text with optional diarization and known-speaker hints. Use when a user asks to transcribe speech from audio/video, extract text from recordings, or label speakers in interviews or meetings."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-vercel-deploy/README.md
+++ b/profiles/openai-skills/openai-skills-vercel-deploy/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-vercel-deploy
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-vercel-deploy/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-vercel-deploy/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-vercel-deploy
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-vercel-deploy/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-vercel-deploy/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-vercel-deploy
-version: "0.0.3"
+version: "0.0.6"
 description: "Deploy applications and websites to Vercel. Use when the user requests deployment actions like 'deploy my app', 'deploy and give me the link', 'push this live', or 'create a preview deployment'."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-winui-app/README.md
+++ b/profiles/openai-skills/openai-skills-winui-app/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-winui-app
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-winui-app/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-winui-app/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-winui-app
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-winui-app/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-winui-app/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-winui-app
-version: "0.0.3"
+version: "0.0.6"
 description: "Bootstrap, develop, and design modern WinUI 3 desktop applications with C# and the Windows App SDK using official Microsoft guidance, WinUI Gallery patterns, Windows App SDK samples, and CommunityToolkit components. Use when creating a brand new app, preparing a machine for WinUI, reviewing, refactoring, planning, troubleshooting, environment-checking, or setting up WinUI 3 XAML, controls, navigation, windowing, theming, accessibility, responsiveness, performance, deployment, or related Windows app design and development work."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"

--- a/profiles/openai-skills/openai-skills-yeet/README.md
+++ b/profiles/openai-skills/openai-skills-yeet/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai-skills-yeet
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-yeet/for-forgecat/README.md
+++ b/profiles/openai-skills/openai-skills-yeet/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai-skills-yeet
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.3` |
+| Version | `0.0.6` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai-skills/openai-skills-yeet/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai-skills-yeet/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: openai-skills-yeet
-version: "0.0.3"
+version: "0.0.6"
 description: "Use only when the user explicitly asks to stage, commit, push, and open a GitHub pull request in one flow using the GitHub CLI (`gh`)."
 repository: "https://github.com/openai/skills"
 license: "Apache-2.0"


### PR DESCRIPTION
## Summary

Updates all profile versions to match the current Forgecat registry state after successful push.

## Changes
- Bumped 83 profiles to latest versions
- Updated profile.yml and both README files for each profile
- 252 files changed (profile.yml + READMEs)

## Registry Push Results
- ✅ 81 profiles successfully published
- ❌ 2 profiles blocked by security scanner:
  - `knowledge-work-plugins-bio-research` (contains curl | bash)
  - `openai-skills-render-deploy` (contains curl | bash)

## Versions
All profiles now at 0.0.4 - 0.0.8 depending on group.