### PR TITLE
fix: update original commit info for agency-agents profiles

### DIFF
--- a/profiles/agency-agents/agency-academic/README.md
+++ b/profiles/agency-agents/agency-academic/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/agency-academic
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.5` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-academic/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-academic/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/agency-academic
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.5` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-design/README.md
+++ b/profiles/agency-agents/agency-design/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/agency-design
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.6` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-design/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-design/for-forgecat/README.md
@@ -31,7 +31,7 @@ npx forgecat install @forgecat/agency-design
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.6` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-engineering/README.md
+++ b/profiles/agency-agents/agency-engineering/README.md
@@ -44,7 +44,7 @@ npx forgecat install @forgecat/agency-engineering
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.6` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-engineering/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-engineering/for-forgecat/README.md
@@ -46,7 +46,7 @@ npx forgecat install @forgecat/agency-engineering
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.6` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-game-development/README.md
+++ b/profiles/agency-agents/agency-game-development/README.md
@@ -41,7 +41,7 @@ npx forgecat install @forgecat/agency-game-development
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.6` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-game-development/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-game-development/for-forgecat/README.md
@@ -43,7 +43,7 @@ npx forgecat install @forgecat/agency-game-development
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.6` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-marketing/README.md
+++ b/profiles/agency-agents/agency-marketing/README.md
@@ -48,7 +48,7 @@ npx forgecat install @forgecat/agency-marketing
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.6` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-marketing/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-marketing/for-forgecat/README.md
@@ -50,7 +50,7 @@ npx forgecat install @forgecat/agency-marketing
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.6` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-paid-media/README.md
+++ b/profiles/agency-agents/agency-paid-media/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/agency-paid-media
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.6` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-paid-media/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-paid-media/for-forgecat/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/agency-paid-media
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.6` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-product/README.md
+++ b/profiles/agency-agents/agency-product/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/agency-product
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.6` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-product/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-product/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/agency-product
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.6` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-project-management/README.md
+++ b/profiles/agency-agents/agency-project-management/README.md
@@ -27,7 +27,7 @@ npx forgecat install @forgecat/agency-project-management
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.6` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-project-management/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-project-management/for-forgecat/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/agency-project-management
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.6` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-sales/README.md
+++ b/profiles/agency-agents/agency-sales/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/agency-sales
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.6` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-sales/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-sales/for-forgecat/README.md
@@ -31,7 +31,7 @@ npx forgecat install @forgecat/agency-sales
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.6` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-spatial-computing/README.md
+++ b/profiles/agency-agents/agency-spatial-computing/README.md
@@ -27,7 +27,7 @@ npx forgecat install @forgecat/agency-spatial-computing
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.6` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-spatial-computing/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-spatial-computing/for-forgecat/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/agency-spatial-computing
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.6` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-specialized/README.md
+++ b/profiles/agency-agents/agency-specialized/README.md
@@ -48,7 +48,7 @@ npx forgecat install @forgecat/agency-specialized
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.6` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-specialized/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-specialized/for-forgecat/README.md
@@ -50,7 +50,7 @@ npx forgecat install @forgecat/agency-specialized
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.6` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-support/README.md
+++ b/profiles/agency-agents/agency-support/README.md
@@ -27,7 +27,7 @@ npx forgecat install @forgecat/agency-support
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.6` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-support/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-support/for-forgecat/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/agency-support
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.6` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-testing/README.md
+++ b/profiles/agency-agents/agency-testing/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/agency-testing
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.6` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 

--- a/profiles/agency-agents/agency-testing/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-testing/for-forgecat/README.md
@@ -31,7 +31,7 @@ npx forgecat install @forgecat/agency-testing
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
 | Version | `0.0.6` |
-| Original commit | `source-preserved-in-ori` |
+| Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
 


### PR DESCRIPTION
- Replaced 'source-preserved-in-ori' placeholder with actual commit hash
- Commit: 9c31d86 (2026-03-23) from msitarzewski/agency-agents
- Updated 26 README files (13 profiles × 2 READMEs each)