### PR TITLE
Profile: tldraw (reconverted)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This repository hosts a curated set of **AI Agent Profiles** for [ForgeCat](http
 | [cursor-plugins](./profiles/cursor-plugins) | 1 | Plugins for Cursor — CI, code review, shipping, test reliability |
 | [knowledge-work-plugins](./profiles/knowledge-work-plugins) | 14 | Knowledge work plugins — legal, finance, HR, marketing, operations, and more |
 | [openai-skills](./profiles/openai-skills) | 45 | Skills for OpenAI platforms — ASP.NET Core, Figma, Playwright, and more |
+| [tldraw](./profiles/tldraw) | 1 | Visual collaboration profile powered by the tldraw MCP server |
 
 ---
 

--- a/profiles/tldraw/README.md
+++ b/profiles/tldraw/README.md
@@ -1,0 +1,49 @@
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+
+# tldraw
+
+Draw and visually collaborate with your agents using the official tldraw Cursor marketplace plugin configuration.
+
+## Tags
+
+- cursor
+- mcp
+- productivity
+- whiteboard
+
+## Installation
+
+```bash
+npx forgecat install @forgecat-nota/tldraw
+```
+
+## Skills
+
+- **tldraw** — Connects to the hosted tldraw MCP server for collaborative drawing workflows. `mcp`
+
+## MCPs
+
+| Server | Transport | URL |
+|---|---|---|
+| tldraw | http | https://tldraw-mcp-app.tldraw.workers.dev/mcp |
+
+## Details
+
+| Field | Value |
+|---|---|
+| Author | tldraw |
+| Original repository | https://github.com/tldraw/tldraw |
+| Version | `0.0.0` |
+| Original commit | `8e0d015` |
+| License | `-` |
+| Source platform | Cursor |
+
+## Compatibility
+
+### Platforms
+
+| Platform | Status |
+|---|---|
+| Claude Code | Partial |
+| Cursor | Tested |
+| Codex | Partial |

--- a/profiles/tldraw/for-forgecat/README.md
+++ b/profiles/tldraw/for-forgecat/README.md
@@ -1,0 +1,51 @@
+*written by Forgecat*
+
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+
+# tldraw
+
+Draw and visually collaborate with your agents using the official tldraw Cursor marketplace plugin configuration.
+
+## Tags
+
+- cursor
+- mcp
+- productivity
+- whiteboard
+
+## Installation
+
+```bash
+npx forgecat install @forgecat-nota/tldraw
+```
+
+## Skills
+
+- **tldraw** — Connects to the hosted tldraw MCP server for collaborative drawing workflows. `mcp`
+
+## MCPs
+
+| Server | Transport | URL |
+|---|---|---|
+| tldraw | http | https://tldraw-mcp-app.tldraw.workers.dev/mcp |
+
+## Details
+
+| Field | Value |
+|---|---|
+| Author | tldraw |
+| Original repository | https://github.com/tldraw/tldraw |
+| Version | `0.0.0` |
+| Original commit | `8e0d015` |
+| License | `-` |
+| Source platform | Cursor |
+
+## Compatibility
+
+### Platforms
+
+| Platform | Status |
+|---|---|
+| Claude Code | Partial |
+| Cursor | Tested |
+| Codex | Partial |

--- a/profiles/tldraw/for-forgecat/mcp.jsonc
+++ b/profiles/tldraw/for-forgecat/mcp.jsonc
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "tldraw": {
+      "transport": "http",
+      "url": "https://tldraw-mcp-app.tldraw.workers.dev/mcp"
+    }
+  }
+}

--- a/profiles/tldraw/for-forgecat/profile.yml
+++ b/profiles/tldraw/for-forgecat/profile.yml
@@ -1,0 +1,18 @@
+name: tldraw
+version: 0.0.0
+description: Draw and visually collaborate with your agents inside Cursor.
+repository: https://github.com/tldraw/tldraw
+license: "-"
+visibility: public
+compatibility:
+  platforms:
+    tested:
+      - cursor
+    partial:
+      - claude-code
+      - codex
+  models:
+    recommended: []
+    minimum: []
+mcp:
+  path: mcp.jsonc


### PR DESCRIPTION
## tldraw

Recreated this profile conversion and opened a fresh PR after closing #30.

### Fixes vs previous PR
- places files under `profiles/tldraw/` (repo schema-consistent path)
- uses Forgecat banner URL
- uses `@forgecat-nota/tldraw` install command
- keeps profile manifest + MCP config aligned with conversion schema

### Source
- Repository: https://github.com/tldraw/tldraw
- Original commit: `8e0d015`
- Platform: Cursor
