### PR TITLE
Sync agency-agents versions with registry

### DIFF
--- a/profiles/agency-agents/agency-academic/README.md
+++ b/profiles/agency-agents/agency-academic/README.md
@@ -25,7 +25,7 @@ npx forgecat install @forgecat/agency-academic
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.5` |
+| Version | `0.0.6` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-academic/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-academic/for-forgecat/README.md
@@ -27,7 +27,7 @@ npx forgecat install @forgecat/agency-academic
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.5` |
+| Version | `0.0.6` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-academic/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-academic/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: "agency-academic"
-version: "0.0.5"
+version: "0.0.6"
 description: >-
   Academic division from The Agency — 5 specialized academic
   agent personalities from msitarzewski/agency-agents.

--- a/profiles/agency-agents/agency-design/README.md
+++ b/profiles/agency-agents/agency-design/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/agency-design
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-design/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-design/for-forgecat/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/agency-design
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-design/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-design/for-forgecat/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-design"
-version: "0.0.6"
+version: "0.0.7"
 description: >-
   Design division from The Agency — 8 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,

--- a/profiles/agency-agents/agency-engineering/README.md
+++ b/profiles/agency-agents/agency-engineering/README.md
@@ -43,7 +43,7 @@ npx forgecat install @forgecat/agency-engineering
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-engineering/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-engineering/for-forgecat/README.md
@@ -45,7 +45,7 @@ npx forgecat install @forgecat/agency-engineering
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-engineering/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-engineering/for-forgecat/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-engineering"
-version: "0.0.6"
+version: "0.0.7"
 description: >-
   Engineering division from The Agency — 23 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,

--- a/profiles/agency-agents/agency-game-development/README.md
+++ b/profiles/agency-agents/agency-game-development/README.md
@@ -40,7 +40,7 @@ npx forgecat install @forgecat/agency-game-development
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-game-development/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-game-development/for-forgecat/README.md
@@ -42,7 +42,7 @@ npx forgecat install @forgecat/agency-game-development
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-game-development/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-game-development/for-forgecat/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-game-development"
-version: "0.0.6"
+version: "0.0.7"
 description: >-
   Game Development division from The Agency — 20 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,

--- a/profiles/agency-agents/agency-marketing/README.md
+++ b/profiles/agency-agents/agency-marketing/README.md
@@ -47,7 +47,7 @@ npx forgecat install @forgecat/agency-marketing
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-marketing/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-marketing/for-forgecat/README.md
@@ -49,7 +49,7 @@ npx forgecat install @forgecat/agency-marketing
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-marketing/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-marketing/for-forgecat/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-marketing"
-version: "0.0.6"
+version: "0.0.7"
 description: >-
   Marketing division from The Agency — 27 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,

--- a/profiles/agency-agents/agency-paid-media/README.md
+++ b/profiles/agency-agents/agency-paid-media/README.md
@@ -27,7 +27,7 @@ npx forgecat install @forgecat/agency-paid-media
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-paid-media/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-paid-media/for-forgecat/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/agency-paid-media
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-paid-media/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-paid-media/for-forgecat/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-paid-media"
-version: "0.0.6"
+version: "0.0.7"
 description: >-
   Paid Media division from The Agency — 7 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,

--- a/profiles/agency-agents/agency-product/README.md
+++ b/profiles/agency-agents/agency-product/README.md
@@ -25,7 +25,7 @@ npx forgecat install @forgecat/agency-product
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-product/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-product/for-forgecat/README.md
@@ -27,7 +27,7 @@ npx forgecat install @forgecat/agency-product
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-product/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-product/for-forgecat/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-product"
-version: "0.0.6"
+version: "0.0.7"
 description: >-
   Product division from The Agency — 5 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,

--- a/profiles/agency-agents/agency-project-management/README.md
+++ b/profiles/agency-agents/agency-project-management/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/agency-project-management
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-project-management/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-project-management/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/agency-project-management
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-project-management/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-project-management/for-forgecat/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-project-management"
-version: "0.0.6"
+version: "0.0.7"
 description: >-
   Project Management division from The Agency — 6 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,

--- a/profiles/agency-agents/agency-sales/README.md
+++ b/profiles/agency-agents/agency-sales/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/agency-sales
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-sales/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-sales/for-forgecat/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/agency-sales
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-sales/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-sales/for-forgecat/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-sales"
-version: "0.0.6"
+version: "0.0.7"
 description: >-
   Sales division from The Agency — 8 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,

--- a/profiles/agency-agents/agency-spatial-computing/README.md
+++ b/profiles/agency-agents/agency-spatial-computing/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/agency-spatial-computing
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-spatial-computing/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-spatial-computing/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/agency-spatial-computing
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-spatial-computing/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-spatial-computing/for-forgecat/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-spatial-computing"
-version: "0.0.6"
+version: "0.0.7"
 description: >-
   Spatial Computing division from The Agency — 6 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,

--- a/profiles/agency-agents/agency-specialized/README.md
+++ b/profiles/agency-agents/agency-specialized/README.md
@@ -47,7 +47,7 @@ npx forgecat install @forgecat/agency-specialized
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-specialized/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-specialized/for-forgecat/README.md
@@ -49,7 +49,7 @@ npx forgecat install @forgecat/agency-specialized
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-specialized/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-specialized/for-forgecat/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-specialized"
-version: "0.0.6"
+version: "0.0.7"
 description: >-
   Specialized division from The Agency — 27 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,

--- a/profiles/agency-agents/agency-support/README.md
+++ b/profiles/agency-agents/agency-support/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/agency-support
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-support/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-support/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/agency-support
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-support/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-support/for-forgecat/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-support"
-version: "0.0.6"
+version: "0.0.7"
 description: >-
   Support division from The Agency — 6 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,

--- a/profiles/agency-agents/agency-testing/README.md
+++ b/profiles/agency-agents/agency-testing/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/agency-testing
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-testing/for-forgecat/README.md
+++ b/profiles/agency-agents/agency-testing/for-forgecat/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/agency-testing
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/agency-agents/agency-testing/for-forgecat/profile.yml
+++ b/profiles/agency-agents/agency-testing/for-forgecat/profile.yml
@@ -1,6 +1,6 @@
 
 name: "agency-testing"
-version: "0.0.6"
+version: "0.0.7"
 description: >-
   Testing division from The Agency — 8 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise,


### PR DESCRIPTION
## Summary

Sync GitHub versions with Forgecat registry after push.

## Changes
- 13 agency-agents profiles bumped
- 39 files updated (profile.yml + 2 READMEs per profile)

## Versions
- agency-academic: 0.0.6
- All others: 0.0.7