### PR TITLE
Add hooks to addyosmani agent skills

### DIFF
--- a/profiles/addyosmani_agent-skills/README.md
+++ b/profiles/addyosmani_agent-skills/README.md
@@ -40,13 +40,18 @@ npx forgecat install @forgecat/addyosmani_agent-skills
 - **security-auditor** — Security engineer focused on vulnerability detection, threat modeling, and secure coding practices. Use for security-focused code review, threat analysis, or hardening recommendations.
 - **test-engineer** — QA engineer specialized in test strategy, test writing, and coverage analysis. Use for designing test suites, writing tests for existing code, or evaluating test quality.
 
+## Hooks
+
+- **agent-skills-session-start** — Injects the `using-agent-skills` meta-skill into each new Claude Code session.
+- **simplify-ignore** — Protects `simplify-ignore` blocks while Claude Code reads, edits, writes, and stops.
+
 ## Details
 
 | Field | Value |
 |---|---|
 | Author | Addy Osmani |
 | Original repository | https://github.com/addyosmani/agent-skills |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | `8d79b5f` |
 | License | MIT |
 | Source platform | Claude Code |

--- a/profiles/addyosmani_agent-skills/README.md
+++ b/profiles/addyosmani_agent-skills/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/addyosmani_agent-skills
 ## Skills
 
 - **api-and-interface-design** — Guides stable API and interface design. Use when designing APIs, module boundaries, or any public interface. Use when creating REST or GraphQL endpoints, defining type contracts between modules, or establishing boundaries between frontend and backend.
-- **browser-testing-with-devtools** — Tests in real browsers. Use when building or debugging anything that runs in a browser. Use when you need to inspect the DOM, capture console errors, analyze network requests, profile performance, or verify visual output with real runtime data via Chrome DevTools MCP.
+- **browser-testing-with-devtools** — Tests in real browsers via Chrome DevTools MCP. Use when building or debugging anything that runs in a browser. Use when you need to inspect the DOM, capture console errors, analyze network requests, profile performance, or verify visual output with real runtime data. Requires the chrome-devtools MCP server to be configured.
 - **ci-cd-and-automation** — Automates CI/CD pipeline setup. Use when setting up or modifying build and deployment pipelines. Use when you need to automate quality gates, configure test runners in CI, or establish deployment strategies.
 - **code-review-and-quality** — Conducts multi-axis code review. Use before merging any change. Use when reviewing code written by yourself, another agent, or a human. Use when you need to assess code quality across multiple dimensions before it enters the main branch.
 - **code-simplification** — Simplifies code for clarity. Use when refactoring code for clarity without changing behavior. Use when code works but is harder to read, maintain, or extend than it should be. Use when reviewing code that has accumulated unnecessary complexity.
@@ -29,10 +29,20 @@ npx forgecat install @forgecat/addyosmani_agent-skills
 - **debugging-and-error-recovery** — Guides systematic root-cause debugging. Use when tests fail, builds break, behavior doesn't match expectations, or you encounter any unexpected error. Use when you need a systematic approach to finding and fixing the root cause rather than guessing.
 - **deprecation-and-migration** — Manages deprecation and migration. Use when removing old systems, APIs, or features. Use when migrating users from one implementation to another. Use when deciding whether to maintain or sunset existing code.
 - **documentation-and-adrs** — Records decisions and documentation. Use when making architectural decisions, changing public APIs, shipping features, or when you need to record context that future engineers and agents will need to understand the codebase.
+- **doubt-driven-development** — Subjects every non-trivial decision to a fresh-context adversarial review before it stands. Use when correctness matters more than speed, when working in unfamiliar code, when stakes are high (production, security-sensitive logic, irreversible operations), or any time a confident output would be cheaper to verify now than to debug later.
 - **frontend-ui-engineering** — Builds production-quality UIs. Use when building or modifying user-facing interfaces. Use when creating components, implementing layouts, managing state, or when the output needs to look and feel production-quality rather than AI-generated.
 - **git-workflow-and-versioning** — Structures git workflow practices. Use when making any code change. Use when committing, branching, resolving conflicts, or when you need to organize work across multiple parallel streams.
-- **idea-refine** — Refines ideas iteratively. Refine ideas through structured divergent and convergent thinking. Use "idea-refine" or "ideate" to trigger.
-- **...and 8 more skills**
+- **idea-refine** — Refines raw ideas into sharp, actionable concepts through structured divergent and convergent thinking. Use when an idea is still vague, when you need to stress-test assumptions before committing to a plan, or when you want to expand options before converging on one. Triggers on "ideate", "refine this idea", or "stress-test my plan".
+- **incremental-implementation** — Delivers changes incrementally. Use when implementing any feature or change that touches more than one file. Use when you're about to write a large amount of code at once, or when a task feels too big to land in one step.
+- **interview-me** — Extracts what the user actually wants instead of what they think they should want. Achieves this through one-question-at-a-time interview until ~95% confidence about the underlying intent. Use when an ask is underspecified ("build me X" without "for whom" or "why now"), when the user explicitly invokes ("interview me", "grill me", "are we sure?", "stress-test my thinking"), or when you catch yourself silently filling in ambiguous requirements before any plan, spec, or code exists.
+- **performance-optimization** — Optimizes application performance. Use when performance requirements exist, when you suspect performance regressions, or when Core Web Vitals or load times need improvement. Use when profiling reveals bottlenecks that need fixing.
+- **planning-and-task-breakdown** — Breaks work into ordered tasks. Use when you have a spec or clear requirements and need to break work into implementable tasks. Use when a task feels too large to start, when you need to estimate scope, or when parallel work is possible.
+- **security-and-hardening** — Hardens code against vulnerabilities. Use when handling user input, authentication, data storage, or external integrations. Use when building any feature that accepts untrusted data, manages user sessions, or interacts with third-party services.
+- **shipping-and-launch** — Prepares production launches. Use when preparing to deploy to production. Use when you need a pre-launch checklist, when setting up monitoring, when planning a staged rollout, or when you need a rollback strategy.
+- **source-driven-development** — Grounds every implementation decision in official documentation. Use when you want authoritative, source-cited code free from outdated patterns. Use when building with any framework or library where correctness matters.
+- **spec-driven-development** — Creates specs before coding. Use when starting a new project, feature, or significant change and no specification exists yet. Use when requirements are unclear, ambiguous, or only exist as a vague idea.
+- **test-driven-development** — Drives development with tests. Use when implementing any logic, fixing any bug, or changing any behavior. Use when you need to prove that code works, when a bug report arrives, or when you're about to modify existing functionality.
+- **using-agent-skills** — Discovers and invokes agent skills. Use when starting a session or when you need to discover which skill applies to the current task. This is the meta-skill that governs how all other skills are discovered and invoked.
 
 ## Agents
 
@@ -40,10 +50,21 @@ npx forgecat install @forgecat/addyosmani_agent-skills
 - **security-auditor** — Security engineer focused on vulnerability detection, threat modeling, and secure coding practices. Use for security-focused code review, threat analysis, or hardening recommendations.
 - **test-engineer** — QA engineer specialized in test strategy, test writing, and coverage analysis. Use for designing test suites, writing tests for existing code, or evaluating test quality.
 
+## Commands
+
+- **/build** — Implement the next task incrementally — build, test, verify, commit
+- **/code-simplify** — Simplify code for clarity and maintainability — reduce complexity without changing behavior
+- **/plan** — Break work into small verifiable tasks with acceptance criteria and dependency ordering
+- **/review** — Conduct a five-axis code review — correctness, readability, architecture, security, performance
+- **/ship** — Run the pre-launch checklist via parallel fan-out to specialist personas, then synthesize a go/no-go decision
+- **/spec** — Start spec-driven development — write a structured specification before writing code
+- **/test** — Run TDD workflow — write failing tests, implement, verify. For bugs, use the Prove-It pattern.
+
 ## Hooks
 
 - **agent-skills-session-start** — Injects the `using-agent-skills` meta-skill into each new Claude Code session.
 - **simplify-ignore** — Protects `simplify-ignore` blocks while Claude Code reads, edits, writes, and stops.
+- **sdd-cache** — Revalidates and serves source-driven-development WebFetch documentation cache entries.
 
 ## Details
 
@@ -51,8 +72,8 @@ npx forgecat install @forgecat/addyosmani_agent-skills
 |---|---|
 | Author | Addy Osmani |
 | Original repository | https://github.com/addyosmani/agent-skills |
-| Version | `0.0.1` |
-| Original commit | `8d79b5f` |
+| Version | `0.0.2` |
+| Original commit | `2a62238` |
 | License | MIT |
 | Source platform | Claude Code |
 

--- a/profiles/addyosmani_agent-skills/for-forgecat/AGENTS.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/AGENTS.md
@@ -6,6 +6,81 @@ This file provides guidance to AI coding agents (Claude Code, Cursor, Copilot, A
 
 A collection of skills for Claude.ai and Claude Code for senior software engineers. Skills are packaged instructions and scripts that extend Claude and your coding agents capabilities.
 
+## OpenCode Integration
+
+OpenCode uses a **skill-driven execution model** powered by the `skill` tool and this repository's `/skills` directory.
+
+### Core Rules
+
+- If a task matches a skill, you MUST invoke it
+- Skills are located in `skills/<skill-name>/SKILL.md`
+- Never implement directly if a skill applies
+- Always follow the skill instructions exactly (do not partially apply them)
+
+### Intent → Skill Mapping
+
+The agent should automatically map user intent to skills:
+
+- Feature / new functionality → `spec-driven-development`, then `incremental-implementation`, `test-driven-development`
+- Planning / breakdown → `planning-and-task-breakdown`
+- Bug / failure / unexpected behavior → `debugging-and-error-recovery`
+- Code review → `code-review-and-quality`
+- Refactoring / simplification → `code-simplification`
+- API or interface design → `api-and-interface-design`
+- UI work → `frontend-ui-engineering`
+
+### Lifecycle Mapping (Implicit Commands)
+
+OpenCode does not support slash commands like `/spec` or `/plan`.
+
+Instead, the agent must internally follow this lifecycle:
+
+- DEFINE → `spec-driven-development`
+- PLAN → `planning-and-task-breakdown`
+- BUILD → `incremental-implementation` + `test-driven-development`
+- VERIFY → `debugging-and-error-recovery`
+- REVIEW → `code-review-and-quality`
+- SHIP → `shipping-and-launch`
+
+### Execution Model
+
+For every request:
+
+1. Determine if any skill applies (even 1% chance)
+2. Invoke the appropriate skill using the `skill` tool
+3. Follow the skill workflow strictly
+4. Only proceed to implementation after required steps (spec, plan, etc.) are complete
+
+### Anti-Rationalization
+
+The following thoughts are incorrect and must be ignored:
+
+- "This is too small for a skill"
+- "I can just quickly implement this"
+- "I’ll gather context first"
+
+Correct behavior:
+
+- Always check for and use skills first
+
+This ensures OpenCode behaves similarly to Claude Code with full workflow enforcement.
+
+## Orchestration: Personas, Skills, and Commands
+
+This repo has three composable layers. They have different jobs and should not be confused:
+
+- **Skills** (`skills/<name>/SKILL.md`) — workflows with steps and exit criteria. The *how*. Mandatory hops when an intent matches.
+- **Personas** (`agents/<role>.md`) — roles with a perspective and an output format. The *who*.
+- **Slash commands** (`.claude/commands/*.md`) — user-facing entry points. The *when*. The orchestration layer.
+
+Composition rule: **the user (or a slash command) is the orchestrator. Personas do not invoke other personas.** A persona may invoke skills.
+
+The only multi-persona orchestration pattern this repo endorses is **parallel fan-out with a merge step** — used by `/ship` to run `code-reviewer`, `security-auditor`, and `test-engineer` concurrently and synthesize their reports. Do not build a "router" persona that decides which other persona to call; that's the job of slash commands and intent mapping.
+
+See [agents/README.md](agents/README.md) for the decision matrix and [references/orchestration-patterns.md](references/orchestration-patterns.md) for the full pattern catalog.
+
+**Claude Code interop:** the personas in `agents/` work as Claude Code subagents (auto-discovered from this plugin's `agents/` directory) and as Agent Teams teammates (referenced by name when spawning). Two platform constraints align with our rules: subagents cannot spawn other subagents, and teams cannot nest. Plugin agents silently ignore the `hooks`, `mcpServers`, and `permissionMode` frontmatter fields.
+
 ## Creating a New Skill
 
 ### Directory Structure
@@ -31,18 +106,22 @@ skills/
 ```markdown
 ---
 name: {skill-name}
-description: {One sentence describing when to use this skill. Include trigger phrases like "Deploy my app", "Check logs", etc.}
+description: {One sentence describing what the skill does, followed by one or more "Use when" trigger conditions. Include trigger phrases like "Deploy my app" or "Check logs" when helpful.}
 ---
 
 # {Skill Title}
 
-{Brief description of what the skill does.}
+{Brief overview of what the skill does and why it matters.}
 
 ## How It Works
 
 {Numbered list explaining the skill's workflow}
 
-## Usage
+Equivalent headings like `Workflow`, `Core Process`, or `When to Use` are fine when they communicate the same structure clearly.
+
+## Usage (Optional)
+
+Include this section only if the skill ships runnable helpers under `scripts/`. Markdown-only skills can omit both the section and the directory entirely.
 
 ```bash
 bash /mnt/skills/user/{skill-name}/scripts/{script}.sh [args]

--- a/profiles/addyosmani_agent-skills/for-forgecat/CLAUDE.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/CLAUDE.md
@@ -1,0 +1,43 @@
+# agent-skills
+
+This is the agent-skills project — a collection of production-grade engineering skills for AI coding agents.
+
+## Project Structure
+
+```
+skills/       → Core skills (SKILL.md per directory)
+agents/       → Reusable agent personas (code-reviewer, test-engineer, security-auditor)
+hooks/        → Session lifecycle hooks
+.claude/commands/ → Slash commands (/spec, /plan, /build, /test, /review, /code-simplify, /ship)
+references/   → Supplementary checklists (testing, performance, security, accessibility)
+docs/         → Setup guides for different tools
+```
+
+## Skills by Phase
+
+**Define:** interview-me, idea-refine, spec-driven-development
+**Plan:** planning-and-task-breakdown
+**Build:** incremental-implementation, test-driven-development, context-engineering, source-driven-development, doubt-driven-development, frontend-ui-engineering, api-and-interface-design
+**Verify:** browser-testing-with-devtools, debugging-and-error-recovery
+**Review:** code-review-and-quality, code-simplification, security-and-hardening, performance-optimization
+**Ship:** git-workflow-and-versioning, ci-cd-and-automation, deprecation-and-migration, documentation-and-adrs, shipping-and-launch
+
+## Conventions
+
+- Every skill lives in `skills/<name>/SKILL.md`
+- YAML frontmatter with `name` and `description` fields
+- Description starts with what the skill does (third person), followed by trigger conditions ("Use when...")
+- Every skill has: Overview, When to Use, Process, Common Rationalizations, Red Flags, Verification
+- References are in `references/`, not inside skill directories
+- Supporting files only created when content exceeds 100 lines
+
+## Commands
+
+- `npm test` — Not applicable (this is a documentation project)
+- Validate: Check that all SKILL.md files have valid YAML frontmatter with name and description
+
+## Boundaries
+
+- Always: Follow the skill-anatomy.md format for new skills
+- Never: Add skills that are vague advice instead of actionable processes
+- Never: Duplicate content between skills — reference other skills instead

--- a/profiles/addyosmani_agent-skills/for-forgecat/CONTRIBUTING.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for your interest in contributing! This project is a collection of produc
 1. Create a directory under `skills/` with a kebab-case name
 2. Add a `SKILL.md` following the format in [docs/skill-anatomy.md](docs/skill-anatomy.md)
 3. Include YAML frontmatter with `name` and `description` fields
-4. Ensure the `description` starts with "Use when" and describes triggering conditions
+4. Ensure the `description` starts with what the skill does (third person), then includes one or more `Use when` trigger conditions
 
 ### Skill Quality Bar
 
@@ -20,7 +20,12 @@ Skills should be:
 
 ### Structure
 
-Every skill should include these sections:
+Every new skill must have:
+
+- `SKILL.md` in the skill directory
+- YAML frontmatter with valid `name` and `description`
+
+New skills should generally follow the standard anatomy:
 
 - **Overview** — What this skill does and why it matters
 - **When to Use** — Triggering conditions
@@ -29,11 +34,14 @@ Every skill should include these sections:
 - **Red Flags** — Warning signs that the skill is being applied incorrectly
 - **Verification** — How to confirm the skill was applied correctly
 
+The frontmatter fields above are required. The section anatomy is a recommended pattern: equivalent headings such as `How It Works`, `Workflow`, or `Core Process` are fine when they preserve the same intent and keep the skill easy to follow.
+
 ### What Not to Do
 
 - Don't duplicate content between skills — reference other skills instead
 - Don't add skills that are vague advice instead of actionable processes
 - Don't create supporting files unless content exceeds 100 lines
+- Don't create an empty `scripts/` directory just to match another skill — add `scripts/` only when the skill includes runnable helpers
 - Don't put reference material inside skill directories — use `references/` instead
 
 ## Modifying Existing Skills
@@ -41,6 +49,35 @@ Every skill should include these sections:
 - Keep changes focused and minimal
 - Preserve the existing structure and tone
 - Test that YAML frontmatter remains valid after edits
+
+## Testing Hooks
+
+The session-start hook (`hooks/session-start.sh`) injects the `using-agent-skills` meta-skill into every new Claude Code session. A regression test at `hooks/session-start-test.sh` validates the hook's JSON payload — both when `jq` is available and when it isn't.
+
+Run it before opening any PR that touches:
+
+- `hooks/session-start.sh`
+- `skills/using-agent-skills/SKILL.md` (the meta-skill content embedded by the hook)
+
+```bash
+bash hooks/session-start-test.sh
+```
+
+Expected output: `session-start JSON payload OK`. The script exits non-zero on any assertion failure.
+
+### Reproducing the no-jq fallback
+
+The hook gracefully degrades to an `INFO`-priority payload when `jq` isn't on `PATH`. To exercise that branch locally, strip `jq`'s directory from `PATH` for the test invocation:
+
+```bash
+JQ_DIR=$(dirname "$(command -v jq)")
+PATH=$(echo "$PATH" | tr ':' '\n' | grep -v "^${JQ_DIR}$" | tr '\n' ':' | sed 's/:$//') \
+  bash hooks/session-start-test.sh
+```
+
+This works cleanly when `jq` lives in its own directory (e.g. `/opt/homebrew/bin` from Homebrew, `/usr/local/bin` from a manual install). If your `jq` shares a system bin with other tools the test depends on (such as `mktemp` in `/usr/bin`), the simpler approach is to install `jq` via a separate package manager so it has its own bin directory, then re-run.
+
+The hook's `command -v jq` check fails under the stripped `PATH`, the `INFO`-priority fallback runs, and the test asserts the `jq is required` guidance message instead of the normal payload.
 
 ## Reporting Issues
 

--- a/profiles/addyosmani_agent-skills/for-forgecat/README.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/README.md
@@ -42,13 +42,18 @@ npx forgecat install @forgecat/addyosmani_agent-skills
 - **security-auditor** — Security engineer focused on vulnerability detection, threat modeling, and secure coding practices. Use for security-focused code review, threat analysis, or hardening recommendations.
 - **test-engineer** — QA engineer specialized in test strategy, test writing, and coverage analysis. Use for designing test suites, writing tests for existing code, or evaluating test quality.
 
+## Hooks
+
+- **agent-skills-session-start** — Injects the `using-agent-skills` meta-skill into each new Claude Code session.
+- **simplify-ignore** — Protects `simplify-ignore` blocks while Claude Code reads, edits, writes, and stops.
+
 ## Details
 
 | Field | Value |
 |---|---|
 | Author | Addy Osmani |
 | Original repository | https://github.com/addyosmani/agent-skills |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | `8d79b5f` |
 | License | MIT |
 | Source platform | Claude Code |

--- a/profiles/addyosmani_agent-skills/for-forgecat/README.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/addyosmani_agent-skills
 ## Skills
 
 - **api-and-interface-design** — Guides stable API and interface design. Use when designing APIs, module boundaries, or any public interface. Use when creating REST or GraphQL endpoints, defining type contracts between modules, or establishing boundaries between frontend and backend.
-- **browser-testing-with-devtools** — Tests in real browsers. Use when building or debugging anything that runs in a browser. Use when you need to inspect the DOM, capture console errors, analyze network requests, profile performance, or verify visual output with real runtime data via Chrome DevTools MCP.
+- **browser-testing-with-devtools** — Tests in real browsers via Chrome DevTools MCP. Use when building or debugging anything that runs in a browser. Use when you need to inspect the DOM, capture console errors, analyze network requests, profile performance, or verify visual output with real runtime data. Requires the chrome-devtools MCP server to be configured.
 - **ci-cd-and-automation** — Automates CI/CD pipeline setup. Use when setting up or modifying build and deployment pipelines. Use when you need to automate quality gates, configure test runners in CI, or establish deployment strategies.
 - **code-review-and-quality** — Conducts multi-axis code review. Use before merging any change. Use when reviewing code written by yourself, another agent, or a human. Use when you need to assess code quality across multiple dimensions before it enters the main branch.
 - **code-simplification** — Simplifies code for clarity. Use when refactoring code for clarity without changing behavior. Use when code works but is harder to read, maintain, or extend than it should be. Use when reviewing code that has accumulated unnecessary complexity.
@@ -31,10 +31,20 @@ npx forgecat install @forgecat/addyosmani_agent-skills
 - **debugging-and-error-recovery** — Guides systematic root-cause debugging. Use when tests fail, builds break, behavior doesn't match expectations, or you encounter any unexpected error. Use when you need a systematic approach to finding and fixing the root cause rather than guessing.
 - **deprecation-and-migration** — Manages deprecation and migration. Use when removing old systems, APIs, or features. Use when migrating users from one implementation to another. Use when deciding whether to maintain or sunset existing code.
 - **documentation-and-adrs** — Records decisions and documentation. Use when making architectural decisions, changing public APIs, shipping features, or when you need to record context that future engineers and agents will need to understand the codebase.
+- **doubt-driven-development** — Subjects every non-trivial decision to a fresh-context adversarial review before it stands. Use when correctness matters more than speed, when working in unfamiliar code, when stakes are high (production, security-sensitive logic, irreversible operations), or any time a confident output would be cheaper to verify now than to debug later.
 - **frontend-ui-engineering** — Builds production-quality UIs. Use when building or modifying user-facing interfaces. Use when creating components, implementing layouts, managing state, or when the output needs to look and feel production-quality rather than AI-generated.
 - **git-workflow-and-versioning** — Structures git workflow practices. Use when making any code change. Use when committing, branching, resolving conflicts, or when you need to organize work across multiple parallel streams.
-- **idea-refine** — Refines ideas iteratively. Refine ideas through structured divergent and convergent thinking. Use "idea-refine" or "ideate" to trigger.
-- **...and 8 more skills**
+- **idea-refine** — Refines raw ideas into sharp, actionable concepts through structured divergent and convergent thinking. Use when an idea is still vague, when you need to stress-test assumptions before committing to a plan, or when you want to expand options before converging on one. Triggers on "ideate", "refine this idea", or "stress-test my plan".
+- **incremental-implementation** — Delivers changes incrementally. Use when implementing any feature or change that touches more than one file. Use when you're about to write a large amount of code at once, or when a task feels too big to land in one step.
+- **interview-me** — Extracts what the user actually wants instead of what they think they should want. Achieves this through one-question-at-a-time interview until ~95% confidence about the underlying intent. Use when an ask is underspecified ("build me X" without "for whom" or "why now"), when the user explicitly invokes ("interview me", "grill me", "are we sure?", "stress-test my thinking"), or when you catch yourself silently filling in ambiguous requirements before any plan, spec, or code exists.
+- **performance-optimization** — Optimizes application performance. Use when performance requirements exist, when you suspect performance regressions, or when Core Web Vitals or load times need improvement. Use when profiling reveals bottlenecks that need fixing.
+- **planning-and-task-breakdown** — Breaks work into ordered tasks. Use when you have a spec or clear requirements and need to break work into implementable tasks. Use when a task feels too large to start, when you need to estimate scope, or when parallel work is possible.
+- **security-and-hardening** — Hardens code against vulnerabilities. Use when handling user input, authentication, data storage, or external integrations. Use when building any feature that accepts untrusted data, manages user sessions, or interacts with third-party services.
+- **shipping-and-launch** — Prepares production launches. Use when preparing to deploy to production. Use when you need a pre-launch checklist, when setting up monitoring, when planning a staged rollout, or when you need a rollback strategy.
+- **source-driven-development** — Grounds every implementation decision in official documentation. Use when you want authoritative, source-cited code free from outdated patterns. Use when building with any framework or library where correctness matters.
+- **spec-driven-development** — Creates specs before coding. Use when starting a new project, feature, or significant change and no specification exists yet. Use when requirements are unclear, ambiguous, or only exist as a vague idea.
+- **test-driven-development** — Drives development with tests. Use when implementing any logic, fixing any bug, or changing any behavior. Use when you need to prove that code works, when a bug report arrives, or when you're about to modify existing functionality.
+- **using-agent-skills** — Discovers and invokes agent skills. Use when starting a session or when you need to discover which skill applies to the current task. This is the meta-skill that governs how all other skills are discovered and invoked.
 
 ## Agents
 
@@ -42,10 +52,21 @@ npx forgecat install @forgecat/addyosmani_agent-skills
 - **security-auditor** — Security engineer focused on vulnerability detection, threat modeling, and secure coding practices. Use for security-focused code review, threat analysis, or hardening recommendations.
 - **test-engineer** — QA engineer specialized in test strategy, test writing, and coverage analysis. Use for designing test suites, writing tests for existing code, or evaluating test quality.
 
+## Commands
+
+- **/build** — Implement the next task incrementally — build, test, verify, commit
+- **/code-simplify** — Simplify code for clarity and maintainability — reduce complexity without changing behavior
+- **/plan** — Break work into small verifiable tasks with acceptance criteria and dependency ordering
+- **/review** — Conduct a five-axis code review — correctness, readability, architecture, security, performance
+- **/ship** — Run the pre-launch checklist via parallel fan-out to specialist personas, then synthesize a go/no-go decision
+- **/spec** — Start spec-driven development — write a structured specification before writing code
+- **/test** — Run TDD workflow — write failing tests, implement, verify. For bugs, use the Prove-It pattern.
+
 ## Hooks
 
 - **agent-skills-session-start** — Injects the `using-agent-skills` meta-skill into each new Claude Code session.
 - **simplify-ignore** — Protects `simplify-ignore` blocks while Claude Code reads, edits, writes, and stops.
+- **sdd-cache** — Revalidates and serves source-driven-development WebFetch documentation cache entries.
 
 ## Details
 
@@ -53,8 +74,8 @@ npx forgecat install @forgecat/addyosmani_agent-skills
 |---|---|
 | Author | Addy Osmani |
 | Original repository | https://github.com/addyosmani/agent-skills |
-| Version | `0.0.1` |
-| Original commit | `8d79b5f` |
+| Version | `0.0.2` |
+| Original commit | `2a62238` |
 | License | MIT |
 | Source platform | Claude Code |
 
@@ -68,6 +89,7 @@ npx forgecat install @forgecat/addyosmani_agent-skills
 | Cursor | Partial |
 | Codex | Partial |
 
+
 ---
 *written by original source*
 
@@ -77,14 +99,7 @@ npx forgecat install @forgecat/addyosmani_agent-skills
 
 Skills encode the workflows, quality gates, and best practices that senior engineers use when building software. These ones are packaged so AI agents follow them consistently across every phase of development.
 
-```
-  DEFINE          PLAN           BUILD          VERIFY         REVIEW          SHIP
- ┌──────┐      ┌──────┐      ┌──────┐      ┌──────┐      ┌──────┐      ┌──────┐
- │ Idea │ ───▶ │ Spec │ ───▶ │ Code │ ───▶ │ Test │ ───▶ │  QA  │ ───▶ │  Go  │
- │Refine│      │  PRD │      │ Impl │      │Debug │      │ Gate │      │ Live │
- └──────┘      └──────┘      └──────┘      └──────┘      └──────┘      └──────┘
-  /spec          /plan          /build        /test         /review       /ship
-```
+![Addy's Agent Skills](https://addyosmani.com/assets/images/addys-agent-skills.jpg)
 
 ---
 
@@ -117,6 +132,12 @@ Skills also activate automatically based on what you're doing — designing an A
 /plugin marketplace add addyosmani/agent-skills
 /plugin install agent-skills@addy-agent-skills
 ```
+
+> **SSH errors?** The marketplace clones repos via SSH. If you don't have SSH keys set up on GitHub, either [add your SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) or use the full HTTPS URL to force the HTTPS cloning:
+> ```bash
+> /plugin marketplace add https://github.com/addyosmani/agent-skills.git
+> /plugin install agent-skills@addy-agent-skills
+> ```
 
 **Local / development:**
 
@@ -161,10 +182,24 @@ Add skill contents to your Windsurf rules configuration. See [docs/windsurf-setu
 </details>
 
 <details>
+<summary><b>OpenCode</b></summary>
+
+Uses agent-driven skill execution via AGENTS.md and the `skill` tool.
+
+See [docs/opencode-setup.md](docs/opencode-setup.md).
+
+</details>
+
+<details>
 <summary><b>GitHub Copilot</b></summary>
 
 Use agent definitions from `agents/` as Copilot personas and skill content in `.github/copilot-instructions.md`. See [docs/copilot-setup.md](docs/copilot-setup.md).
 
+</details>
+
+<details>
+  <summary><b>Kiro IDE & CLI </b></summary>
+  Skills for Kiro reside under ".kiro/skills/" and can be stored under Project or Global level. Kiro also supports Agents.md. See Kiro docs at https://kiro.dev/docs/skills/
 </details>
 
 <details>
@@ -174,16 +209,25 @@ Skills are plain Markdown - they work with any agent that accepts system prompts
 
 </details>
 
+
+
 ---
 
-## All 19 Skills
+## All 23 Skills
 
-The commands above are the entry points. Under the hood, they activate these 19 skills — each one a structured workflow with steps, verification gates, and anti-rationalization tables. You can also reference any skill directly.
+The commands above are entry points. The pack includes 23 skills total — 22 lifecycle skills plus the `using-agent-skills` meta-skill. Each skill is a structured workflow with steps, verification gates, and anti-rationalization tables. You can also reference any skill directly.
+
+### Meta - Discover which skill applies
+
+| Skill | What It Does | Use When |
+|-------|-------------|----------|
+| [using-agent-skills](skills/using-agent-skills/SKILL.md) | Maps incoming work to the right skill workflow and defines shared operating rules | Starting a session or deciding which skill applies |
 
 ### Define - Clarify what to build
 
 | Skill | What It Does | Use When |
 |-------|-------------|----------|
+| [interview-me](skills/interview-me/SKILL.md) | One-question-at-a-time interview that extracts what the user actually wants instead of what they think they should want, until ~95% confidence | The ask is underspecified, or the user invokes "interview me" / "grill me" |
 | [idea-refine](skills/idea-refine/SKILL.md) | Structured divergent/convergent thinking to turn vague ideas into concrete proposals | You have a rough concept that needs exploration |
 | [spec-driven-development](skills/spec-driven-development/SKILL.md) | Write a PRD covering objectives, commands, structure, code style, testing, and boundaries before any code | Starting a new project, feature, or significant change |
 
@@ -200,6 +244,8 @@ The commands above are the entry points. Under the hood, they activate these 19 
 | [incremental-implementation](skills/incremental-implementation/SKILL.md) | Thin vertical slices - implement, test, verify, commit. Feature flags, safe defaults, rollback-friendly changes | Any change touching more than one file |
 | [test-driven-development](skills/test-driven-development/SKILL.md) | Red-Green-Refactor, test pyramid (80/15/5), test sizes, DAMP over DRY, Beyonce Rule, browser testing | Implementing logic, fixing bugs, or changing behavior |
 | [context-engineering](skills/context-engineering/SKILL.md) | Feed agents the right information at the right time - rules files, context packing, MCP integrations | Starting a session, switching tasks, or when output quality drops |
+| [source-driven-development](skills/source-driven-development/SKILL.md) | Ground every framework decision in official documentation - verify, cite sources, flag what's unverified | You want authoritative, source-cited code for any framework or library |
+| [doubt-driven-development](skills/doubt-driven-development/SKILL.md) | Adversarial fresh-context review of every non-trivial decision in-flight - CLAIM → EXTRACT → DOUBT → RECONCILE → STOP, with optional user-authorized cross-model escalation | Stakes are high (production, security, irreversible), working in unfamiliar code, or a confident output is cheaper to verify now than to debug later |
 | [frontend-ui-engineering](skills/frontend-ui-engineering/SKILL.md) | Component architecture, design systems, state management, responsive design, WCAG 2.1 AA accessibility | Building or modifying user-facing interfaces |
 | [api-and-interface-design](skills/api-and-interface-design/SKILL.md) | Contract-first design, Hyrum's Law, One-Version Rule, error semantics, boundary validation | Designing APIs, module boundaries, or public interfaces |
 
@@ -261,21 +307,21 @@ Quick-reference material that skills pull in when needed:
 Every skill follows a consistent anatomy:
 
 ```
-┌─────────────────────────────────────────────┐
-│  SKILL.md                                   │
-│                                             │
-│  ┌─ Frontmatter ─────────────────────────┐  │
-│  │ name: lowercase-hyphen-name           │  │
-│  │ description: Use when [trigger]       │  │
-│  └───────────────────────────────────────┘  │
-│                                             │
-│  Overview         → What this skill does    │
-│  When to Use      → Triggering conditions   │
-│  Process          → Step-by-step workflow   │
-│  Rationalizations → Excuses + rebuttals     │
-│  Red Flags        → Signs something's wrong │
-│  Verification     → Evidence requirements   │
-└─────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────┐
+│  SKILL.md                                       │
+│                                                 │
+│  ┌─ Frontmatter ─────────────────────────────┐  │
+│  │ name: lowercase-hyphen-name               │  │
+│  │ description: Guides agents through [task].│  │
+│  │              Use when…                    │  │
+│  └───────────────────────────────────────────┘  │
+│  Overview         → What this skill does        │
+│  When to Use      → Triggering conditions       │
+│  Process          → Step-by-step workflow       │
+│  Rationalizations → Excuses + rebuttals         │
+│  Red Flags        → Signs something's wrong     │
+│  Verification     → Evidence requirements       │
+└─────────────────────────────────────────────────┘
 ```
 
 **Key design choices:**
@@ -291,12 +337,15 @@ Every skill follows a consistent anatomy:
 
 ```
 agent-skills/
-├── skills/                            # 19 core skills (SKILL.md per directory)
+├── skills/                            # 23 skills (22 lifecycle + 1 meta)
+│   ├── interview-me/                  #   Define
 │   ├── idea-refine/                   #   Define
 │   ├── spec-driven-development/       #   Define
 │   ├── planning-and-task-breakdown/   #   Plan
 │   ├── incremental-implementation/    #   Build
 │   ├── context-engineering/           #   Build
+│   ├── source-driven-development/     #   Build
+│   ├── doubt-driven-development/      #   Build
 │   ├── frontend-ui-engineering/       #   Build
 │   ├── test-driven-development/       #   Build
 │   ├── api-and-interface-design/      #   Build
@@ -314,6 +363,9 @@ agent-skills/
 │   └── using-agent-skills/            #   Meta: how to use this pack
 ├── agents/                            # 3 specialist personas
 ├── references/                        # 4 supplementary checklists
+├── hooks/                             # Session lifecycle hooks
+├── .claude/commands/                  # 7 slash commands (Claude Code)
+├── .gemini/commands/                  # 7 slash commands (Gemini CLI)
 └── docs/                              # Setup guides per tool
 ```
 

--- a/profiles/addyosmani_agent-skills/for-forgecat/agents/code-reviewer.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/agents/code-reviewer.md
@@ -89,3 +89,9 @@ Categorize every finding:
 4. Don't approve code with Critical issues
 5. Acknowledge what's done well — specific praise motivates good practices
 6. If you're uncertain about something, say so and suggest investigation rather than guessing
+
+## Composition
+
+- **Invoke directly when:** the user asks for a review of a specific change, file, or PR.
+- **Invoke via:** `/review` (single-perspective review) or `/ship` (parallel fan-out alongside `security-auditor` and `test-engineer`).
+- **Do not invoke from another persona.** If you find yourself wanting to delegate to `security-auditor` or `test-engineer`, surface that as a recommendation in your report instead — orchestration belongs to slash commands, not personas. See [agents/README.md](README.md).

--- a/profiles/addyosmani_agent-skills/for-forgecat/agents/security-auditor.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/agents/security-auditor.md
@@ -93,3 +93,9 @@ You are an experienced Security Engineer conducting a security review. Your role
 5. Check the OWASP Top 10 as a minimum baseline
 6. Review dependencies for known CVEs
 7. Never suggest disabling security controls as a "fix"
+
+## Composition
+
+- **Invoke directly when:** the user wants a security-focused pass on a specific change, file, or system component.
+- **Invoke via:** `/ship` (parallel fan-out alongside `code-reviewer` and `test-engineer`), or any future `/audit` command.
+- **Do not invoke from another persona.** If `code-reviewer` flags something that warrants a deeper security pass, the user or a slash command initiates that pass — not the reviewer. See [agents/README.md](README.md).

--- a/profiles/addyosmani_agent-skills/for-forgecat/agents/test-engineer.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/agents/test-engineer.md
@@ -87,3 +87,9 @@ When analyzing test coverage:
 5. Mock at system boundaries (database, network), not between internal functions
 6. Every test name should read like a specification
 7. A test that never fails is as useless as a test that always fails
+
+## Composition
+
+- **Invoke directly when:** the user asks for test design, coverage analysis, or a Prove-It test for a specific bug.
+- **Invoke via:** `/test` (TDD workflow) or `/ship` (parallel fan-out for coverage gap analysis alongside `code-reviewer` and `security-auditor`).
+- **Do not invoke from another persona.** Recommendations to add tests belong in your report; the user or a slash command decides when to act on them. See [agents/README.md](README.md).

--- a/profiles/addyosmani_agent-skills/for-forgecat/commands/build.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/commands/build.md
@@ -1,0 +1,18 @@
+---
+description: Implement the next task incrementally — build, test, verify, commit
+---
+
+Invoke the agent-skills:incremental-implementation skill alongside agent-skills:test-driven-development.
+
+Pick the next pending task from the plan. For each task:
+
+1. Read the task's acceptance criteria
+2. Load relevant context (existing code, patterns, types)
+3. Write a failing test for the expected behavior (RED)
+4. Implement the minimum code to pass the test (GREEN)
+5. Run the full test suite to check for regressions
+6. Run the build to verify compilation
+7. Commit with a descriptive message
+8. Mark the task complete and move to the next one
+
+If any step fails, follow the agent-skills:debugging-and-error-recovery skill.

--- a/profiles/addyosmani_agent-skills/for-forgecat/commands/code-simplify.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/commands/code-simplify.md
@@ -1,0 +1,22 @@
+---
+description: Simplify code for clarity and maintainability — reduce complexity without changing behavior
+---
+
+Invoke the agent-skills:code-simplification skill.
+
+Simplify recently changed code (or the specified scope) while preserving exact behavior:
+
+1. Read CLAUDE.md and study project conventions
+2. Identify the target code — recent changes unless a broader scope is specified
+3. Understand the code's purpose, callers, edge cases, and test coverage before touching it
+4. Scan for simplification opportunities:
+   - Deep nesting → guard clauses or extracted helpers
+   - Long functions → split by responsibility
+   - Nested ternaries → if/else or switch
+   - Generic names → descriptive names
+   - Duplicated logic → shared functions
+   - Dead code → remove after confirming
+5. Apply each simplification incrementally — run tests after each change
+6. Verify all tests pass, the build succeeds, and the diff is clean
+
+If tests fail after a simplification, revert that change and reconsider. Use `code-review-and-quality` to review the result.

--- a/profiles/addyosmani_agent-skills/for-forgecat/commands/plan.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/commands/plan.md
@@ -1,0 +1,16 @@
+---
+description: Break work into small verifiable tasks with acceptance criteria and dependency ordering
+---
+
+Invoke the agent-skills:planning-and-task-breakdown skill.
+
+Read the existing spec (SPEC.md or equivalent) and the relevant codebase sections. Then:
+
+1. Enter plan mode — read only, no code changes
+2. Identify the dependency graph between components
+3. Slice work vertically (one complete path per task, not horizontal layers)
+4. Write tasks with acceptance criteria and verification steps
+5. Add checkpoints between phases
+6. Present the plan for human review
+
+Save the plan to tasks/plan.md and task list to tasks/todo.md.

--- a/profiles/addyosmani_agent-skills/for-forgecat/commands/review.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/commands/review.md
@@ -1,0 +1,16 @@
+---
+description: Conduct a five-axis code review — correctness, readability, architecture, security, performance
+---
+
+Invoke the agent-skills:code-review-and-quality skill.
+
+Review the current changes (staged or recent commits) across all five axes:
+
+1. **Correctness** — Does it match the spec? Edge cases handled? Tests adequate?
+2. **Readability** — Clear names? Straightforward logic? Well-organized?
+3. **Architecture** — Follows existing patterns? Clean boundaries? Right abstraction level?
+4. **Security** — Input validated? Secrets safe? Auth checked? (Use security-and-hardening skill)
+5. **Performance** — No N+1 queries? No unbounded ops? (Use performance-optimization skill)
+
+Categorize findings as Critical, Important, or Suggestion.
+Output a structured review with specific file:line references and fix recommendations.

--- a/profiles/addyosmani_agent-skills/for-forgecat/commands/ship.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/commands/ship.md
@@ -1,0 +1,72 @@
+---
+description: Run the pre-launch checklist via parallel fan-out to specialist personas, then synthesize a go/no-go decision
+---
+
+Invoke the agent-skills:shipping-and-launch skill.
+
+`/ship` is a **fan-out orchestrator**. It runs three specialist personas in parallel against the current change, then merges their reports into a single go/no-go decision with a rollback plan. The personas operate independently — no shared state, no ordering — which is what makes parallel execution safe and useful here.
+
+## Phase A — Parallel fan-out
+
+Spawn three subagents concurrently using the Agent tool. **Issue all three Agent tool calls in a single assistant turn so they execute in parallel** — sequential calls defeat the purpose of this command.
+
+In Claude Code, each call passes `subagent_type` matching the persona's `name` field:
+
+1. **`code-reviewer`** — Run a five-axis review (correctness, readability, architecture, security, performance) on the staged changes or recent commits. Output the standard review template.
+2. **`security-auditor`** — Run a vulnerability and threat-model pass. Check OWASP Top 10, secrets handling, auth/authz, dependency CVEs. Output the standard audit report.
+3. **`test-engineer`** — Analyze test coverage for the change. Identify gaps in happy path, edge cases, error paths, and concurrency scenarios. Output the standard coverage analysis.
+
+In other harnesses without an Agent tool, invoke each persona's system prompt sequentially and treat their outputs as if returned in parallel — the merge phase still works.
+
+Constraints (from Claude Code's subagent model):
+- Subagents cannot spawn other subagents — do not let one persona delegate to another.
+- Each subagent gets its own context window and returns only its report to this main session.
+- If you need teammates that talk to each other instead of just reporting back, use Claude Code Agent Teams and reference these personas as teammate types (see `references/orchestration-patterns.md`).
+
+**Persona resolution.** If you've defined your own `code-reviewer`, `security-auditor`, or `test-engineer` in `.claude/agents/` or `~/.claude/agents/`, those take precedence over this plugin's versions — `/ship` picks up your customizations automatically. This is intentional: plugin subagents sit at the bottom of Claude Code's scope priority table, so user-level definitions win by design.
+
+## Phase B — Merge in main context
+
+Once all three reports are back, the main agent (not a sub-persona) synthesizes them:
+
+1. **Code Quality** — Aggregate Critical/Important findings from `code-reviewer` and any failing tests, lint, or build output. Resolve duplicates between reviewers.
+2. **Security** — Promote any Critical/High `security-auditor` findings to launch blockers. Cross-reference with `code-reviewer`'s security axis.
+3. **Performance** — Pull from `code-reviewer`'s performance axis; cross-check Core Web Vitals if applicable.
+4. **Accessibility** — Verify keyboard nav, screen reader support, contrast (not covered by the three personas — handle directly here, or invoke the accessibility checklist).
+5. **Infrastructure** — Env vars, migrations, monitoring, feature flags. Verify directly.
+6. **Documentation** — README, ADRs, changelog. Verify directly.
+
+## Phase C — Decision and rollback
+
+Produce a single output:
+
+```markdown
+## Ship Decision: GO | NO-GO
+
+### Blockers (must fix before ship)
+- [Source persona: Critical finding + file:line]
+
+### Recommended fixes (should fix before ship)
+- [Source persona: Important finding + file:line]
+
+### Acknowledged risks (shipping anyway)
+- [Risk + mitigation]
+
+### Rollback plan
+- Trigger conditions: [what signals would prompt rollback]
+- Rollback procedure: [exact steps]
+- Recovery time objective: [target]
+
+### Specialist reports (full)
+- [code-reviewer report]
+- [security-auditor report]
+- [test-engineer report]
+```
+
+## Rules
+
+1. The three Phase A personas run in parallel — never sequentially.
+2. Personas do not call each other. The main agent merges in Phase B.
+3. The rollback plan is mandatory before any GO decision.
+4. If any persona returns a Critical finding, the default verdict is NO-GO unless the user explicitly accepts the risk.
+5. **Skip the fan-out only if all of the following are true:** the change touches 2 files or fewer, the diff is under 50 lines, and it does not touch auth, payments, data access, or config/env. Otherwise, default to fan-out. `/ship` is designed for production-bound changes — when the blast radius is non-trivial, run the parallel review even if the diff looks small.

--- a/profiles/addyosmani_agent-skills/for-forgecat/commands/spec.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/commands/spec.md
@@ -1,0 +1,15 @@
+---
+description: Start spec-driven development — write a structured specification before writing code
+---
+
+Invoke the agent-skills:spec-driven-development skill.
+
+Begin by understanding what the user wants to build. Ask clarifying questions about:
+1. The objective and target users
+2. Core features and acceptance criteria
+3. Tech stack preferences and constraints
+4. Known boundaries (what to always do, ask first about, and never do)
+
+Then generate a structured spec covering all six core areas: objective, commands, project structure, code style, testing strategy, and boundaries.
+
+Save the spec as SPEC.md in the project root and confirm with the user before proceeding.

--- a/profiles/addyosmani_agent-skills/for-forgecat/commands/test.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/commands/test.md
@@ -1,0 +1,19 @@
+---
+description: Run TDD workflow — write failing tests, implement, verify. For bugs, use the Prove-It pattern.
+---
+
+Invoke the agent-skills:test-driven-development skill.
+
+For new features:
+1. Write tests that describe the expected behavior (they should FAIL)
+2. Implement the code to make them pass
+3. Refactor while keeping tests green
+
+For bug fixes (Prove-It pattern):
+1. Write a test that reproduces the bug (must FAIL)
+2. Confirm the test fails
+3. Implement the fix
+4. Confirm the test passes
+5. Run the full test suite for regressions
+
+For browser-related issues, also invoke agent-skills:browser-testing-with-devtools to verify with Chrome DevTools MCP.

--- a/profiles/addyosmani_agent-skills/for-forgecat/docs/copilot-setup.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/docs/copilot-setup.md
@@ -16,15 +16,20 @@ cat /path/to/agent-skills/skills/code-review-and-quality/SKILL.md > .github/skil
 
 For more details, refer [Creating agent skills for GitHub Copilot](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/create-skills).
 
-### Agent Personas (agents.md)
+### Agent Personas (*.agent.md)
 
 Copilot supports specialized agent personas. Use the agent-skills agents:
 
+> **Important:** GitHub Copilot requires custom agent files to be named `*.agent.md`.
+> Files named `*.md` are silently ignored by Copilot.
+> See [VS Code custom agents docs](https://code.visualstudio.com/docs/copilot/customization/custom-agents#_custom-agent-file-structure) for details.
+
 ```bash
-# Copy agent definitions
-cp /path/to/agent-skills/agents/code-reviewer.md .github/agents/code-reviewer.md
-cp /path/to/agent-skills/agents/test-engineer.md .github/agents/test-engineer.md
-cp /path/to/agent-skills/agents/security-auditor.md .github/agents/security-auditor.md
+# Create the agents directory and copy agent definitions
+mkdir -p .github/agents
+cp /path/to/agent-skills/agents/code-reviewer.md .github/agents/code-reviewer.agent.md
+cp /path/to/agent-skills/agents/test-engineer.md .github/agents/test-engineer.agent.md
+cp /path/to/agent-skills/agents/security-auditor.md .github/agents/security-auditor.agent.md
 ```
 
 Invoke agents in Copilot Chat:

--- a/profiles/addyosmani_agent-skills/for-forgecat/docs/cursor-setup.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/docs/cursor-setup.md
@@ -29,15 +29,6 @@ echo "\n---\n" >> .cursorrules
 cat /path/to/agent-skills/skills/code-review-and-quality/SKILL.md >> .cursorrules
 ```
 
-### Option 3: Notepads
-
-Cursor's Notepads feature lets you store reusable context. Create a notepad for each skill you use frequently:
-
-1. Open Cursor → Settings → Notepads
-2. Create a new notepad named "swe: Test-Driven Development"
-3. Paste the content of `skills/test-driven-development/SKILL.md`
-4. Reference it in chat with `@notepad swe: Test-Driven Development`
-
 ## Recommended Configuration
 
 ### Essential Skills (Always Load)
@@ -48,20 +39,20 @@ Add these to `.cursor/rules/`:
 2. `code-review-and-quality.md` — Five-axis review
 3. `incremental-implementation.md` — Build in small verifiable slices
 
-### Phase-Specific Skills (Load as Notepads)
+### Phase-Specific Skills (Load on Demand)
 
-Create notepads for skills you use contextually:
+For phase-specific work, create additional rule files as needed:
 
-- "swe: Spec Development" → `spec-driven-development/SKILL.md`
-- "swe: Frontend UI" → `frontend-ui-engineering/SKILL.md`
-- "swe: Security" → `security-and-hardening/SKILL.md`
-- "swe: Performance" → `performance-optimization/SKILL.md`
+- `spec-development.md` -> `spec-driven-development/SKILL.md`
+- `frontend-ui.md` -> `frontend-ui-engineering/SKILL.md`
+- `security.md` -> `security-and-hardening/SKILL.md`
+- `performance.md` -> `performance-optimization/SKILL.md`
 
-Reference them with `@notepad` when working on relevant tasks.
+Add these to `.cursor/rules/` when working on relevant tasks, then remove when done to manage context limits.
 
 ## Usage Tips
 
-1. **Don't load all skills at once** — Cursor has context limits. Load 2-3 skills as rules and keep others as notepads.
-2. **Reference skills explicitly** — Tell Cursor "Follow the test-driven-development rules for this change" to ensure it reads the loaded rules.
-3. **Use agents for review** — Copy `agents/code-reviewer.md` content and tell Cursor to "review this diff using this code review framework."
-4. **Load references on demand** — When working on performance, reference `@notepad performance-checklist` or paste the checklist content.
+1. **Don't load all skills at once** - Cursor has context limits. Load 2-3 essential skills as rules and add phase-specific skills as needed.
+2. **Reference skills explicitly** - Tell Cursor "Follow the test-driven-development rules for this change" to ensure it reads the loaded rules.
+3. **Use agents for review** - Copy `agents/code-reviewer.md` content and tell Cursor to "review this diff using this code review framework."
+4. **Load references on demand** - When working on performance, add `performance.md` to `.cursor/rules/` or paste the checklist content directly.

--- a/profiles/addyosmani_agent-skills/for-forgecat/docs/gemini-cli-setup.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/docs/gemini-cli-setup.md
@@ -78,9 +78,54 @@ Install these as skills so they activate only when relevant:
 - `security-and-hardening` — Activates during security reviews
 - `performance-optimization` — Activates during performance work
 
+## Advanced Configuration
+
+### MCP Integration
+
+Many skills in this pack leverage [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) tools to interact with the environment. For example:
+
+- `browser-testing-with-devtools` uses the `chrome-devtools` MCP extension.
+- `performance-optimization` can benefit from performance-related MCP tools.
+
+To enable these, ensure you have the relevant MCP extensions installed in your Gemini CLI configuration (`~/.gemini/config.json`).
+
+### Session Hooks
+
+Gemini CLI supports session lifecycle hooks. You can use these to automatically inject context or run validation scripts at the start of a session.
+
+To replicate the `agent-skills` experience from other tools, you can configure a `SessionStart` hook that reminds you of the available skills or loads a meta-skill.
+
+### Explicit Context Loading
+
+You can explicitly load any skill into your current session by referencing it with the `@` symbol in your prompt:
+
+```markdown
+Use the @skills/test-driven-development/SKILL.md skill to implement this fix.
+```
+
+This is useful when you want to ensure a specific workflow is followed without waiting for auto-discovery.
+
+## Slash Commands
+
+The repo ships 7 slash commands under `.gemini/commands/` that map to the development lifecycle. Gemini CLI auto-discovers them when you run from the project root.
+
+| Command | What it does |
+|---------|--------------|
+| `/spec` | Write a structured spec before writing code |
+| `/planning` | Break work into small, verifiable tasks |
+| `/build` | Implement the next task incrementally |
+| `/test` | Run TDD workflow — red, green, refactor |
+| `/review` | Five-axis code review |
+| `/code-simplify` | Reduce complexity without changing behavior |
+| `/ship` | Pre-launch checklist via parallel persona fan-out |
+
+Each command invokes the corresponding skill automatically — no manual skill loading required.
+
+> **Note:** Use `/planning` instead of `/plan` — `/plan` conflicts with a Gemini CLI internal command name.
+
 ## Usage Tips
 
 1. **Prefer skills over GEMINI.md** — Skills activate on demand and keep your context window focused. Only put skills in GEMINI.md if you want them always loaded.
-2. **Skill descriptions matter** — Each SKILL.md has a `description` field in its frontmatter that tells Gemini when to activate it. The descriptions in this repo are already optimized for auto-activation.
+2. **Skill descriptions matter** — Each SKILL.md has a `description` field in its frontmatter that tells agents when to activate it. The descriptions in this repo are optimized for auto-discovery across all supported tools (Claude Code, Gemini CLI, etc.) by clearly stating both *what* the skill does and *when* it should be triggered.
 3. **Use agents for review** — Copy `agents/code-reviewer.md` content when requesting structured code reviews.
 4. **Combine with references** — Reference checklists from `references/` when working on specific quality areas like testing or performance.

--- a/profiles/addyosmani_agent-skills/for-forgecat/docs/getting-started.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/docs/getting-started.md
@@ -125,6 +125,14 @@ The `references/` directory contains supplementary checklists:
 
 Load a reference when you need detailed patterns beyond what the skill covers.
 
+## Spec and task artifacts
+
+The `/spec` and `/plan` commands create working artifacts (`SPEC.md`, `tasks/plan.md`, `tasks/todo.md`). Treat them as **living documents** while the work is in progress:
+
+- Keep them in version control during development so the human and the agent have a shared source of truth.
+- Update them when scope or decisions change.
+- If your repo doesn’t want these files long‑term, delete them before merge or add the folder to `.gitignore` — the workflow doesn’t require them to be permanent.
+
 ## Tips
 
 1. **Start with spec-driven-development** for any non-trivial work

--- a/profiles/addyosmani_agent-skills/for-forgecat/docs/opencode-setup.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/docs/opencode-setup.md
@@ -1,0 +1,178 @@
+# OpenCode Setup
+
+This guide explains how to use Agent Skills with OpenCode in a way that closely mirrors the Claude Code experience (automatic skill selection, lifecycle-driven workflows, and strict process enforcement).
+
+## Overview
+
+OpenCode supports custom `/commands`, but does not have a native plugin system or automatic skill routing like Claude Code.
+
+Instead, we achieve parity through:
+
+- A strong system prompt (`AGENTS.md`)
+- The built-in `skill` tool
+- Consistent skill discovery from the `/skills` directory
+
+This creates an **agent-driven workflow** where skills are selected and executed automatically.
+
+While it is possible to recreate `/spec`, `/plan`, and other commands in OpenCode, this integration intentionally uses an agent-driven approach instead:
+
+- Skills are selected automatically based on intent
+- Workflows are enforced via `AGENTS.md`
+- No manual command invocation is required
+
+This more closely matches how Claude Code behaves in practice, where skills are triggered automatically rather than manually.
+
+---
+
+## Installation
+
+1. Clone the repository:
+
+```bash
+git clone https://github.com/addyosmani/agent-skills.git
+```
+
+2. Open the project in OpenCode.
+
+3. Ensure the following files are present in your workspace:
+
+- `AGENTS.md` (root)
+- `skills/` directory
+
+No additional installation is required.
+
+---
+
+## How It Works
+
+### 1. Skill Discovery
+
+All skills live in:
+
+```
+skills/<skill-name>/SKILL.md
+```
+
+OpenCode agents are instructed (via `AGENTS.md`) to:
+
+- Detect when a skill applies
+- Invoke the `skill` tool
+- Follow the skill exactly
+
+### 2. Automatic Skill Invocation
+
+The agent evaluates every request and maps it to the appropriate skill.
+
+Examples:
+
+- "build a feature" → `incremental-implementation` + `test-driven-development`
+- "design a system" → `spec-driven-development`
+- "fix a bug" → `debugging-and-error-recovery`
+- "review this code" → `code-review-and-quality`
+
+The user does **not** need to explicitly request skills.
+
+### 3. Lifecycle Mapping (Implicit Commands)
+
+The development lifecycle is encoded implicitly:
+
+- DEFINE → `spec-driven-development`
+- PLAN → `planning-and-task-breakdown`
+- BUILD → `incremental-implementation` + `test-driven-development`
+- VERIFY → `debugging-and-error-recovery`
+- REVIEW → `code-review-and-quality`
+- SHIP → `shipping-and-launch`
+
+This replaces slash commands like `/spec`, `/plan`, etc.
+
+---
+
+## Usage Examples
+
+### Example 1: Feature Development
+
+User:
+```
+Add authentication to this app
+```
+
+Agent behavior:
+- Detects feature work
+- Invokes `spec-driven-development`
+- Produces a spec before writing code
+- Moves to planning and implementation skills
+
+---
+
+### Example 2: Bug Fix
+
+User:
+```
+This endpoint is returning 500 errors
+```
+
+Agent behavior:
+- Invokes `debugging-and-error-recovery`
+- Reproduces → localizes → fixes → adds guards
+
+---
+
+### Example 3: Code Review
+
+User:
+```
+Review this PR
+```
+
+Agent behavior:
+- Invokes `code-review-and-quality`
+- Applies structured review (correctness, design, readability, etc.)
+
+---
+
+## Agent Expectations (Critical)
+
+For OpenCode to work correctly, the agent must follow these rules:
+
+- Always check if a skill applies before acting
+- If a skill applies, it MUST be used
+- Never skip required workflows (spec, plan, test, etc.)
+- Do not jump directly to implementation
+
+These rules are enforced via `AGENTS.md`.
+
+---
+
+## Limitations
+
+- No native slash commands (handled via intent mapping instead)
+- No plugin system (handled via prompt + structure)
+- Skill invocation depends on model compliance
+
+Despite these, the workflow closely matches Claude Code in practice.
+
+---
+
+## Recommended Workflow
+
+Just use natural language:
+
+- "Design a feature"
+- "Plan this change"
+- "Implement this"
+- "Fix this bug"
+- "Review this"
+
+The agent will automatically select and execute the correct skills.
+
+---
+
+## Summary
+
+OpenCode integration works by combining:
+
+- Structured skills (this repo)
+- Strong agent rules (`AGENTS.md`)
+- Automatic skill invocation via reasoning
+
+This results in a **fully agent-driven, production-grade engineering workflow** without requiring plugins or manual commands.

--- a/profiles/addyosmani_agent-skills/for-forgecat/docs/skill-anatomy.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/docs/skill-anatomy.md
@@ -9,9 +9,12 @@ Every skill lives in its own directory under `skills/`:
 ```
 skills/
   skill-name/
-    SKILL.md          # Required: The skill definition
+    SKILL.md           # Required: The skill definition
+    scripts/           # Optional: Runnable helpers used by the skill workflow
     supporting-file.md # Optional: Reference material loaded on demand
 ```
+
+`SKILL.md` is the only required file. Add `scripts/` only when the skill actually ships runnable helpers, and omit the directory entirely for markdown-only skills.
 
 ## SKILL.md Format
 
@@ -20,17 +23,19 @@ skills/
 ```yaml
 ---
 name: skill-name-with-hyphens
-description: Brief statement of what the skill does. Use when [specific trigger conditions].
+description: Guides agents through [task/workflow]. Use when [specific trigger conditions].
 ---
 ```
 
 **Rules:**
 - `name`: Lowercase, hyphen-separated. Must match the directory name.
-- `description`: Starts with what the skill does (third person), followed by trigger conditions. Include both *what* and *when*. Maximum 1024 characters.
+- `description`: Start with what the skill does in third person, then include one or more clear "Use when" trigger conditions. Include both *what* and *when*. Maximum 1024 characters.
 
 **Why this matters:** Agents discover skills by reading descriptions. The description is injected into the system prompt, so it must tell the agent both what the skill provides and when to activate it. Do not summarize the workflow — if the description contains process steps, the agent may follow the summary instead of reading the full skill.
 
-### Standard Sections
+### Standard Sections (Recommended Pattern)
+
+The frontmatter contract above is required. The section layout below is a recommended pattern, not a rigid template: equivalent headings are acceptable when they serve the same purpose clearly.
 
 ```markdown
 # Skill Title
@@ -100,6 +105,8 @@ Create supporting files only when:
 
 Keep patterns and principles inline when under 50 lines.
 
+If a skill does not need runnable helpers, do not create an empty `scripts/` directory just to mirror other skills. Empty directories add noise without changing how the skill works.
+
 ## Writing Principles
 
 1. **Process over knowledge.** Skills are workflows, not reference docs. Steps, not facts.
@@ -126,3 +133,17 @@ If the build breaks, use the `debugging-and-error-recovery` skill.
 ```
 
 Don't duplicate content between skills — reference and link instead.
+
+## Required vs Recommended
+
+Required:
+
+- A `skills/<skill-name>/SKILL.md` file
+- Valid YAML frontmatter with `name` and `description`
+- A description that includes both what the skill does and when to use it
+
+Recommended:
+
+- The standard section flow shown above
+- Equivalent headings such as `How It Works`, `Core Process`, or `Workflow` when they read more naturally for the skill
+- Supporting files only when they keep the main `SKILL.md` focused

--- a/profiles/addyosmani_agent-skills/for-forgecat/hooks/SDD-CACHE.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/hooks/SDD-CACHE.md
@@ -1,0 +1,167 @@
+# sdd-cache hook
+
+Cross-session citation cache for [`source-driven-development`](../skills/source-driven-development/SKILL.md). Skips redundant `WebFetch` calls without weakening the skill's "verify against current docs" guarantee.
+
+## Why
+
+`source-driven-development` fetches official docs for every framework-specific decision. Working on the same project across sessions means fetching the same pages over and over. Caching the content as local memory would contradict the skill — docs change, and a stale cache hides that.
+
+This hook caches fetched content on disk, but **revalidates with the origin server on every reuse** via HTTP `If-None-Match` / `If-Modified-Since`. Content is only served from cache when the server responds `304 Not Modified`, which is a fresh verification — not a memory read.
+
+## Setup
+
+1. Add hooks to `.claude/settings.json` (or `.claude/settings.local.json` for personal use):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "WebFetch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PROJECT_DIR}/hooks/sdd-cache-pre.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "WebFetch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PROJECT_DIR}/hooks/sdd-cache-post.sh",
+            "async": true,
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+   `${CLAUDE_PROJECT_DIR}` resolves to the directory you launched Claude Code from. The snippet above works when the hooks live inside the same project. If you installed `agent-skills` elsewhere (e.g. as a shared plugin under `~/agent-skills`), replace `${CLAUDE_PROJECT_DIR}/hooks/...` with the absolute path to each script.
+
+2. Make sure `.claude/sdd-cache/` is in your `.gitignore` (already included in this repo).
+
+3. Use `/source-driven-development` (or the skill) as usual. No changes to the skill or the agent's workflow — the cache is transparent.
+
+## Mental model
+
+HTTP resource cache keyed by URL. Freshness is delegated to the origin via `ETag` / `Last-Modified`; no TTL, no prompt in the key.
+
+The stored body is not raw HTML — `WebFetch` post-processes each response through a model using the caller's prompt, so what we cache is one agent's reading of the page. The key stays URL-only so reads reuse across sessions; the original prompt is kept as metadata and surfaced in the hit message so the next agent can tell whether the earlier reading fits.
+
+## How it works
+
+One cache entry per URL, stored as JSON in `.claude/sdd-cache/<sha>.json`:
+
+| Event | Action |
+|---|---|
+| `PreToolUse WebFetch` | If an entry exists, sends a `HEAD` request with `If-None-Match` / `If-Modified-Since`. On `304`, blocks the fetch and returns the cached content to the agent via stderr, with the original prompt surfaced as metadata. Otherwise allows the fetch. |
+| `PostToolUse WebFetch` | Captures the response, issues a `HEAD` request to record the current `ETag` / `Last-Modified`, and stores `{url, prompt, etag, last_modified, content, fetched_at}`. |
+
+**Freshness rules:**
+
+- Entry is served only if the origin confirms `304 Not Modified`.
+- Entries without an `ETag` or `Last-Modified` header are never cached — without a validator, the hook cannot verify freshness later, and caching would mean trusting memory.
+- Cache key is `sha256(url)`. The same URL asked with a different prompt hits the same entry; the cached body reflects the prompt used on the first fetch, and that prompt is shown alongside the hit so the agent can decide whether to re-use or re-fetch manually.
+
+**What the agent sees:**
+
+- Cache hit: `WebFetch` is blocked via exit code 2. Claude Code delivers the hook's stderr payload back to the agent as a tool error — this is the intended signal for a cache hit, not a failure. The payload is prefixed with `[sdd-cache] Cache hit for <url>` and wraps the cached body between `----- BEGIN CACHED CONTENT -----` / `----- END CACHED CONTENT -----` markers so the agent can use it as if `WebFetch` had just returned it.
+- Cache miss or stale: `WebFetch` runs normally; the result is stored for next time.
+
+The skill itself is unchanged. It continues to follow `DETECT → FETCH → IMPLEMENT → CITE`. The hook only changes what happens under the hood when `FETCH` runs.
+
+## Local testing
+
+### 1. Smoke test the scripts directly
+
+```bash
+# Simulate a PostToolUse payload: cache a page
+echo '{
+  "tool_input": {
+    "url": "https://react.dev/reference/react/useActionState",
+    "prompt": "extract the signature"
+  },
+  "tool_response": "useActionState(action, initialState) returns [state, formAction, isPending]"
+}' | bash hooks/sdd-cache-post.sh
+
+# Inspect the stored entry
+ls .claude/sdd-cache/
+cat .claude/sdd-cache/*.json | jq .
+
+# Simulate the next PreToolUse on the same URL + prompt
+echo '{
+  "tool_input": {
+    "url": "https://react.dev/reference/react/useActionState",
+    "prompt": "extract the signature"
+  }
+}' | bash hooks/sdd-cache-pre.sh
+echo "exit=$?"
+```
+
+Expected:
+
+- First command creates one file under `.claude/sdd-cache/` (only if the server returned an `ETag` or `Last-Modified`).
+- Second command exits `2` with the cached content on stderr when the origin replies `304`, or exits `0` silently otherwise.
+
+### 2. End-to-end in a real session
+
+1. Register the hooks in `.claude/settings.local.json` as shown above.
+2. Start a Claude Code session in this repo.
+3. Ask the agent to fetch a documentation page (e.g. "fetch `https://react.dev/reference/react/useActionState` and summarize").
+4. Verify a file appears under `.claude/sdd-cache/`.
+5. Ask the agent to fetch the same page with the same prompt again.
+6. Verify the second `WebFetch` is blocked and the cached content is returned (visible in the session transcript as a tool error with `[sdd-cache]` prefix).
+
+### 3. Freshness verification
+
+To confirm the cache invalidates when docs change, force an `ETag` mismatch. Pick one specific entry — `*.json` is unsafe once the cache holds more than one file:
+
+```bash
+# Pick the entry you want to corrupt (swap in the actual filename)
+ENTRY=.claude/sdd-cache/e49c9f378670cfbb1d7d871b6dee16d9.json
+
+# Patch its ETag to something the origin will not recognize
+jq '.etag = "W/\"stale-etag-forced\""' "$ENTRY" > "$ENTRY.tmp" && mv "$ENTRY.tmp" "$ENTRY"
+
+# Next PreToolUse should miss (server returns 200, not 304)
+echo '{"tool_input":{"url":"...", "prompt":"..."}}' | bash hooks/sdd-cache-pre.sh
+echo "exit=$?"   # expect 0 (fetch allowed through)
+```
+
+### 4. Debugging
+
+Both hooks write timestamped events to `.claude/sdd-cache/.debug.log` when debug mode is on. Enable it with either:
+
+```bash
+# Option A: env var (per-session)
+SDD_CACHE_DEBUG=1 claude
+
+# Option B: sentinel file (persistent)
+mkdir -p .claude/sdd-cache && touch .claude/sdd-cache/.debug
+# …disable with: rm .claude/sdd-cache/.debug
+```
+
+The log captures URL, detected `tool_response` shape, HEAD status, and why each invocation hit or missed. Useful when a cache miss looks unexpected (typically: the origin stopped emitting validators).
+
+## Known limitations
+
+- **Body is prompt-shaped.** A hit returns the earlier agent's reading of the page, with the original prompt surfaced so the current agent can decide whether it applies. If it doesn't, delete the file under `.claude/sdd-cache/` to force a re-fetch.
+- **Every cache write costs an extra HEAD.** Claude Code doesn't expose the response headers that `WebFetch` already received, so the post hook re-queries the origin to capture `ETag` / `Last-Modified`. One extra roundtrip per miss — the price of keeping this a pure hook with no core changes.
+- **Servers without `ETag` or `Last-Modified` are never cached.** Most official doc sites (react.dev, docs.djangoproject.com, developer.mozilla.org) emit validators. Sites that don't are always re-fetched.
+- **A misbehaving server can serve a wrong `304`.** That's a server bug to diagnose, not a cache invariant to defend against; we don't paper over it with a TTL. Delete the entry if you spot a stale one.
+- **Cache is local and per-project.** There is no team-wide shared cache. Adding one would require a signed-content-addressable storage layer, which is out of scope.
+
+## Requirements
+
+- `jq`
+- `curl`
+- `shasum` or `sha256sum` (auto-detected)
+- Bash 3.2+

--- a/profiles/addyosmani_agent-skills/for-forgecat/hooks/SIMPLIFY-IGNORE.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/hooks/SIMPLIFY-IGNORE.md
@@ -1,0 +1,90 @@
+# simplify-ignore hook
+
+Block-level protection for `/code-simplify`. Mark code that should never be simplified — the model won't see it.
+
+## Setup
+
+1. Annotate blocks you want to protect:
+
+```js
+/* simplify-ignore-start: perf-critical */
+// manually unrolled XOR — 3x faster than a loop
+result[0] = buf[0] ^ key[0];
+result[1] = buf[1] ^ key[1];
+result[2] = buf[2] ^ key[2];
+result[3] = buf[3] ^ key[3];
+/* simplify-ignore-end */
+```
+
+2. Add hooks to `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [{ "type": "command", "command": "bash ${CLAUDE_PROJECT_DIR}/hooks/simplify-ignore.sh" }]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [{ "type": "command", "command": "bash ${CLAUDE_PROJECT_DIR}/hooks/simplify-ignore.sh" }]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [{ "type": "command", "command": "bash ${CLAUDE_PROJECT_DIR}/hooks/simplify-ignore.sh" }]
+      }
+    ]
+  }
+}
+```
+
+3. Run `/code-simplify` — protected blocks become `/* BLOCK_de115a1d: perf-critical */` placeholders. The model reasons about surrounding code without seeing the protected implementation.
+
+> **Note:** The hook stores temporary backups in `.claude/.simplify-ignore-cache/`. Make sure this path is in your `.gitignore`.
+
+## How it works
+
+One script, three hook events:
+
+| Event | Action |
+|---|---|
+| `PreToolUse Read` | Backs up file, replaces blocks with `BLOCK_<hash>` placeholders in-place |
+| `PostToolUse Edit\|Write` | Expands placeholders back to real code, saves model's changes, re-filters |
+| `Stop` | Restores all files from backup when session ends |
+
+Each block is content-hashed (8 hex chars via `shasum`/`sha1sum`) so the round-trip is unambiguous even if the model duplicates or reorders placeholders. Cache is project-scoped to prevent cross-session interference.
+
+## Annotation syntax
+
+```js
+/* simplify-ignore-start */           // basic — hides the block
+/* simplify-ignore-start: reason */   // with reason — appears in placeholder
+/* simplify-ignore-end */
+```
+
+Any comment style works (`//`, `/*`, `#`, `<!--`). Multiple blocks per file and single-line blocks supported. Placeholders preserve the original comment syntax (e.g. `# BLOCK_xxx` for Python, `<!-- BLOCK_xxx -->` for HTML).
+
+## Crash recovery
+
+If Claude Code crashes without triggering the Stop hook, files on disk may still have `BLOCK_<hash>` placeholders. To restore manually:
+
+```bash
+echo '{}' | bash hooks/simplify-ignore.sh
+```
+
+Backups are stored in `.claude/.simplify-ignore-cache/` within your project directory.
+
+## Known limitations
+
+- **Single-line blocks hide the entire line.** If `simplify-ignore-start` and `simplify-ignore-end` appear on the same line as other code, the whole line is hidden from the model, not just the annotated portion. Use dedicated lines for annotations.
+- **Comment suffix detection covers `*/` and `-->` only.** Template engines with non-standard comment closers (ERB `%>`, Blade `--}}`) may produce unbalanced placeholders. Use `#` or `//` style comments instead.
+- **Fallback expansion is progressive, not exact.** If the model alters a placeholder's formatting (e.g. changes the reason text), the hook tries progressively simpler matches: full placeholder → prefix+hash+suffix → hash-only. The hash-only fallback may leave cosmetic debris (e.g. stray `:` or reason text). A warning is printed to stderr when this happens.
+- **File renaming leaves placeholders.** If the model renames or moves a file via a shell command, the new file will retain `BLOCK_<hash>` placeholders. The original code is saved as `<old-filename>.recovered` when the session stops. You must manually restore the recovered code into the new file.
+
+## Requirements
+
+- `jq`, `shasum` or `sha1sum` (auto-detected), Bash 3.2+

--- a/profiles/addyosmani_agent-skills/for-forgecat/hooks/hooks.json
+++ b/profiles/addyosmani_agent-skills/for-forgecat/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/profiles/addyosmani_agent-skills/for-forgecat/hooks/sdd-cache-post.sh
+++ b/profiles/addyosmani_agent-skills/for-forgecat/hooks/sdd-cache-post.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# sdd-cache-post.sh — PostToolUse hook for WebFetch.
+#
+# After WebFetch, stores the response body in .claude/sdd-cache/<sha>.json
+# with the current ETag / Last-Modified captured via a HEAD request so the
+# pre hook can revalidate on the next fetch.
+#
+# Keyed by URL. The caller's prompt is stored as metadata (not part of the
+# key) so a future cache hit can show what question produced the cached
+# reading. Entries without ETag or Last-Modified are not cached.
+#
+# Dependencies: jq, curl, shasum (or sha256sum).
+
+set -euo pipefail
+
+command -v jq   >/dev/null 2>&1 || exit 0
+command -v curl >/dev/null 2>&1 || exit 0
+command -v shasum >/dev/null 2>&1 || command -v sha256sum >/dev/null 2>&1 || exit 0
+
+if [ -t 0 ]; then INPUT="{}"; else INPUT=$(cat); fi
+
+# Debug logging: active when SDD_CACHE_DEBUG=1 is set, or when a sentinel
+# file exists at .claude/sdd-cache/.debug. Toggle with `touch` / `rm`.
+dbg() {
+  local dir="${CLAUDE_PROJECT_DIR:-$PWD}/.claude/sdd-cache"
+  [ "${SDD_CACHE_DEBUG:-0}" = "1" ] || [ -f "$dir/.debug" ] || return 0
+  mkdir -p "$dir"
+  printf '%s [post] %s\n' "$(date -u +%FT%TZ)" "$*" >> "$dir/.debug.log"
+}
+dbg "fired, input=$(printf '%s' "$INPUT" | head -c 400)"
+
+URL=$(printf '%s'    "$INPUT" | jq -r '.tool_input.url    // empty' 2>/dev/null || true)
+PROMPT=$(printf '%s' "$INPUT" | jq -r '.tool_input.prompt // empty' 2>/dev/null || true)
+if [ -z "$URL" ]; then dbg "no url in tool_input, exit"; exit 0; fi
+dbg "url=$URL prompt=$(printf '%s' "$PROMPT" | head -c 80)"
+
+# WebFetch tool_response shape (Claude Code as of 2026-04): an object with
+# keys bytes, code, codeText, durationMs, result, url — content lives at
+# .result. The other keys (.output / .text / .content / .body) are kept as
+# defensive fallbacks in case the shape changes; jq returns empty if none
+# match. The string branch handles older/custom integrations.
+TOOL_RESPONSE_TYPE=$(printf '%s' "$INPUT" | jq -r '.tool_response | type' 2>/dev/null || echo "unknown")
+dbg "tool_response type=$TOOL_RESPONSE_TYPE keys=$(printf '%s' "$INPUT" | jq -r 'try (.tool_response | keys | join(",")) catch "n/a"' 2>/dev/null)"
+
+CONTENT=$(printf '%s' "$INPUT" | jq -r '
+  if (.tool_response | type) == "object" then
+    (.tool_response.result
+     // .tool_response.output
+     // .tool_response.text
+     // .tool_response.content
+     // .tool_response.body
+     // empty)
+  elif (.tool_response | type) == "string" then
+    .tool_response
+  else
+    empty
+  end
+' 2>/dev/null || true)
+
+if [ -z "$CONTENT" ]; then
+  dbg "could not extract content from tool_response, exit (shape unknown)"
+  exit 0
+fi
+dbg "extracted content bytes=${#CONTENT}"
+
+# Must match the pre hook: sha256(URL), first 32 hex chars.
+hash_key() {
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$1" | shasum -a 256 | cut -c1-32
+  else
+    printf '%s' "$1" | sha256sum | cut -c1-32
+  fi
+}
+
+CACHE_DIR="${CLAUDE_PROJECT_DIR:-$PWD}/.claude/sdd-cache"
+mkdir -p "$CACHE_DIR"
+CACHE_FILE="$CACHE_DIR/$(hash_key "$URL").json"
+
+# Capture validators from the origin. Follow redirects so they match the
+# URL the agent actually talked to. Strip CR so awk's paragraph mode
+# recognises blank separators between response blocks on a redirect chain.
+HEAD_OUT=$(curl -sI -L --max-time 5 "$URL" 2>/dev/null | tr -d '\r' || true)
+
+# Take only the final response's headers (last paragraph) to avoid picking
+# up validators from intermediate 301/302 hops.
+FINAL_HEADERS=$(printf '%s' "$HEAD_OUT" | awk '
+  BEGIN { RS = ""; last = "" }
+  { last = $0 }
+  END { print last }
+')
+
+extract_header() {
+  local name="$1"
+  printf '%s' "$FINAL_HEADERS" | awk -v h="$name" '
+    BEGIN { FS = ":" }
+    tolower($1) == tolower(h) {
+      sub(/^[^:]*:[ \t]*/, "")
+      sub(/[ \t]+$/, "")
+      print
+      exit
+    }
+  '
+}
+
+ETAG=$(extract_header "ETag")
+LAST_MOD=$(extract_header "Last-Modified")
+dbg "HEAD etag=$ETAG last_modified=$LAST_MOD"
+
+if [ -z "$ETAG" ] && [ -z "$LAST_MOD" ]; then
+  dbg "no validator from origin, removing any stale entry and exit"
+  rm -f "$CACHE_FILE"
+  exit 0
+fi
+
+NOW=$(date +%s)
+
+TMP="${CACHE_FILE}.$$.tmp"
+if jq -n \
+  --arg url           "$URL" \
+  --arg prompt        "$PROMPT" \
+  --arg etag          "$ETAG" \
+  --arg last_modified "$LAST_MOD" \
+  --arg content       "$CONTENT" \
+  --argjson fetched_at "$NOW" \
+  '{url: $url, prompt: $prompt, etag: $etag, last_modified: $last_modified, content: $content, fetched_at: $fetched_at}' \
+  > "$TMP"
+then
+  mv "$TMP" "$CACHE_FILE"
+  dbg "wrote cache file $CACHE_FILE"
+else
+  rm -f "$TMP"
+  dbg "jq failed, temp cleaned"
+fi
+
+exit 0

--- a/profiles/addyosmani_agent-skills/for-forgecat/hooks/sdd-cache-pre.sh
+++ b/profiles/addyosmani_agent-skills/for-forgecat/hooks/sdd-cache-pre.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# sdd-cache-pre.sh — PreToolUse hook for WebFetch.
+#
+# HTTP resource cache keyed by URL. Freshness is delegated to the origin via
+# HTTP validators; 304 Not Modified is the only signal to serve from cache.
+# On hit, exits 2 and writes the cached body to stderr so Claude Code can
+# deliver it to the agent in place of the WebFetch result. Otherwise exits 0.
+#
+# No TTL: if validators don't catch a change, nothing will. Entries without
+# ETag or Last-Modified are never cached (can't revalidate).
+#
+# Cached bodies are prompt-shaped (WebFetch post-processes through a model),
+# so the key is URL-only and the original prompt is surfaced in the hit
+# message so the next agent can tell if the earlier reading still applies.
+#
+# Dependencies: jq, curl, shasum (or sha256sum).
+
+set -euo pipefail
+
+# Graceful degradation: if any dependency is missing, let the fetch through.
+command -v jq   >/dev/null 2>&1 || exit 0
+command -v curl >/dev/null 2>&1 || exit 0
+command -v shasum >/dev/null 2>&1 || command -v sha256sum >/dev/null 2>&1 || exit 0
+
+if [ -t 0 ]; then INPUT="{}"; else INPUT=$(cat); fi
+
+# Debug logging: active when SDD_CACHE_DEBUG=1 is set, or when a sentinel
+# file exists at .claude/sdd-cache/.debug. Toggle with `touch` / `rm`.
+dbg() {
+  local dir="${CLAUDE_PROJECT_DIR:-$PWD}/.claude/sdd-cache"
+  [ "${SDD_CACHE_DEBUG:-0}" = "1" ] || [ -f "$dir/.debug" ] || return 0
+  mkdir -p "$dir"
+  printf '%s [pre]  %s\n' "$(date -u +%FT%TZ)" "$*" >> "$dir/.debug.log"
+}
+dbg "fired"
+
+URL=$(printf '%s' "$INPUT" | jq -r '.tool_input.url // empty' 2>/dev/null || true)
+if [ -z "$URL" ]; then dbg "no url in tool_input, exit"; exit 0; fi
+dbg "url=$URL"
+
+# Cache key is sha256(URL), truncated to 128 bits.
+hash_key() {
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$1" | shasum -a 256 | cut -c1-32
+  else
+    printf '%s' "$1" | sha256sum | cut -c1-32
+  fi
+}
+
+CACHE_DIR="${CLAUDE_PROJECT_DIR:-$PWD}/.claude/sdd-cache"
+CACHE_FILE="$CACHE_DIR/$(hash_key "$URL").json"
+
+if [ ! -f "$CACHE_FILE" ]; then dbg "no cache file at $CACHE_FILE, exit"; exit 0; fi
+dbg "cache file exists: $CACHE_FILE"
+
+FETCHED_AT=$(jq -r '.fetched_at // 0' "$CACHE_FILE" 2>/dev/null || echo 0)
+ORIGINAL_PROMPT=$(jq -r '.prompt // empty' "$CACHE_FILE" 2>/dev/null || true)
+ETAG=$(jq -r '.etag // empty' "$CACHE_FILE" 2>/dev/null || true)
+LAST_MOD=$(jq -r '.last_modified // empty' "$CACHE_FILE" 2>/dev/null || true)
+
+# No validator means we cannot verify freshness — never serve from cache.
+if [ -z "$ETAG" ] && [ -z "$LAST_MOD" ]; then
+  dbg "cached entry has no etag/last-modified, cannot revalidate, bypass"
+  exit 0
+fi
+
+HEADERS=()
+[ -n "$ETAG" ]     && HEADERS+=(-H "If-None-Match: $ETAG")
+[ -n "$LAST_MOD" ] && HEADERS+=(-H "If-Modified-Since: $LAST_MOD")
+
+STATUS=$(curl -sI -o /dev/null -w "%{http_code}" \
+  --max-time 5 -L \
+  "${HEADERS[@]}" \
+  "$URL" 2>/dev/null || echo "000")
+dbg "revalidation HEAD status=$STATUS"
+
+if [ "$STATUS" != "304" ]; then
+  dbg "not 304, letting WebFetch proceed"
+  exit 0
+fi
+
+# Server confirmed content unchanged. Serve cached copy to the agent.
+CONTENT=$(jq -r '.content // empty' "$CACHE_FILE" 2>/dev/null || true)
+if [ -z "$CONTENT" ]; then dbg "cache file has empty content field, bypass"; exit 0; fi
+dbg "cache HIT, blocking WebFetch with ${#CONTENT} bytes of cached content"
+
+VERIFIED_AT_ISO=$(date -u -r "$FETCHED_AT" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+              || date -u -d "@$FETCHED_AT" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+              || echo "unknown")
+
+# Emit the payload with printf so $CONTENT is never interpreted by the shell
+# (docs contain backticks, $vars, and backslashes in code examples; an
+# unquoted heredoc would treat them as command substitution).
+{
+  printf '[sdd-cache] Cache hit for %s\n\n' "$URL"
+  printf 'Revalidated via HTTP 304; unchanged since %s. Use the cached\n' "$VERIFIED_AT_ISO"
+  printf 'content below as if WebFetch had just returned it.\n\n'
+  if [ -n "$ORIGINAL_PROMPT" ]; then
+    printf 'Original WebFetch prompt: "%s". If your angle differs, judge\n' "$ORIGINAL_PROMPT"
+    printf 'whether this reading still covers it.\n\n'
+  fi
+  printf -- '----- BEGIN CACHED CONTENT -----\n'
+  printf '%s\n' "$CONTENT"
+  printf -- '----- END CACHED CONTENT -----\n'
+} >&2
+exit 2

--- a/profiles/addyosmani_agent-skills/for-forgecat/hooks/session-start.sh
+++ b/profiles/addyosmani_agent-skills/for-forgecat/hooks/session-start.sh
@@ -1,20 +1,36 @@
 #!/bin/bash
 # agent-skills session start hook
-# Injects the using-agent-skills meta-skill into every new session
+# Injects the using-agent-skills meta-skill into every new session.
+
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-SKILLS_DIR="$(dirname "$SCRIPT_DIR")/skills"
-META_SKILL="$SKILLS_DIR/using-agent-skills/SKILL.md"
+PROFILE_DIR="$(dirname "$SCRIPT_DIR")"
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
 
-if [ -f "$META_SKILL" ]; then
-  if command -v jq >/dev/null 2>&1; then
-    jq -Rs \
-      --arg prefix "agent-skills loaded. Use the skill discovery flowchart to find the right skill for your task.\n\n" \
-      '{priority: "IMPORTANT", message: ($prefix + .)}' \
-      "$META_SKILL"
-  else
-    echo '{"priority": "IMPORTANT", "message": "agent-skills loaded. Use the skill discovery flowchart to find the right skill for your task."}'
-  fi
+find_meta_skill() {
+  for candidate in \
+    "$PROFILE_DIR/skills/using-agent-skills/SKILL.md" \
+    "$PROJECT_DIR/.claude/skills/using-agent-skills/SKILL.md" \
+    "$PROJECT_DIR/.agents/skills/using-agent-skills/SKILL.md"
+  do
+    [ -f "$candidate" ] && printf '%s\n' "$candidate" && return 0
+  done
+  return 1
+}
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo '{"priority": "INFO", "message": "agent-skills: jq is required for the session-start hook but was not found on PATH. Install jq to enable meta-skill injection. Skills remain available individually."}'
+  exit 0
+fi
+
+if META_SKILL="$(find_meta_skill)"; then
+  CONTENT="$(cat "$META_SKILL")"
+  jq -cn \
+    --arg message "agent-skills loaded. Use the skill discovery flowchart to find the right skill for your task.
+
+$CONTENT" \
+    '{priority: "IMPORTANT", message: $message}'
 else
   echo '{"priority": "INFO", "message": "agent-skills: using-agent-skills meta-skill not found. Skills may still be available individually."}'
 fi

--- a/profiles/addyosmani_agent-skills/for-forgecat/hooks/session-start.sh
+++ b/profiles/addyosmani_agent-skills/for-forgecat/hooks/session-start.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# agent-skills session start hook
+# Injects the using-agent-skills meta-skill into every new session
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILLS_DIR="$(dirname "$SCRIPT_DIR")/skills"
+META_SKILL="$SKILLS_DIR/using-agent-skills/SKILL.md"
+
+if [ -f "$META_SKILL" ]; then
+  if command -v jq >/dev/null 2>&1; then
+    jq -Rs \
+      --arg prefix "agent-skills loaded. Use the skill discovery flowchart to find the right skill for your task.\n\n" \
+      '{priority: "IMPORTANT", message: ($prefix + .)}' \
+      "$META_SKILL"
+  else
+    echo '{"priority": "IMPORTANT", "message": "agent-skills loaded. Use the skill discovery flowchart to find the right skill for your task."}'
+  fi
+else
+  echo '{"priority": "INFO", "message": "agent-skills: using-agent-skills meta-skill not found. Skills may still be available individually."}'
+fi

--- a/profiles/addyosmani_agent-skills/for-forgecat/hooks/simplify-ignore.sh
+++ b/profiles/addyosmani_agent-skills/for-forgecat/hooks/simplify-ignore.sh
@@ -1,0 +1,302 @@
+#!/bin/bash
+# simplify-ignore.sh — Hook for Read (PreToolUse), Edit|Write (PostToolUse), Stop
+#
+# PreToolUse Read   → backs up file, replaces blocks with BLOCK_<hash> in-place
+# PostToolUse Edit  → expands placeholders, re-filters so file stays hidden
+# PostToolUse Write → expands placeholders, re-filters so file stays hidden
+# Stop              → restores real file content from backup
+#
+# The file on disk ALWAYS has placeholders while the session is active.
+# The real content (with model's changes applied) lives in the backup.
+#
+# Dependencies: jq, shasum or sha1sum (auto-detected)
+
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf '%s\n' "error: missing jq" >&2; exit 1
+fi
+
+CACHE="${CLAUDE_PROJECT_DIR:-.}/.claude/.simplify-ignore-cache"
+if [ -t 0 ]; then INPUT="{}"; else INPUT=$(cat); fi
+
+# Parse hook input — trap errors explicitly so set -e doesn't cause
+# a silent exit on malformed JSON, and surface a useful diagnostic.
+parse_error=""
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null) || {
+  parse_error="failed to parse .tool_name from hook input"
+  TOOL_NAME=""
+}
+FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || {
+  parse_error="failed to parse .tool_input.file_path from hook input"
+  FILE_PATH=""
+}
+if [ -n "$parse_error" ]; then
+  printf 'Warning: %s (input: %.120s)\n' "$parse_error" "$INPUT" >&2
+fi
+
+hash_cmd() {
+  if command -v shasum >/dev/null 2>&1; then shasum
+  elif command -v sha1sum >/dev/null 2>&1; then sha1sum
+  else printf '%s\n' "error: missing shasum or sha1sum" >&2; exit 1; fi
+}
+file_id() { printf '%s' "$1" | hash_cmd | cut -c1-16; }
+block_hash() { printf '%s' "$1" | hash_cmd | cut -c1-8; }
+# Escape glob metacharacters so ${var/pattern/repl} treats pattern as literal.
+# Needed for Bash 3.2 (macOS) where quotes don't suppress globbing in PE patterns.
+escape_glob() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\*/\\*}"
+  s="${s//\?/\\?}"
+  s="${s//\[/\\[}"
+  printf '%s' "$s"
+}
+
+# ── filter_file: replace simplify-ignore blocks with BLOCK_<hash> placeholders ─
+# Reads $1 (source), writes filtered version to $2 (dest), saves blocks to cache.
+# Returns 0 if blocks were found, 1 if none.
+filter_file() {
+  local src="$1" dest="$2" fid="$3"
+  : > "$dest"
+  rm -f "$CACHE/${fid}".block.* "$CACHE/${fid}".reason.* "$CACHE/${fid}".prefix.* "$CACHE/${fid}".suffix.*
+
+  local count=0 in_block=0 buf="" reason="" prefix="" suffix=""
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    # Check for start marker (no fork — uses bash case)
+    if [ $in_block -eq 0 ]; then
+      case "$line" in *simplify-ignore-start*)
+        in_block=1
+        buf="$line"
+        # Extract comment prefix/suffix to preserve language-appropriate syntax
+        prefix="${line%%simplify-ignore-start*}"
+        suffix=""
+        case "$line" in *'*/'*) suffix=" */" ;; *'-->'*) suffix=" -->" ;; esac
+        reason=$(printf '%s' "$line" | sed -n 's/.*simplify-ignore-start:[[:space:]]*//p' \
+          | sed 's/[[:space:]]*\*\/.*$//' | sed 's/[[:space:]]*-->.*$//' | sed 's/[[:space:]]*$//')
+        # Handle single-line block (start + end on same line)
+        case "$line" in *simplify-ignore-end*)
+          in_block=0
+          # Write single-line block immediately and skip to next line
+          # to avoid the end-marker check below firing again
+          local h; h=$(block_hash "$buf")
+          count=$((count + 1))
+          printf '%s' "$buf" > "$CACHE/${fid}.block.${h}"
+          [ -n "$reason" ] && printf '%s' "$reason" > "$CACHE/${fid}.reason.${h}"
+          printf '%s' "$prefix" > "$CACHE/${fid}.prefix.${h}"
+          printf '%s' "$suffix" > "$CACHE/${fid}.suffix.${h}"
+          if [ -n "$reason" ]; then
+            printf '%s\n' "${prefix}BLOCK_${h}: ${reason}${suffix}" >> "$dest"
+          else
+            printf '%s\n' "${prefix}BLOCK_${h}${suffix}" >> "$dest"
+          fi
+          buf=""; reason=""; prefix=""; suffix=""
+          continue
+          ;; *)
+          continue
+          ;;
+        esac
+      ;; esac
+    fi
+    # Accumulate block content
+    if [ $in_block -eq 1 ]; then
+      buf="${buf}
+${line}"
+    fi
+    # Check for end marker
+    case "$line" in *simplify-ignore-end*)
+      if [ $in_block -eq 1 ]; then
+        local h; h=$(block_hash "$buf")
+        count=$((count + 1))
+        printf '%s' "$buf" > "$CACHE/${fid}.block.${h}"
+        [ -n "$reason" ] && printf '%s' "$reason" > "$CACHE/${fid}.reason.${h}"
+        printf '%s' "$prefix" > "$CACHE/${fid}.prefix.${h}"
+        printf '%s' "$suffix" > "$CACHE/${fid}.suffix.${h}"
+        if [ -n "$reason" ]; then
+          printf '%s\n' "${prefix}BLOCK_${h}: ${reason}${suffix}" >> "$dest"
+        else
+          printf '%s\n' "${prefix}BLOCK_${h}${suffix}" >> "$dest"
+        fi
+        in_block=0; buf=""; reason=""; prefix=""; suffix=""
+        continue
+      fi
+      ;;
+    esac
+    [ $in_block -eq 0 ] && printf '%s\n' "$line" >> "$dest"
+  done < "$src"
+
+  # Unclosed block → flush as-is
+  if [ $in_block -eq 1 ] && [ -n "$buf" ]; then
+    printf 'Warning: unclosed simplify-ignore-start in %s (block not hidden)\n' "$src" >&2
+    printf '%s\n' "$buf" >> "$dest"
+  fi
+
+  # Preserve trailing newline status of source
+  if [ -s "$dest" ] && [ -s "$src" ] && [ -n "$(tail -c 1 "$src")" ]; then
+    perl -pe 'chomp if eof' "$dest" > "${dest}.nnl" && \
+      cat "${dest}.nnl" > "$dest" && rm -f "${dest}.nnl"
+  fi
+
+  [ $count -gt 0 ] && return 0 || return 1
+}
+
+# ── Stop: restore all files from backup ───────────────────────────────────────
+if [ -z "$TOOL_NAME" ]; then
+  [ -d "$CACHE" ] || exit 0
+  for bak in "$CACHE"/*.bak; do
+    [ -f "$bak" ] || continue
+    fid="${bak##*/}"; fid="${fid%.bak}"
+    pathfile="$CACHE/${fid}.path"
+    [ -f "$pathfile" ] || { rm -f "$bak"; continue; }
+    orig=$(cat "$pathfile")
+    if [ -f "$orig" ]; then
+      cat "$bak" > "$orig"
+      rm -f "$bak" "$pathfile" "$CACHE/${fid}".block.* "$CACHE/${fid}".reason.* "$CACHE/${fid}".prefix.* "$CACHE/${fid}".suffix.*
+      rmdir "$CACHE/${fid}.lock" 2>/dev/null
+    else
+      # File was moved/deleted — save backup as .recovered, don't destroy it
+      mkdir -p "$(dirname "${orig}.recovered")"
+      mv "$bak" "${orig}.recovered"
+      rm -f "$pathfile" "$CACHE/${fid}".block.* "$CACHE/${fid}".reason.* "$CACHE/${fid}".prefix.* "$CACHE/${fid}".suffix.*
+      rmdir "$CACHE/${fid}.lock" 2>/dev/null
+      printf 'Warning: %s was moved/deleted. Recovered original to %s.recovered\n' "$orig" "$orig" >&2
+    fi
+  done
+  # Clean orphan locks (created but crash before backup)
+  for lockdir in "$CACHE"/*.lock; do
+    [ -d "$lockdir" ] || continue
+    rmdir "$lockdir" 2>/dev/null
+  done
+  exit 0
+fi
+
+[ -z "$FILE_PATH" ] && exit 0
+
+# ── PreToolUse Read: filter in-place ──────────────────────────────────────────
+if [ "$TOOL_NAME" = "Read" ]; then
+  [ -f "$FILE_PATH" ] || exit 0
+  case "$(basename "$FILE_PATH")" in simplify-ignore*|SIMPLIFY-IGNORE*) exit 0 ;; esac
+
+  mkdir -p "$CACHE"
+  ID=$(file_id "$FILE_PATH")
+
+  # If backup exists, file is already filtered — skip
+  [ -f "$CACHE/${ID}.bak" ] && exit 0
+
+  grep -q 'simplify-ignore-start' -- "$FILE_PATH" || exit 0
+
+  # Atomic lock: mkdir fails if another session races us
+  if ! mkdir "$CACHE/${ID}.lock" 2>/dev/null; then
+    # Lock exists — reclaim only if stale (>60s old, no backup = crash leftover)
+    if [ ! -f "$CACHE/${ID}.bak" ] && \
+       [ -n "$(find "$CACHE/${ID}.lock" -maxdepth 0 -mmin +1 2>/dev/null)" ]; then
+      rmdir "$CACHE/${ID}.lock" 2>/dev/null || true
+      mkdir "$CACHE/${ID}.lock" 2>/dev/null || exit 0
+    else
+      exit 0
+    fi
+  fi
+
+  # Back up the original (preserve trailing newline status)
+  cp -p "$FILE_PATH" "$CACHE/${ID}.bak" 2>/dev/null || cp "$FILE_PATH" "$CACHE/${ID}.bak"
+  printf '%s' "$FILE_PATH" > "$CACHE/${ID}.path"
+
+  # Filter in-place (cat > preserves inode and permissions)
+  FILTERED="$CACHE/${ID}.$$.tmp"
+  rm -f "$FILTERED"
+  if filter_file "$FILE_PATH" "$FILTERED" "$ID"; then
+    cat "$FILTERED" > "$FILE_PATH"
+    rm -f "$FILTERED"
+  else
+    rm -f "$FILTERED" "$CACHE/${ID}.bak" "$CACHE/${ID}.path"
+    rmdir "$CACHE/${ID}.lock" 2>/dev/null
+  fi
+  exit 0
+fi
+
+# ── PostToolUse Edit|Write: expand, then re-filter ────────────────────────────
+if [ "$TOOL_NAME" = "Edit" ] || [ "$TOOL_NAME" = "Write" ]; then
+  ID=$(file_id "$FILE_PATH")
+  [ -f "$CACHE/${ID}.bak" ] || exit 0
+  ls "$CACHE/${ID}".block.* >/dev/null 2>&1 || exit 0
+
+  # Expand placeholders, preserving any inline code the model added around them
+  EXPANDED="$CACHE/${ID}.$$.expanded"
+  rm -f "$EXPANDED"
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in *BLOCK_*)
+      # Expand all placeholders on this line (supports multiple per line)
+      for bf in "$CACHE/${ID}".block.*; do
+        [ -f "$bf" ] || continue
+        h="${bf##*.}"
+        case "$line" in *"BLOCK_${h}"*)
+          # Reconstruct the exact placeholder pattern
+          bp=""; bs=""; br=""
+          [ -f "$CACHE/${ID}.prefix.${h}" ] && bp=$(cat "$CACHE/${ID}.prefix.${h}")
+          [ -f "$CACHE/${ID}.suffix.${h}" ] && bs=$(cat "$CACHE/${ID}.suffix.${h}")
+          [ -f "$CACHE/${ID}.reason.${h}" ] && br=$(cat "$CACHE/${ID}.reason.${h}")
+          if [ -n "$br" ]; then
+            placeholder="${bp}BLOCK_${h}: ${br}${bs}"
+          else
+            placeholder="${bp}BLOCK_${h}${bs}"
+          fi
+          block_content=$(cat "$bf"; printf x); block_content="${block_content%x}"
+          # Escape glob metacharacters (* ? [ \) in the pattern
+          esc_placeholder=$(escape_glob "$placeholder")
+          # Bash native substitution (// = global replace): replace placeholder, keep surrounding code
+          line="${line//$esc_placeholder/$block_content}"
+          # Fallback: if model altered the reason text, try without reason
+          # (only trigger if BLOCK_hash is still present AND wasn't in the original block content)
+          case "$block_content" in *"BLOCK_${h}"*) ;; *)
+            case "$line" in *"BLOCK_${h}"*)
+              printf 'Warning: placeholder BLOCK_%s was modified by model, using fuzzy match\n' "$h" >&2
+              esc_fuzzy=$(escape_glob "${bp}BLOCK_${h}${bs}")
+              line="${line//$esc_fuzzy/$block_content}"
+              # Last resort: match just the hash token
+              case "$line" in *"BLOCK_${h}"*)
+                line="${line//BLOCK_${h}/$block_content}"
+              ;; esac
+            ;; esac
+          ;; esac
+        ;; esac
+      done
+    ;; esac
+    printf '%s\n' "$line" >> "$EXPANDED"
+  done < "$FILE_PATH"
+  # Preserve trailing newline status
+  if [ -s "$EXPANDED" ] && [ -s "$FILE_PATH" ] && [ -n "$(tail -c 1 "$FILE_PATH")" ]; then
+    perl -pe 'chomp if eof' "$EXPANDED" > "${EXPANDED}.nnl" && \
+      cat "${EXPANDED}.nnl" > "$EXPANDED" && rm -f "${EXPANDED}.nnl"
+  fi
+  # Warn if model deleted a protected block entirely
+  for bf in "$CACHE/${ID}".block.*; do
+    [ -f "$bf" ] || continue
+    bh="${bf##*.}"
+    # After expansion, blocks appear as original code (simplify-ignore-start).
+    # If neither the expanded code nor the placeholder is in EXPANDED, it was deleted.
+    if ! grep -qF "BLOCK_${bh}" "$EXPANDED" 2>/dev/null; then
+      # Get first line of block to check if it was expanded back
+      first_line=$(head -1 "$bf")
+      if ! grep -qF "$first_line" "$EXPANDED" 2>/dev/null; then
+        printf 'Warning: protected block BLOCK_%s was deleted by model\n' "$bh" >&2
+      fi
+    fi
+  done
+  # Preserve inode and permissions
+  cat "$EXPANDED" > "$FILE_PATH"
+  rm -f "$EXPANDED"
+
+  # Save expanded version as new backup (this is the "real" file with model's changes)
+  cp "$FILE_PATH" "$CACHE/${ID}.bak"
+
+  # Re-filter in-place so the file on disk stays with placeholders
+  FILTERED="$CACHE/${ID}.$$.tmp"
+  rm -f "$FILTERED"
+  if filter_file "$FILE_PATH" "$FILTERED" "$ID"; then
+    cat "$FILTERED" > "$FILE_PATH"
+    rm -f "$FILTERED"
+  fi
+
+  exit 0
+fi

--- a/profiles/addyosmani_agent-skills/for-forgecat/profile.yml
+++ b/profiles/addyosmani_agent-skills/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: addyosmani_agent-skills
-version: 0.0.0
+version: 0.0.1
 description: Production-grade engineering skills for AI coding agents covering the
   full software development lifecycle from spec to ship.
 repository: https://github.com/addyosmani/agent-skills
@@ -15,6 +15,37 @@ compatibility:
   models:
     recommended: []
     minimum: []
+hooks:
+- id: agent-skills-session-start
+  trigger: session_start
+  command: ./hooks/session-start.sh
+  description: Inject the using-agent-skills meta-skill into each new Claude Code
+    session.
+  platforms:
+  - claude-code
+- id: simplify-ignore-before-read
+  trigger: pre_tool_use
+  tool_match: Read
+  command: ./hooks/simplify-ignore.sh
+  description: Replace simplify-ignore blocks with placeholders before Claude Code
+    reads a file.
+  platforms:
+  - claude-code
+- id: simplify-ignore-after-edit
+  trigger: post_tool_use
+  tool_match: Edit|Write
+  command: ./hooks/simplify-ignore.sh
+  description: Restore simplify-ignore placeholders after Claude Code edits or writes
+    a file.
+  platforms:
+  - claude-code
+- id: simplify-ignore-stop-restore
+  trigger: stop
+  command: ./hooks/simplify-ignore.sh
+  description: Restore simplify-ignore protected file contents when the Claude Code
+    response stops.
+  platforms:
+  - claude-code
 skills:
 - name: api-and-interface-design
   path: skills/api-and-interface-design/SKILL.md

--- a/profiles/addyosmani_agent-skills/for-forgecat/profile.yml
+++ b/profiles/addyosmani_agent-skills/for-forgecat/profile.yml
@@ -1,170 +1,226 @@
 name: addyosmani_agent-skills
-version: 0.0.1
-description: Production-grade engineering skills for AI coding agents covering the
-  full software development lifecycle from spec to ship.
+version: 0.0.2
+description: Production-grade engineering skills for AI coding agents covering the full software
+  development lifecycle from spec to ship.
 repository: https://github.com/addyosmani/agent-skills
 license: MIT
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:
-    - claude-code
+      - claude-code
     partial:
-    - cursor
-    - codex
+      - cursor
+      - codex
   models:
     recommended: []
     minimum: []
 hooks:
-- id: agent-skills-session-start
-  trigger: session_start
-  command: ./hooks/session-start.sh
-  description: Inject the using-agent-skills meta-skill into each new Claude Code
-    session.
-  platforms:
-  - claude-code
-- id: simplify-ignore-before-read
-  trigger: pre_tool_use
-  tool_match: Read
-  command: ./hooks/simplify-ignore.sh
-  description: Replace simplify-ignore blocks with placeholders before Claude Code
-    reads a file.
-  platforms:
-  - claude-code
-- id: simplify-ignore-after-edit
-  trigger: post_tool_use
-  tool_match: Edit|Write
-  command: ./hooks/simplify-ignore.sh
-  description: Restore simplify-ignore placeholders after Claude Code edits or writes
-    a file.
-  platforms:
-  - claude-code
-- id: simplify-ignore-stop-restore
-  trigger: stop
-  command: ./hooks/simplify-ignore.sh
-  description: Restore simplify-ignore protected file contents when the Claude Code
-    response stops.
-  platforms:
-  - claude-code
+  - id: agent-skills-session-start
+    trigger: session_start
+    command: ./hooks/session-start.sh
+    description: Inject the using-agent-skills meta-skill into each new Claude Code session.
+    platforms:
+      - claude-code
+  - id: simplify-ignore-before-read
+    trigger: pre_tool_use
+    tool_match: Read
+    command: ./hooks/simplify-ignore.sh
+    description: Replace simplify-ignore blocks with placeholders before Claude Code reads a file.
+    platforms:
+      - claude-code
+  - id: simplify-ignore-after-edit
+    trigger: post_tool_use
+    tool_match: Edit|Write
+    command: ./hooks/simplify-ignore.sh
+    description: Restore simplify-ignore placeholders after Claude Code edits or writes a file.
+    platforms:
+      - claude-code
+  - id: simplify-ignore-stop-restore
+    trigger: stop
+    command: ./hooks/simplify-ignore.sh
+    description: Restore simplify-ignore protected file contents when the Claude Code response stops.
+    platforms:
+      - claude-code
+  - id: sdd-cache-before-webfetch
+    trigger: pre_tool_use
+    tool_match: WebFetch
+    command: ./hooks/sdd-cache-pre.sh
+    timeout: 10
+    description: Serve verified source-driven-development WebFetch cache hits before Claude Code fetches
+      documentation.
+    platforms:
+      - claude-code
+  - id: sdd-cache-after-webfetch
+    trigger: post_tool_use
+    tool_match: WebFetch
+    command: ./hooks/sdd-cache-post.sh
+    timeout: 10
+    description: Capture WebFetch documentation responses for source-driven-development cache revalidation.
+    platforms:
+      - claude-code
 skills:
-- name: api-and-interface-design
-  path: skills/api-and-interface-design/SKILL.md
-  description: Guides stable API and interface design. Use when designing APIs, module
-    boundaries, or any public interface. Use when creating REST or GraphQL endpoints,
-    defining type contracts between modules, or establishing boundaries between frontend
-    and backend.
-- name: browser-testing-with-devtools
-  path: skills/browser-testing-with-devtools/SKILL.md
-  description: Tests in real browsers. Use when building or debugging anything that
-    runs in a browser. Use when you need to inspect the DOM, capture console errors,
-    analyze network requests, profile performance, or verify visual output with real
-    runtime data via Chrome DevTools MCP.
-- name: ci-cd-and-automation
-  path: skills/ci-cd-and-automation/SKILL.md
-  description: Automates CI/CD pipeline setup. Use when setting up or modifying build
-    and deployment pipelines. Use when you need to automate quality gates, configure
-    test runners in CI, or establish deployment strategies.
-- name: code-review-and-quality
-  path: skills/code-review-and-quality/SKILL.md
-  description: Conducts multi-axis code review. Use before merging any change. Use
-    when reviewing code written by yourself, another agent, or a human. Use when you
-    need to assess code quality across multiple dimensions before it enters the main
-    branch.
-- name: code-simplification
-  path: skills/code-simplification/SKILL.md
-  description: Simplifies code for clarity. Use when refactoring code for clarity
-    without changing behavior. Use when code works but is harder to read, maintain,
-    or extend than it should be. Use when reviewing code that has accumulated unnecessary
-    complexity.
-- name: context-engineering
-  path: skills/context-engineering/SKILL.md
-  description: Optimizes agent context setup. Use when starting a new session, when
-    agent output quality degrades, when switching between tasks, or when you need
-    to configure rules files and context for a project.
-- name: debugging-and-error-recovery
-  path: skills/debugging-and-error-recovery/SKILL.md
-  description: Guides systematic root-cause debugging. Use when tests fail, builds
-    break, behavior doesn't match expectations, or you encounter any unexpected error.
-    Use when you need a systematic approach to finding and fixing the root cause rather
-    than guessing.
-- name: deprecation-and-migration
-  path: skills/deprecation-and-migration/SKILL.md
-  description: Manages deprecation and migration. Use when removing old systems, APIs,
-    or features. Use when migrating users from one implementation to another. Use
-    when deciding whether to maintain or sunset existing code.
-- name: documentation-and-adrs
-  path: skills/documentation-and-adrs/SKILL.md
-  description: Records decisions and documentation. Use when making architectural
-    decisions, changing public APIs, shipping features, or when you need to record
-    context that future engineers and agents will need to understand the codebase.
-- name: frontend-ui-engineering
-  path: skills/frontend-ui-engineering/SKILL.md
-  description: Builds production-quality UIs. Use when building or modifying user-facing
-    interfaces. Use when creating components, implementing layouts, managing state,
-    or when the output needs to look and feel production-quality rather than AI-generated.
-- name: git-workflow-and-versioning
-  path: skills/git-workflow-and-versioning/SKILL.md
-  description: Structures git workflow practices. Use when making any code change.
-    Use when committing, branching, resolving conflicts, or when you need to organize
-    work across multiple parallel streams.
-- name: idea-refine
-  path: skills/idea-refine/SKILL.md
-  description: Refines ideas iteratively. Refine ideas through structured divergent
-    and convergent thinking. Use "idea-refine" or "ideate" to trigger.
-- name: incremental-implementation
-  path: skills/incremental-implementation/SKILL.md
-  description: Delivers changes incrementally. Use when implementing any feature or
-    change that touches more than one file. Use when you're about to write a large
-    amount of code at once, or when a task feels too big to land in one step.
-- name: performance-optimization
-  path: skills/performance-optimization/SKILL.md
-  description: Optimizes application performance. Use when performance requirements
-    exist, when you suspect performance regressions, or when Core Web Vitals or load
-    times need improvement. Use when profiling reveals bottlenecks that need fixing.
-- name: planning-and-task-breakdown
-  path: skills/planning-and-task-breakdown/SKILL.md
-  description: Breaks work into ordered tasks. Use when you have a spec or clear requirements
-    and need to break work into implementable tasks. Use when a task feels too large
-    to start, when you need to estimate scope, or when parallel work is possible.
-- name: security-and-hardening
-  path: skills/security-and-hardening/SKILL.md
-  description: Hardens code against vulnerabilities. Use when handling user input,
-    authentication, data storage, or external integrations. Use when building any
-    feature that accepts untrusted data, manages user sessions, or interacts with
-    third-party services.
-- name: shipping-and-launch
-  path: skills/shipping-and-launch/SKILL.md
-  description: Prepares production launches. Use when preparing to deploy to production.
-    Use when you need a pre-launch checklist, when setting up monitoring, when planning
-    a staged rollout, or when you need a rollback strategy.
-- name: spec-driven-development
-  path: skills/spec-driven-development/SKILL.md
-  description: Creates specs before coding. Use when starting a new project, feature,
-    or significant change and no specification exists yet. Use when requirements are
-    unclear, ambiguous, or only exist as a vague idea.
-- name: test-driven-development
-  path: skills/test-driven-development/SKILL.md
-  description: Drives development with tests. Use when implementing any logic, fixing
-    any bug, or changing any behavior. Use when you need to prove that code works,
-    when a bug report arrives, or when you're about to modify existing functionality.
-- name: using-agent-skills
-  path: skills/using-agent-skills/SKILL.md
-  description: Discovers and invokes agent skills. Use when starting a session or
-    when you need to discover which skill applies to the current task. This is the
-    meta-skill that governs how all other skills are discovered and invoked.
+  - name: api-and-interface-design
+    path: skills/api-and-interface-design
+    description: Guides stable API and interface design. Use when designing APIs, module boundaries, or
+      any public interface. Use when creating REST or GraphQL endpoints, defining type contracts
+      between modules, or establishing boundaries between frontend and backend.
+  - name: browser-testing-with-devtools
+    path: skills/browser-testing-with-devtools
+    description: Tests in real browsers via Chrome DevTools MCP. Use when building or debugging anything
+      that runs in a browser. Use when you need to inspect the DOM, capture console errors, analyze
+      network requests, profile performance, or verify visual output with real runtime data.
+      Requires the chrome-devtools MCP server to be configured.
+  - name: ci-cd-and-automation
+    path: skills/ci-cd-and-automation
+    description: Automates CI/CD pipeline setup. Use when setting up or modifying build and deployment
+      pipelines. Use when you need to automate quality gates, configure test runners in CI, or
+      establish deployment strategies.
+  - name: code-review-and-quality
+    path: skills/code-review-and-quality
+    description: Conducts multi-axis code review. Use before merging any change. Use when reviewing code
+      written by yourself, another agent, or a human. Use when you need to assess code quality
+      across multiple dimensions before it enters the main branch.
+  - name: code-simplification
+    path: skills/code-simplification
+    description: Simplifies code for clarity. Use when refactoring code for clarity without changing
+      behavior. Use when code works but is harder to read, maintain, or extend than it should be.
+      Use when reviewing code that has accumulated unnecessary complexity.
+  - name: context-engineering
+    path: skills/context-engineering
+    description: Optimizes agent context setup. Use when starting a new session, when agent output
+      quality degrades, when switching between tasks, or when you need to configure rules files and
+      context for a project.
+  - name: debugging-and-error-recovery
+    path: skills/debugging-and-error-recovery
+    description: Guides systematic root-cause debugging. Use when tests fail, builds break, behavior
+      doesn't match expectations, or you encounter any unexpected error. Use when you need a
+      systematic approach to finding and fixing the root cause rather than guessing.
+  - name: deprecation-and-migration
+    path: skills/deprecation-and-migration
+    description: Manages deprecation and migration. Use when removing old systems, APIs, or features.
+      Use when migrating users from one implementation to another. Use when deciding whether to
+      maintain or sunset existing code.
+  - name: documentation-and-adrs
+    path: skills/documentation-and-adrs
+    description: Records decisions and documentation. Use when making architectural decisions, changing
+      public APIs, shipping features, or when you need to record context that future engineers and
+      agents will need to understand the codebase.
+  - name: doubt-driven-development
+    path: skills/doubt-driven-development
+    description: Subjects every non-trivial decision to a fresh-context adversarial review before it
+      stands. Use when correctness matters more than speed, when working in unfamiliar code, when
+      stakes are high (production, security-sensitive logic, irreversible operations), or any time a
+      confident output would be cheaper to verify now than to debug later.
+  - name: frontend-ui-engineering
+    path: skills/frontend-ui-engineering
+    description: Builds production-quality UIs. Use when building or modifying user-facing interfaces.
+      Use when creating components, implementing layouts, managing state, or when the output needs
+      to look and feel production-quality rather than AI-generated.
+  - name: git-workflow-and-versioning
+    path: skills/git-workflow-and-versioning
+    description: Structures git workflow practices. Use when making any code change. Use when
+      committing, branching, resolving conflicts, or when you need to organize work across multiple
+      parallel streams.
+  - name: idea-refine
+    path: skills/idea-refine
+    description: Refines raw ideas into sharp, actionable concepts through structured divergent and
+      convergent thinking. Use when an idea is still vague, when you need to stress-test assumptions
+      before committing to a plan, or when you want to expand options before converging on one.
+      Triggers on "ideate", "refine this idea", or "stress-test my plan".
+    scripts:
+      - path: skills/idea-refine/scripts/idea-refine.sh
+        description: idea-refine helper script
+        runtime: bash
+  - name: incremental-implementation
+    path: skills/incremental-implementation
+    description: Delivers changes incrementally. Use when implementing any feature or change that
+      touches more than one file. Use when you're about to write a large amount of code at once, or
+      when a task feels too big to land in one step.
+  - name: interview-me
+    path: skills/interview-me
+    description: Extracts what the user actually wants instead of what they think they should want.
+      Achieves this through one-question-at-a-time interview until ~95% confidence about the
+      underlying intent. Use when an ask is underspecified ("build me X" without "for whom" or "why
+      now"), when the user explicitly invokes ("interview me", "grill me", "are we sure?",
+      "stress-test my thinking"), or when you catch yourself silently filling in ambiguous
+      requirements before any plan, spec, or code exists.
+  - name: performance-optimization
+    path: skills/performance-optimization
+    description: Optimizes application performance. Use when performance requirements exist, when you
+      suspect performance regressions, or when Core Web Vitals or load times need improvement. Use
+      when profiling reveals bottlenecks that need fixing.
+  - name: planning-and-task-breakdown
+    path: skills/planning-and-task-breakdown
+    description: Breaks work into ordered tasks. Use when you have a spec or clear requirements and need
+      to break work into implementable tasks. Use when a task feels too large to start, when you
+      need to estimate scope, or when parallel work is possible.
+  - name: security-and-hardening
+    path: skills/security-and-hardening
+    description: Hardens code against vulnerabilities. Use when handling user input, authentication,
+      data storage, or external integrations. Use when building any feature that accepts untrusted
+      data, manages user sessions, or interacts with third-party services.
+  - name: shipping-and-launch
+    path: skills/shipping-and-launch
+    description: Prepares production launches. Use when preparing to deploy to production. Use when you
+      need a pre-launch checklist, when setting up monitoring, when planning a staged rollout, or
+      when you need a rollback strategy.
+  - name: source-driven-development
+    path: skills/source-driven-development
+    description: Grounds every implementation decision in official documentation. Use when you want
+      authoritative, source-cited code free from outdated patterns. Use when building with any
+      framework or library where correctness matters.
+  - name: spec-driven-development
+    path: skills/spec-driven-development
+    description: Creates specs before coding. Use when starting a new project, feature, or significant
+      change and no specification exists yet. Use when requirements are unclear, ambiguous, or only
+      exist as a vague idea.
+  - name: test-driven-development
+    path: skills/test-driven-development
+    description: Drives development with tests. Use when implementing any logic, fixing any bug, or
+      changing any behavior. Use when you need to prove that code works, when a bug report arrives,
+      or when you're about to modify existing functionality.
+  - name: using-agent-skills
+    path: skills/using-agent-skills
+    description: Discovers and invokes agent skills. Use when starting a session or when you need to
+      discover which skill applies to the current task. This is the meta-skill that governs how all
+      other skills are discovered and invoked.
 agents:
-- name: code-reviewer
-  path: agents/code-reviewer.md
-  description: Senior code reviewer that evaluates changes across five dimensions
-    — correctness, readability, architecture, security, and performance. Use for thorough
-    code review before merge.
-- name: security-auditor
-  path: agents/security-auditor.md
-  description: Security engineer focused on vulnerability detection, threat modeling,
-    and secure coding practices. Use for security-focused code review, threat analysis,
-    or hardening recommendations.
-- name: test-engineer
-  path: agents/test-engineer.md
-  description: QA engineer specialized in test strategy, test writing, and coverage
-    analysis. Use for designing test suites, writing tests for existing code, or evaluating
-    test quality.
+  - name: code-reviewer
+    path: agents/code-reviewer.md
+    description: Senior code reviewer that evaluates changes across five dimensions — correctness,
+      readability, architecture, security, and performance. Use for thorough code review before
+      merge.
+  - name: security-auditor
+    path: agents/security-auditor.md
+    description: Security engineer focused on vulnerability detection, threat modeling, and secure
+      coding practices. Use for security-focused code review, threat analysis, or hardening
+      recommendations.
+  - name: test-engineer
+    path: agents/test-engineer.md
+    description: QA engineer specialized in test strategy, test writing, and coverage analysis. Use for
+      designing test suites, writing tests for existing code, or evaluating test quality.
+commands:
+  - name: build
+    path: commands/build.md
+    description: Implement the next task incrementally — build, test, verify, commit
+  - name: code-simplify
+    path: commands/code-simplify.md
+    description: Simplify code for clarity and maintainability — reduce complexity without changing behavior
+  - name: plan
+    path: commands/plan.md
+    description: Break work into small verifiable tasks with acceptance criteria and dependency ordering
+  - name: review
+    path: commands/review.md
+    description: Conduct a five-axis code review — correctness, readability, architecture, security, performance
+  - name: ship
+    path: commands/ship.md
+    description: Run the pre-launch checklist via parallel fan-out to specialist personas, then
+      synthesize a go/no-go decision
+  - name: spec
+    path: commands/spec.md
+    description: Start spec-driven development — write a structured specification before writing code
+  - name: test
+    path: commands/test.md
+    description: Run TDD workflow — write failing tests, implement, verify. For bugs, use the Prove-It pattern.

--- a/profiles/addyosmani_agent-skills/for-forgecat/references/accessibility-checklist.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/references/accessibility-checklist.md
@@ -18,7 +18,7 @@ Quick reference for WCAG 2.1 AA compliance. Use alongside the `frontend-ui-engin
 - [ ] Focus is visible (outline/ring on focused elements)
 - [ ] Custom widgets have keyboard support (Enter to activate, Escape to close)
 - [ ] No keyboard traps (user can always Tab away from a component)
-- [ ] Skip-to-content link at top of page
+- [ ] Skip-to-content link at top of page - visible (at least) on keyboard focus
 - [ ] Modals trap focus while open, return focus on close
 
 ### Screen Readers
@@ -43,6 +43,7 @@ Quick reference for WCAG 2.1 AA compliance. Use alongside the `frontend-ui-engin
 - [ ] Error messages specific and associated with the field
 - [ ] Error state visible by more than color (icon, text, border)
 - [ ] Form submission errors summarized and focusable
+- [ ] Known fields use autocomplete (for example `type="email" autocomplete="email"`)
 
 ### Content
 - [ ] Language declared (`<html lang="en">`)

--- a/profiles/addyosmani_agent-skills/for-forgecat/references/orchestration-patterns.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/references/orchestration-patterns.md
@@ -1,0 +1,370 @@
+# Orchestration Patterns
+
+Reference catalog of agent orchestration patterns this repo endorses, plus anti-patterns to avoid. Read this before adding a new slash command that coordinates multiple personas, or before introducing a new persona that "wraps" existing ones.
+
+The governing rule: **the user (or a slash command) is the orchestrator. Personas do not invoke other personas.** Skills are mandatory hops inside a persona's workflow.
+
+---
+
+## Endorsed patterns
+
+### 1. Direct invocation (no orchestration)
+
+Single persona, single perspective, single artifact. The default and the cheapest option.
+
+```
+user → code-reviewer → report → user
+```
+
+**Use when:** the work is one perspective on one artifact and you can describe it in one sentence.
+
+**Examples:**
+- "Review this PR" → `code-reviewer`
+- "Find security issues in `auth.ts`" → `security-auditor`
+- "What tests are missing for the checkout flow?" → `test-engineer`
+
+**Cost:** one round trip. The baseline you should always compare orchestrated patterns against.
+
+---
+
+### 2. Single-persona slash command
+
+A slash command that wraps one persona with the project's skills. Saves the user from re-explaining the workflow every time.
+
+```
+/review → code-reviewer (with code-review-and-quality skill) → report
+```
+
+**Use when:** the same single-persona invocation happens repeatedly with the same setup.
+
+**Examples in this repo:** `/review`, `/test`, `/code-simplify`.
+
+**Cost:** same as direct invocation. The slash command is just a saved prompt.
+
+**Anti-signal:** if the slash command's body is mostly "decide which persona to call," delete it and let the user call the persona directly.
+
+---
+
+### 3. Parallel fan-out with merge
+
+Multiple personas operate on the same input concurrently, each producing an independent report. A merge step (in the main agent's context) synthesizes them into a single decision.
+
+```
+                    ┌─→ code-reviewer    ─┐
+/ship → fan out  ───┼─→ security-auditor ─┤→ merge → go/no-go + rollback
+                    └─→ test-engineer    ─┘
+```
+
+**Use when:**
+- The sub-tasks are genuinely independent (no shared mutable state, no ordering dependency)
+- Each sub-agent benefits from its own context window
+- The merge step is small enough to stay in the main context
+- Wall-clock latency matters
+
+**Examples in this repo:** `/ship`.
+
+**Cost:** N parallel sub-agent contexts + one merge turn. Higher than direct invocation, but faster wall-clock and produces better reports because each sub-agent stays focused on its single perspective.
+
+**Validation checklist before adopting this pattern:**
+- [ ] Can I run all sub-agents at the same time without ordering issues?
+- [ ] Does each persona produce a different *kind* of finding, not just the same finding from a different angle?
+- [ ] Will the merge step fit in the main agent's remaining context?
+- [ ] Is the user's wait time long enough that parallelism is actually noticeable?
+
+If any answer is "no," fall back to direct invocation or a single-persona command.
+
+---
+
+### 4. Sequential pipeline as user-driven slash commands
+
+The user runs slash commands in a defined order, carrying context (or commit history) between them. There is no orchestrator agent — the user IS the orchestrator.
+
+```
+user runs:  /spec  →  /plan  →  /build  →  /test  →  /review  →  /ship
+```
+
+**Use when:** the workflow has dependencies (each step needs the previous step's output) and human judgment between steps adds value.
+
+**Examples in this repo:** the entire DEFINE → PLAN → BUILD → VERIFY → REVIEW → SHIP lifecycle.
+
+**Cost:** one sub-agent context per step. Free for the orchestration layer because there is no orchestrator agent.
+
+**Why not automate it:** an LLM "lifecycle orchestrator" would (a) lose nuance between steps because it has to summarize for hand-off, (b) skip the human checkpoints that catch wrong-direction work early, and (c) double the token cost via paraphrasing turns.
+
+---
+
+### 5. Research isolation (context preservation)
+
+When a task requires reading large amounts of material that shouldn't pollute the main context, spawn a research sub-agent that returns only a digest.
+
+```
+main agent → research sub-agent (reads 50 files) → digest → main agent continues
+```
+
+**Use when:**
+- The main session needs to stay focused on a downstream task
+- The investigation result is much smaller than the input it consumes
+- The decision quality benefits from the main agent having room to think after
+
+**Examples:** "Find every call site of this deprecated API across the monorepo," "Summarize what these 30 ADRs say about caching."
+
+**Cost:** one isolated sub-agent context. Worth it any time the alternative is loading hundreds of files into the main context.
+
+**On Claude Code, use the built-in `Explore` subagent** rather than defining a custom research persona. `Explore` runs on Haiku, is denied write/edit tools, and is purpose-built for this pattern. Define a custom research subagent only when `Explore` doesn't fit (e.g. you need a domain-specific system prompt the model wouldn't infer).
+
+---
+
+## Claude Code compatibility
+
+This catalog is harness-agnostic, but most readers will run it on Claude Code. Here's how each pattern maps onto Claude Code's primitives — and where the platform enforces our rules for us.
+
+### Where personas live
+
+Plugin subagents go in `agents/` at the plugin root. This repo is a plugin (`.claude-plugin/plugin.json`), so `agents/code-reviewer.md`, `agents/security-auditor.md`, and `agents/test-engineer.md` are auto-discovered when the plugin is enabled. No path configuration needed.
+
+### Subagents vs. Agent Teams
+
+Claude Code has two parallelism primitives. Pattern 3 (parallel fan-out with merge) maps to **subagents**. If you need teammates that talk to each other, use **Agent Teams** instead.
+
+| | Subagents | Agent Teams |
+|--|-----------|-------------|
+| Coordination | Main agent fans out, sub-agents only report back | Teammates message each other, share a task list |
+| Context | Own context window per subagent | Own context window per teammate |
+| When to use | Independent tasks producing reports | Collaborative work needing discussion |
+| Status | Stable | Experimental — requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` |
+| Cost | Lower | Higher — each teammate is a separate Claude instance |
+
+**The personas in this repo work in both modes.** When spawned as subagents (e.g. by `/ship`), they report findings to the main session. When spawned as teammates (`Spawn a teammate using the security-auditor agent type…`), they can challenge each other's findings directly. The persona definition is the same; only the spawning context changes.
+
+One subtlety: the `skills` and `mcpServers` frontmatter fields in a persona are honored when it runs as a subagent but **ignored when it runs as a teammate** — teammates load skills and MCP servers from your project and user settings, the same as a regular session. If a persona depends on a specific skill or MCP server being loaded, configure it at the session level so it's available in both modes.
+
+### Platform-enforced rules
+
+Two rules in this catalog aren't just convention — Claude Code enforces them:
+
+- **"Subagents cannot spawn other subagents"** (verbatim from the docs). Anti-pattern B (persona-calls-persona) and Anti-pattern D (deep persona trees) cannot exist on Claude Code by construction.
+- **"No nested teams"** — teammates cannot spawn their own teams. Same anti-patterns blocked at the team level.
+
+This means you can adopt the patterns in this catalog without worrying about contributors accidentally building the anti-patterns. They'll just fail to load.
+
+### Built-in subagents to know about
+
+Before defining a custom subagent, check whether one of these covers the role:
+
+| Built-in | Purpose |
+|----------|---------|
+| `Explore` | Read-only codebase search and analysis. Use this for Pattern 5 (research isolation). |
+| `Plan` | Read-only research during plan mode. |
+| `general-purpose` | Multi-step tasks needing both exploration and modification. |
+
+Don't redefine these. Layer your specialist personas (code-reviewer, security-auditor, test-engineer) on top of them.
+
+### Frontmatter restrictions for plugin agents
+
+Plugin subagents do **not** support the `hooks`, `mcpServers`, or `permissionMode` frontmatter fields — these are silently ignored. If a future persona needs any of those, the user must copy the file into `.claude/agents/` or `~/.claude/agents/` instead.
+
+The fields that DO work in plugin agents are: `name`, `description`, `tools`, `disallowedTools`, `model`, `maxTurns`, `skills`, `memory`, `background`, `effort`, `isolation`, `color`, `initialPrompt`. Use `model` per-persona if you want to optimize cost (e.g. Haiku for `test-engineer` coverage scans, Sonnet for `code-reviewer`, Opus for `security-auditor`).
+
+### Spawning multiple subagents in parallel
+
+In Claude Code, parallel fan-out (Pattern 3) requires issuing **multiple Agent tool calls in a single assistant turn**. Sequential turns serialize execution. `/ship` calls this out explicitly. Any new orchestrator command should do the same.
+
+---
+
+## Worked example: Agent Teams for competing-hypothesis debugging
+
+This example shows when to reach for **Agent Teams** instead of `/ship`'s subagent fan-out. The two patterns look similar from a distance — both spawn the same three personas — but the value comes from a different place.
+
+### The scenario
+
+> *Checkout occasionally hangs for ~30 seconds before completing. It happens roughly once every 50 sessions. No errors in logs. Started after last week's release.*
+
+Plausible root causes (mutually exclusive, all fit the symptoms):
+
+1. A race condition in the new payment-confirmation flow
+2. An auth check that occasionally falls through to a slow synchronous network call
+3. A missing index on a query that scales with cart size
+4. A flaky third-party API where the SDK retries silently before timing out
+
+A single agent will pick the first plausible theory and stop investigating. A `/ship`-style subagent fan-out would have each persona report independently — but their reports never meet, so nothing rules out the wrong theories.
+
+This is exactly the case the Agent Teams docs describe: *"With multiple independent investigators actively trying to disprove each other, the theory that survives is much more likely to be the actual root cause."*
+
+### Why this is *not* a `/ship` job
+
+| | `/ship` (subagents) | Agent Teams |
+|--|--------------------|-------------|
+| Sub-agents see | The same diff, different lenses | A shared task list, each other's messages |
+| Output | Three independent reports → one merge | Adversarial debate → consensus root cause |
+| Right when | You want a verdict on a known artifact | You want to *find* the artifact among hypotheses |
+
+`/ship` is a verdict; Agent Teams is an investigation.
+
+### Setup (one-time, per-environment)
+
+Agent Teams is experimental. In `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  }
+}
+```
+
+Requires Claude Code v2.1.32 or later. The personas in this repo are picked up automatically — no team-config files to author by hand.
+
+### The trigger prompt
+
+Type into the lead session, in natural language:
+
+```
+Users report checkout hangs for ~30 seconds intermittently after last
+week's release. No errors in logs.
+
+Create an agent team to debug this with competing hypotheses. Spawn
+three teammates using the existing agent types:
+
+  - code-reviewer  — investigate race conditions and blocking calls
+                     in the checkout code path
+  - security-auditor — investigate auth checks, session handling,
+                       and any synchronous network calls added recently
+  - test-engineer  — propose tests that would distinguish between the
+                     hypotheses and check coverage gaps in checkout
+
+Have them message each other directly to challenge each other's
+theories. Update findings as consensus emerges. Only converge when
+two teammates agree they can disprove the others'.
+```
+
+The lead spawns three teammates referencing the existing persona names. The persona body is **appended** to each teammate's system prompt as additional instructions (on top of the team-coordination instructions the lead installs); the trigger prompt above becomes their task.
+
+### What happens
+
+1. Each teammate runs in its own context window, exploring the codebase from its own lens.
+2. Teammates use `message` to send findings to each other directly. The lead doesn't have to relay.
+3. The shared task list shows who's investigating what — visible at any time with `Ctrl+T` (in-process mode) or in a tmux pane (split mode).
+4. When `code-reviewer` finds a `Promise.all` that should be sequential, it messages `security-auditor` to confirm the auth call isn't part of the race. `security-auditor` checks and replies — either confirming the race is the real issue or producing counter-evidence.
+5. `test-engineer` proposes a focused integration test for whichever theory is winning, which the team uses to verify before declaring consensus.
+6. The lead synthesizes the converged finding and presents it to you.
+
+You can interrupt at any teammate by cycling with `Shift+Down` and typing — useful for redirecting an investigator who's gone down a wrong path.
+
+### When to clean up
+
+When the investigation lands on a root cause, tell the lead:
+
+```
+Clean up the team
+```
+
+Always cleanup through the lead, not a teammate (per the docs: teammates lack full team context for cleanup).
+
+### Cost expectation
+
+Three Sonnet teammates running for ~10–15 minutes of investigation costs noticeably more than the same three personas spawned as subagents by `/ship`. The justification is *quality of conclusion* — for production debugging where the wrong fix is expensive, the extra tokens are a bargain. For a routine PR review, stick with `/ship`.
+
+### Anti-pattern in this scenario
+
+Do **not** rebuild this as a `/debug` slash command that fans out subagents. Subagents can't message each other — you'd lose the adversarial debate that makes the pattern work. If a workflow keeps coming up, document the trigger prompt above as a snippet rather than wrapping it in a slash command that misuses subagents.
+
+### When *not* to use Agent Teams
+
+- Production-bound verdict on a known diff → use `/ship` (subagents).
+- One specialist perspective on one artifact → direct persona invocation.
+- Sequential lifecycle (spec → plan → build) → user-driven slash commands (Pattern 4).
+- Read-heavy research with a small digest → built-in `Explore` subagent.
+
+Reach for Agent Teams only when teammates **need** to challenge each other to produce the right answer.
+
+---
+
+## Anti-patterns
+
+### A. Router persona ("meta-orchestrator")
+
+A persona whose job is to decide which other persona to call.
+
+```
+/work → router-persona → "this needs a review" → code-reviewer → router (paraphrases) → user
+```
+
+**Why it fails:**
+- Pure routing layer with no domain value
+- Adds two paraphrasing hops → information loss + roughly 2× token cost
+- The user already knew they wanted a review; they could have called `/review` directly
+- Replicates the work that slash commands and intent mapping in `AGENTS.md` already do
+
+**What to do instead:** add or refine slash commands. Document intent → command mapping in `AGENTS.md`.
+
+---
+
+### B. Persona that calls another persona
+
+A `code-reviewer` that internally invokes `security-auditor` when it sees auth code.
+
+**Why it fails:**
+- Personas were designed to produce a single perspective; chaining them defeats that
+- The summary the calling persona passes loses context the called persona needs
+- Failure modes multiply (which persona's output format wins? whose rules apply?)
+- Hides cost from the user
+
+**What to do instead:** have the calling persona *recommend* a follow-up audit in its report. The user or a slash command runs the second pass.
+
+---
+
+### C. Sequential orchestrator that paraphrases
+
+An agent that calls `/spec`, then `/plan`, then `/build`, etc. on the user's behalf.
+
+**Why it fails:**
+- Loses the human checkpoints that catch wrong-direction work
+- Each hand-off summarizes context — accumulated drift over a long pipeline
+- Doubles token cost: orchestrator turn + sub-agent turn for every step
+- Removes user agency at exactly the points where judgment matters most
+
+**What to do instead:** keep the user as the orchestrator. Document the recommended sequence in `README.md` and let users invoke it.
+
+---
+
+### D. Deep persona trees
+
+`/ship` calls a `pre-ship-coordinator` that calls a `quality-coordinator` that calls `code-reviewer`.
+
+**Why it fails:**
+- Each layer adds latency and tokens with no decision value
+- Debugging becomes a multi-level investigation
+- The leaf personas lose context to multiple summarization steps
+
+**What to do instead:** keep the orchestration depth at most 1 (slash command → personas). The merge happens in the main agent.
+
+---
+
+## Decision flow
+
+When considering a new orchestrated workflow, walk this flow:
+
+```
+Is the work one perspective on one artifact?
+├── Yes → Direct invocation. Stop.
+└── No  → Will the same composition repeat?
+         ├── No  → Direct invocation, ad hoc. Stop.
+         └── Yes → Are sub-tasks independent?
+                  ├── No  → Sequential slash commands run by user (Pattern 4).
+                  └── Yes → Parallel fan-out with merge (Pattern 3).
+                           Validate against the checklist above.
+                           If any check fails → fall back to single-persona command (Pattern 2).
+```
+
+---
+
+## When to add a new pattern to this catalog
+
+Add a new entry only after:
+
+1. You've used the pattern at least twice in real work
+2. You can name a concrete artifact in this repo that demonstrates it
+3. You can explain why an existing pattern wouldn't have worked
+4. You can describe its anti-pattern shadow (what people will mistakenly build instead)
+
+Premature catalog entries become aspirational documentation that no one follows.

--- a/profiles/addyosmani_agent-skills/for-forgecat/references/performance-checklist.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/references/performance-checklist.md
@@ -5,6 +5,7 @@ Quick reference checklist for web application performance. Use alongside the `pe
 ## Table of Contents
 
 - [Core Web Vitals Targets](#core-web-vitals-targets)
+- [TTFB Diagnosis](#ttfb-diagnosis)
 - [Frontend Checklist](#frontend-checklist)
 - [Backend Checklist](#backend-checklist)
 - [Measurement Commands](#measurement-commands)
@@ -18,36 +19,60 @@ Quick reference checklist for web application performance. Use alongside the `pe
 | INP (Interaction to Next Paint) | ≤ 200ms | ≤ 500ms | > 500ms |
 | CLS (Cumulative Layout Shift) | ≤ 0.1 | ≤ 0.25 | > 0.25 |
 
+## TTFB Diagnosis
+
+When TTFB is slow (> 800ms), check each component in DevTools Network waterfall:
+
+- [ ] **DNS resolution** slow → add `<link rel="dns-prefetch">` or `<link rel="preconnect">` for known origins
+- [ ] **TCP/TLS handshake** slow → enable HTTP/2, consider edge deployment, verify keep-alive
+- [ ] **Server processing** slow → profile backend, check slow queries, add caching
+
 ## Frontend Checklist
 
 ### Images
 - [ ] Images use modern formats (WebP, AVIF)
 - [ ] Images are responsively sized (`srcset` and `sizes`)
-- [ ] Images have explicit `width` and `height` attributes (prevents CLS)
-- [ ] Below-the-fold images use `loading="lazy"`
+- [ ] Images and `<source>` elements have explicit `width` and `height` (prevents CLS in art direction)
+- [ ] Below-the-fold images use `loading="lazy"` and `decoding="async"`
 - [ ] Hero/LCP images use `fetchpriority="high"` and no lazy loading
 
 ### JavaScript
 - [ ] Bundle size under 200KB gzipped (initial load)
 - [ ] Code splitting with dynamic `import()` for routes and heavy features
-- [ ] Tree shaking enabled (no dead code in production bundle)
+- [ ] Tree shaking enabled (verify dependency ships ESM and marks `sideEffects: false`)
 - [ ] No blocking JavaScript in `<head>` (use `defer` or `async`)
 - [ ] Heavy computation offloaded to Web Workers (if applicable)
 - [ ] `React.memo()` on expensive components that re-render with same props
 - [ ] `useMemo()` / `useCallback()` only where profiling shows benefit
+- [ ] Long tasks (> 50ms) broken up to keep the main thread available — main lever for INP
+- [ ] `yieldToMain` pattern used inside long-running loops so input events can run between chunks
+- [ ] Modern scheduling APIs used where available: `scheduler.yield()` (preferred), `scheduler.postTask()` with priorities, `isInputPending()` to yield only when needed
+- [ ] `requestIdleCallback` for deferrable, non-urgent work (analytics flush, prefetch, warmup)
+- [ ] Non-critical work deferred out of event handlers (e.g. analytics, logging) so the response to the interaction is not delayed
+- [ ] Third-party scripts loaded with `async` / `defer`, audited for size, and fronted by a facade when heavy (chat widgets, embeds)
 
 ### CSS
 - [ ] Critical CSS inlined or preloaded
 - [ ] No render-blocking CSS for non-critical styles
 - [ ] No CSS-in-JS runtime cost in production (use extraction)
-- [ ] Font display strategy set (`font-display: swap` or `optional`)
-- [ ] System font stack considered before custom fonts
+
+### Fonts
+- [ ] Limited to 2–3 font families, 2–3 weights each (every additional weight is another request)
+- [ ] WOFF2 format only (smallest, universal support — skip WOFF/TTF/EOT)
+- [ ] Self-hosted when possible (third-party font CDNs add DNS + TCP + TLS round-trips)
+- [ ] LCP-critical fonts preloaded: `<link rel="preload" as="font" type="font/woff2" crossorigin>`
+- [ ] `font-display: swap` (or `optional` for non-critical) to avoid FOIT blocking render
+- [ ] Subsetted via `unicode-range` to ship only the glyphs each page needs
+- [ ] Variable fonts considered when multiple weights/styles are required (one file replaces many)
+- [ ] Fallback font metrics adjusted with `size-adjust`, `ascent-override`, `descent-override` to reduce CLS on font swap
+- [ ] System font stack considered before any custom font
 
 ### Network
 - [ ] Static assets cached with long `max-age` + content hashing
 - [ ] API responses cached where appropriate (`Cache-Control`)
 - [ ] HTTP/2 or HTTP/3 enabled
 - [ ] Resources preconnected (`<link rel="preconnect">`) for known origins
+- [ ] `fetchpriority` used on critical non-image resources (e.g., key `<link rel="preload">`, above-the-fold `<script>`) — not only on `<img>`
 - [ ] No unnecessary redirects
 
 ### Rendering
@@ -55,6 +80,8 @@ Quick reference checklist for web application performance. Use alongside the `pe
 - [ ] Animations use `transform` and `opacity` (GPU-accelerated)
 - [ ] Long lists use virtualization (e.g., `react-window`)
 - [ ] No unnecessary full-page re-renders
+- [ ] Off-screen sections use `content-visibility: auto` with `contain-intrinsic-size` to skip layout/paint of non-visible areas
+- [ ] No `unload` event handlers and no `Cache-Control: no-store` on HTML responses — preserves back/forward cache (bfcache) eligibility
 
 ## Backend Checklist
 
@@ -80,6 +107,12 @@ Quick reference checklist for web application performance. Use alongside the `pe
 
 ## Measurement Commands
 
+### INP field data and DevTools workflow
+
+1. **Field data first** — check [CrUX Vis](https://developer.chrome.com/docs/crux/vis) or your RUM tool for real-user INP before optimising
+2. **Identify slow interactions** — open DevTools → Performance panel → record while interacting; look for long tasks triggered by clicks/keystrokes
+3. **Test on mid-range Android** — INP issues often only surface on slower hardware; use a real device or DevTools CPU throttling (4×–6× slowdown)
+
 ```bash
 # Lighthouse CLI
 npx lighthouse https://localhost:3000 --output json --output-path ./report.json
@@ -97,6 +130,13 @@ import { onLCP, onINP, onCLS } from 'web-vitals';
 onLCP(console.log);
 onINP(console.log);
 onCLS(console.log);
+
+# INP with interaction-level detail (attribution build)
+import { onINP } from 'web-vitals/attribution';
+onINP(({ value, attribution }) => {
+  const { interactionTarget, inputDelay, processingDuration, presentationDelay } = attribution;
+  console.log({ value, interactionTarget, inputDelay, processingDuration, presentationDelay });
+});
 ```
 
 ## Common Anti-Patterns
@@ -109,5 +149,5 @@ onCLS(console.log);
 | Layout thrashing | Jank, dropped frames | Batch DOM reads, then batch writes |
 | Unoptimized images | Slow LCP, wasted bandwidth | Use WebP, responsive sizes, lazy load |
 | Large bundles | Slow Time to Interactive | Code split, tree shake, audit deps |
-| Blocking main thread | Poor INP, unresponsive UI | Use Web Workers, defer work |
+| Blocking main thread | Poor INP, unresponsive UI | Chunk long tasks with `scheduler.yield()` / `yieldToMain`, offload to Web Workers |
 | Memory leaks | Growing memory, eventual crash | Clean up listeners, intervals, refs |

--- a/profiles/addyosmani_agent-skills/for-forgecat/skills/browser-testing-with-devtools/SKILL.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/skills/browser-testing-with-devtools/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser-testing-with-devtools
-description: Tests in real browsers. Use when building or debugging anything that runs in a browser. Use when you need to inspect the DOM, capture console errors, analyze network requests, profile performance, or verify visual output with real runtime data via Chrome DevTools MCP.
+description: Tests in real browsers via Chrome DevTools MCP. Use when building or debugging anything that runs in a browser. Use when you need to inspect the DOM, capture console errors, analyze network requests, profile performance, or verify visual output with real runtime data. Requires the chrome-devtools MCP server to be configured.
 ---
 
 # Browser Testing with DevTools

--- a/profiles/addyosmani_agent-skills/for-forgecat/skills/doubt-driven-development/SKILL.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/skills/doubt-driven-development/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: doubt-driven-development
+description: Subjects every non-trivial decision to a fresh-context adversarial review before it stands. Use when correctness matters more than speed, when working in unfamiliar code, when stakes are high (production, security-sensitive logic, irreversible operations), or any time a confident output would be cheaper to verify now than to debug later.
+---
+
+# Doubt-Driven Development
+
+## Overview
+
+A confident answer is not a correct one. Long sessions accumulate context that quietly turns assumptions into "facts" without anyone noticing. Doubt-driven development is the discipline of materializing a fresh-context reviewer — biased to **disprove**, not approve — before any non-trivial output stands.
+
+This is not `/review`. `/review` is a verdict on a finished artifact. This is an in-flight posture: non-trivial decisions get cross-examined while course-correction is still cheap.
+
+## When to Use
+
+A decision is **non-trivial** when at least one of these is true:
+
+- It introduces or modifies branching logic
+- It crosses a module or service boundary
+- It asserts a property the type system or compiler cannot verify (thread safety, idempotence, ordering, invariants)
+- Its correctness depends on context the future reader cannot see
+- Its blast radius is irreversible (production deploy, data migration, public API change)
+
+Apply the skill when:
+
+- About to make an architectural decision under uncertainty
+- About to commit non-trivial code
+- About to claim a non-obvious fact ("this is safe", "this scales", "this matches the spec")
+- Working in code you don't fully understand
+
+**When NOT to use:**
+
+- Mechanical operations (renaming, formatting, file moves)
+- Following a clear, unambiguous user instruction
+- Reading or summarizing existing code
+- One-line changes with obvious correctness
+- Pure tooling operations (running tests, listing files)
+- The user has explicitly asked for speed over verification
+
+If you doubt every keystroke, you ship nothing. The skill applies only to non-trivial decisions as defined above.
+
+## Loading Constraints
+
+This skill is designed for the **main-session orchestrator**, where Step 3 (DOUBT, detailed below) can spawn a fresh-context reviewer.
+
+- **Do NOT add this skill to a persona's `skills:` frontmatter.** A persona that follows Step 3 would spawn another persona — the orchestration anti-pattern explicitly forbidden by `references/orchestration-patterns.md` ("personas do not invoke other personas").
+- **If you find yourself applying this skill from inside a subagent context** (where Claude Code prevents nested subagent spawn): the preferred path is to surface to the user that doubt-driven cannot run nested and let the main session handle it. As a last resort only, a degraded self-questioning fallback exists — rewrite ARTIFACT + CONTRACT as a fresh self-prompt with a hard mental separator from your prior reasoning, and walk Steps 1–5. This is **not fresh-context review** (you carry your own context with you), so flag the result as degraded and prefer escalation whenever the user is reachable.
+
+## The Process
+
+Copy this checklist when applying the skill:
+
+```
+Doubt cycle:
+- [ ] Step 1: CLAIM — wrote the claim + why-it-matters
+- [ ] Step 2: EXTRACT — isolated artifact + contract, stripped reasoning
+- [ ] Step 3: DOUBT — invoked fresh-context reviewer with adversarial prompt
+- [ ] Step 4: RECONCILE — classified every finding against the artifact text
+- [ ] Step 5: STOP — met stop condition (trivial findings, 3 cycles, or user override)
+```
+
+### Step 1: CLAIM — Surface what stands
+
+Name the decision in two or three lines:
+
+```
+CLAIM: "The new caching layer is thread-safe under the
+        read-heavy workload described in the spec."
+WHY THIS MATTERS: a race here corrupts user data and is
+                  hard to detect in QA.
+```
+
+If you can't write the claim that compactly, you have a vibe, not a decision. Surface it before scrutinizing it.
+
+### Step 2: EXTRACT — Smallest reviewable unit
+
+A fresh-context reviewer needs the **artifact** and the **contract**, not the journey.
+
+- Code: the diff or the function — not the whole file
+- Decision: the proposal in 3–5 sentences plus the constraints it has to satisfy
+- Assertion: the claim plus the evidence that supposedly supports it (kept distinct from the Step 1 CLAIM block, which is the orchestrator's hypothesis under scrutiny)
+
+Strip your reasoning. If you hand over conclusions, you'll get back validation of your conclusions. The unit must be small enough that a reviewer can hold it in mind in one read — if it's a 500-line PR, decompose first.
+
+### Step 3: DOUBT — Invoke the fresh-context reviewer
+
+The reviewer's prompt **must be adversarial**. Framing decides the answer.
+
+```
+Adversarial review. Find what is wrong with this artifact.
+Assume the author is overconfident. Look for:
+- Unstated assumptions
+- Edge cases not handled
+- Hidden coupling or shared state
+- Ways the contract could be violated
+- Existing conventions this might break
+- Failure modes under unexpected input
+
+Do NOT validate. Do NOT summarize. Find issues, or state
+explicitly that you cannot find any after thorough examination.
+
+ARTIFACT: <paste artifact>
+CONTRACT: <paste contract>
+```
+
+**Pass ARTIFACT + CONTRACT only. Do NOT pass the CLAIM.** Handing the reviewer your conclusion biases it toward agreement. The reviewer must independently determine whether the artifact satisfies the contract.
+
+In Claude Code, the role-based reviewers in `agents/` start with isolated context by design and are usable here — see `agents/` for the roster and per-domain match.
+
+**The adversarial prompt above takes precedence over the persona's default response shape.** Personas like `code-reviewer` are written to produce balanced verdicts with both strengths and weaknesses; doubt-driven needs issues-only output. Paste the adversarial prompt verbatim into the invocation so it overrides the persona's default. If a persona's response shape can't be overridden cleanly, fall back to a generic subagent with the adversarial prompt.
+
+#### Cross-model escalation
+
+A single-model reviewer shares blind spots with the original author — a colder, different-architecture model catches them. Doubt-driven is already opt-in for non-trivial decisions, so within that scope offering cross-model is part of the skill's value, not optional friction.
+
+**Interactive sessions: always offer. Never silently skip.**
+
+**Step 1: Ask the user**
+
+After the single-model review in Step 3 above, but before RECONCILE, pause and ask:
+
+> *"Single-model review complete. Want a cross-model second opinion? Options: Gemini CLI, Codex CLI, manual external review (you paste it elsewhere), or skip."*
+
+This question is mandatory in every interactive doubt cycle — even on artifacts that feel low-stakes. The user — not the agent — decides whether the cost is worth it. The agent's job is to surface the choice.
+
+**Step 2: If the user picks a CLI — verify, then invoke**
+
+1. Check the tool is in PATH (`which gemini`, `which codex`).
+2. Test it works (`gemini --version` or equivalent) before passing the full prompt — a stale or broken binary may pass `which` but fail on real input.
+3. Confirm the exact invocation with the user, including required flags, auth, and env vars (e.g., API keys). Implementations vary; never assume.
+4. Pass ARTIFACT + CONTRACT + the adversarial prompt **only**. No session context, no CLAIM.
+5. Mind shell escaping. If the artifact contains quotes, `$(...)`, or backticks, prefer stdin (`echo … | gemini`) or a heredoc over inline `-p "…"`. When in doubt, ask the user to confirm the invocation before running it.
+6. Take the output into Step 4 (RECONCILE).
+
+**Never interpolate the artifact into a shell-quoted argument.** Code, markdown, and review prompts routinely contain backticks, `$(...)`, and quote characters that will either truncate the prompt or execute embedded shell. Write the full prompt to a file and pipe it through stdin.
+
+Example shapes (verify flags against your installed tool — syntax differs across implementations and versions):
+
+```bash
+# Write the adversarial prompt + ARTIFACT + CONTRACT to a temp file first.
+# Then pipe via stdin so shell metacharacters in the artifact stay inert.
+
+# Codex (read-only sandbox keeps the CLI from writing to your workspace):
+codex exec --sandbox read-only -C <repo-path> - < /tmp/doubt-prompt.md
+
+# Gemini ('--approval-mode plan' is read-only; '-p ""' triggers non-interactive
+# mode and the prompt is read from stdin):
+gemini --approval-mode plan -p "" < /tmp/doubt-prompt.md
+```
+
+A read-only sandbox is the load-bearing detail: a doubt artifact may itself contain instructions (intentional or accidental prompt injection) that the cross-model CLI would otherwise execute against your workspace.
+
+**Step 3: If the CLI is unavailable or fails**
+
+Surface the failure explicitly. Offer: run it manually, try a different tool, or skip. Do not silently fall back to single-model — the user should know cross-model didn't happen.
+
+**Step 4: If the user skips**
+
+Acknowledge the skip in the output (*"Proceeding with single-model findings only"*) and continue to RECONCILE. Skipping is fine; silent skipping is not.
+
+**Non-interactive contexts** (CI, `/loop`, autonomous-loop, scheduled runs):
+
+- Cross-model is **skipped**, and the skip must be **announced** in the output: *"Cross-model skipped: non-interactive context."*
+- **Never invoke an external CLI without explicit user authorization** — this is a load-bearing safety property.
+
+Cross-model adds cost, latency, and tool fragility. The agent surfaces the choice every cycle; the user decides whether this artifact warrants it.
+
+### Step 4: RECONCILE — Fold findings back
+
+The reviewer's output is data, not verdict. **You are still the orchestrator.** Re-read the artifact text against each finding before classifying — rubber-stamping the reviewer is the same failure mode as ignoring it.
+
+For each finding, classify in this **precedence order** (first matching class wins):
+
+1. **Contract misread** — reviewer flagged something specifically because the CONTRACT you provided was unclear or incomplete. Fix the contract first, re-classify on the next cycle.
+2. **Valid + actionable** — real issue requiring a change to the artifact. Change it, re-loop.
+3. **Valid trade-off** — issue is real but cost of fixing exceeds cost of accepting. Document the trade-off explicitly so the user sees it.
+4. **Noise** — reviewer flagged something that's actually correct under context the reviewer didn't have. Note it, move on, and ask: would adding that context to the contract have prevented the false flag?
+
+A fresh reviewer can be wrong because it lacks context. Don't defer just because it's "fresh."
+
+### Step 5: STOP — Bounded loop, not recursion
+
+Stop when:
+
+- Next iteration returns only trivial or already-considered findings, **or**
+- 3 cycles completed (escalate to user, don't grind a fourth alone), **or**
+- User explicitly says "ship it"
+
+If after 3 cycles the reviewer still surfaces substantive issues, the artifact may not be ready. Surface this to the user — three unresolved cycles is information about the artifact, not a reason to keep looping.
+
+If 3 cycles is "obviously insufficient" because the artifact is large: the artifact is too big — return to Step 2 and decompose. Do not lift the bound.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "I'm confident, skip the doubt step" | Confidence correlates poorly with correctness on novel problems. Moments of certainty are exactly when blind spots hide. |
+| "Spawning a reviewer is expensive" | Debugging a wrong commit in production is more expensive. The check is bounded; the bug isn't. |
+| "The reviewer will just nitpick" | Only if unscoped. Constrain the prompt to "issues that would make this fail under the contract." |
+| "I'll do doubt at the end with `/review`" | `/review` is a final gate. Doubt-driven catches wrong directions early when course-correction is cheap. By PR time it's too late. |
+| "If I doubt every step I'll never ship" | The skill applies to non-trivial decisions, not every keystroke. Re-read "When NOT to Use." |
+| "Two opinions are always better than one" | Not when the second has less context and produces noise. Reconcile, don't defer. |
+| "The reviewer disagreed so I was wrong" | The reviewer lacks your context — disagreement is information, not verdict. Re-read the artifact, classify, then decide. |
+| "Cross-model is always better" | Cross-model catches blind spots a single model shares with itself, but it adds cost and tool fragility. Offer it every interactive doubt cycle — the user decides whether the artifact warrants it. The agent's job is to surface the choice, not to gate it. |
+| "User said yes once, so I can keep invoking the CLI" | Each invocation is its own authorization. The artifact, the prompt, and the flags change between calls — re-confirm the exact command with the user before every run. |
+
+## Red Flags
+
+- Spawning a fresh-context reviewer for a one-line rename or formatting change
+- Treating reviewer output as authoritative without re-reading the artifact text
+- Looping >3 cycles without escalating to the user
+- Prompting the reviewer with "is this good?" instead of "find issues"
+- Skipping doubt under time pressure on a high-stakes decision
+- Re-spawning fresh-context on an unchanged artifact (you'll get the same findings; you're stalling)
+- **Doubt theater (checkable signal)**: across 2 or more cycles where the reviewer surfaced substantive findings, zero findings were classified as actionable. You are validating, not doubting. Stop and escalate.
+- Doubting only after committing — that's `/review`, not doubt-driven development
+- Hardcoding an external CLI invocation without confirming with the user that the tool exists, is configured, and accepts that exact syntax
+- **Silently skipping cross-model in an interactive doubt cycle.** Even when not recommending it, the offer must be visible. Skipping is fine; silent skipping is not.
+- Falling back silently when an external CLI errors or is missing — surface the failure and let the user redirect
+- Stripping the contract from the reviewer's input
+- Passing the CLAIM to the reviewer (biases toward agreement)
+
+## Interaction with Other Skills
+
+- **`code-review-and-quality` / `/review`**: complementary. `/review` is post-hoc PR verdict; doubt-driven is in-flight per-decision. Use both.
+- **`source-driven-development`**: SDD verifies *facts about frameworks* against official docs. Doubt-driven verifies *your reasoning about the artifact*. SDD checks the API exists; doubt-driven checks you used it correctly under the contract.
+- **`test-driven-development`**: TDD's RED step is doubt made concrete — a failing test is a disproof attempt. When TDD applies, that failing test *is* the doubt step for behavioral claims.
+- **`debugging-and-error-recovery`**: when the reviewer surfaces a real failure mode, drop into the debugging skill to localize and fix.
+- **Repo orchestration rules** (`references/orchestration-patterns.md`): this skill orchestrates from the main session. A persona calling another persona is anti-pattern B — see Loading Constraints above.
+
+## Verification
+
+After applying doubt-driven development:
+
+- [ ] Every non-trivial decision (per the definition above) was named explicitly as a CLAIM before standing
+- [ ] At least one fresh-context review per non-trivial artifact (a failing test produced by TDD's RED step satisfies this for behavioral claims, per Interaction with Other Skills)
+- [ ] The reviewer received ARTIFACT + CONTRACT — NOT the CLAIM, NOT your reasoning
+- [ ] The reviewer's prompt was adversarial ("find issues"), not validating ("is it good")
+- [ ] Findings were classified against the artifact text (not rubber-stamped) using the precedence: contract misread / actionable / trade-off / noise
+- [ ] A stop condition was met (trivial findings, 3 cycles, or user override)
+- [ ] In interactive mode, cross-model was **explicitly offered** to the user (regardless of artifact stakes) and the response was acknowledged in the output
+- [ ] In non-interactive mode, cross-model was skipped and the skip was announced
+- [ ] Any external CLI invocation was preceded by a PATH check, a working-binary test, syntax confirmation with the user, and explicit authorization to run

--- a/profiles/addyosmani_agent-skills/for-forgecat/skills/frontend-ui-engineering/SKILL.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/skills/frontend-ui-engineering/SKILL.md
@@ -173,7 +173,13 @@ Every component must meet these standards:
 <button onClick={handleClick}>Click me</button>        // ✓ Focusable by default
 <div onClick={handleClick}>Click me</div>               // ✗ Not focusable
 <div role="button" tabIndex={0} onClick={handleClick}    // ✓ But prefer <button>
-     onKeyDown={e => e.key === 'Enter' && handleClick()}>
+     onKeyDown={e => {
+       if (e.key === 'Enter') handleClick();
+       if (e.key === ' ') e.preventDefault();
+     }}
+     onKeyUp={e => {
+       if (e.key === ' ') handleClick();
+     }}>
   Click me
 </div>
 ```

--- a/profiles/addyosmani_agent-skills/for-forgecat/skills/idea-refine/SKILL.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/skills/idea-refine/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: idea-refine
-description: Refines ideas iteratively. Refine ideas through structured divergent and convergent thinking. Use "idea-refine" or "ideate" to trigger.
+description: Refines raw ideas into sharp, actionable concepts through structured divergent and convergent thinking. Use when an idea is still vague, when you need to stress-test assumptions before committing to a plan, or when you want to expand options before converging on one. Triggers on "ideate", "refine this idea", or "stress-test my plan".
 ---
 
 # Idea Refine

--- a/profiles/addyosmani_agent-skills/for-forgecat/skills/incremental-implementation/SKILL.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/skills/incremental-implementation/SKILL.md
@@ -208,6 +208,8 @@ After each increment, verify:
 - [ ] The new functionality works as expected
 - [ ] The change is committed with a descriptive message
 
+**Note:** Run each verification command after a change that could affect it. After a successful run, don't repeat the same command unless the code has changed since — re-running on unchanged code adds no information.
+
 ## Common Rationalizations
 
 | Rationalization | Reality |
@@ -217,6 +219,7 @@ After each increment, verify:
 | "These changes are too small to commit separately" | Small commits are free. Large commits hide bugs and make rollbacks painful. |
 | "I'll add the feature flag later" | If the feature isn't complete, it shouldn't be user-visible. Add the flag now. |
 | "This refactor is small enough to include" | Refactors mixed with features make both harder to review and debug. Separate them. |
+| "Let me run the build command again just to be sure" | After a successful run, repeating the same command adds nothing unless the code has changed since. Run it again after subsequent edits, not as reassurance. |
 
 ## Red Flags
 
@@ -229,6 +232,7 @@ After each increment, verify:
 - Building abstractions before the third use case demands it
 - Touching files outside the task scope "while I'm here"
 - Creating new utility files for one-time operations
+- Running the same build/test command twice in a row without any intervening code change
 
 ## Verification
 

--- a/profiles/addyosmani_agent-skills/for-forgecat/skills/interview-me/SKILL.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/skills/interview-me/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: interview-me
+description: Extracts what the user actually wants instead of what they think they should want. Achieves this through one-question-at-a-time interview until ~95% confidence about the underlying intent. Use when an ask is underspecified ("build me X" without "for whom" or "why now"), when the user explicitly invokes ("interview me", "grill me", "are we sure?", "stress-test my thinking"), or when you catch yourself silently filling in ambiguous requirements before any plan, spec, or code exists.
+---
+
+# Interview Me
+
+## Overview
+
+What people ask for and what they actually want are different things. They ask for "a dashboard" because that's what one asks for, not because a dashboard solves their problem. They say "make it faster" without a number to hit.
+
+The cheapest moment to find this gap is before any plan, spec, or code exists. Once you've started building, switching costs are real, and the user will rationalize the wrong thing into a "good enough" thing. The misfit gets locked in.
+
+This skill closes the gap before it costs anything. The other Define-phase skills assume you already know roughly what you want: `idea-refine` generates variations from an idea, `spec-driven-development` writes the requirements down, `doubt-driven-development` stress-tests a plan after you've drafted one. Interview-me is the part before all of those, where you ask one question at a time, with your best guess attached, until you can predict what the user is going to say before they say it.
+
+## When to Use
+
+Apply this skill when:
+
+- The ask is missing at least one of: **who** the user is, **why** they want it, what **success** looks like, what the binding **constraint** is
+- The request is conventional rather than specific ("build me X", "make it faster") and you can't unpack the convention without guessing
+- You're tempted to start with assumptions you haven't surfaced
+- The user hasn't said which value they're optimizing for when two reasonable ones are in tension (simplicity vs. flexibility, cost vs. speed)
+- The user explicitly invokes: "interview me", "grill me", "before we start, are we sure?", "stress-test my thinking"
+
+**When NOT to use:**
+
+- The ask is unambiguous and self-contained ("rename this variable", "fix this typo")
+- The user has explicitly asked for speed over verification
+- Pure information requests ("how does X work?", "what does this code do?")
+- Mechanical operations (renames, formats, file moves)
+- You already have ≥95% confidence; re-read the stop condition below before assuming you don't
+
+## Loading Constraints
+
+This skill needs a live, responsive user. **Do not invoke in non-interactive contexts** like CI pipelines, scheduled runs, `/loop`, or autonomous-loop. If you're in one of those and the ask is underspecified, flag that as a blocker for the user instead of guessing.
+
+## The Process
+
+### Step 1: Hypothesize, with a confidence number
+
+Before asking anything, write down your current best read of what the user wants in **one sentence**, plus an honest confidence number (0–100%):
+
+```
+HYPOTHESIS: You want a way to answer "how are we doing?" in standup, and "dashboard" was the convention that came to mind.
+CONFIDENCE: ~30% — missing: who it's for, what "metrics" means in context, and what success looks like
+```
+
+The number forces honesty. If you wrote down a high number but can't actually predict the user's reactions to the next three questions you'd ask, the number is wrong. Start at the confidence level you can defend.
+
+When confidence is below ~70%, append a brief reason on the same line — what's still unresolved or missing. This tells the user exactly what the interview needs to surface, and prevents the number from being a vague signal.
+
+### Step 2: Ask one question at a time, each with a guess attached
+
+Format:
+
+```
+Q: <one focused question>
+GUESS: <your hypothesis for the answer, with the reasoning that produced it>
+```
+
+Wait for the user to react before asking the next question.
+
+**Why one at a time, not a batch:**
+
+- The user can't react to your hypotheses if you bury them in a list
+- Batches encourage skim-reading and surface answers
+- The third question often depends on the answer to the first; asking them all at once locks in the wrong framing
+- The user's energy for thinking carefully is finite; spend it one question at a time
+
+**Why attach a guess:**
+
+- The user reacts faster to a wrong guess than they generate an answer from scratch
+- It commits you to a hypothesis you can be visibly wrong about, which keeps you honest
+- It surfaces *your* assumptions, which is what the interview is meant to expose
+
+The risk here is a polite user agreeing with your guess to be agreeable. Mitigate by being visibly willing to be wrong, and occasionally guess in a direction you expect the user to push back on.
+
+### Step 3: Listen for "want vs. should want"
+
+The most dangerous answers are the ones where the user says what a thoughtful answer *sounds like* rather than what they actually want. Watch for:
+
+- Answers that pattern-match best-practice talk ("I want it to be scalable", "clean architecture") without specifics
+- Answers that defer to convention ("the way most apps do it", "the standard approach")
+- Phrases like "I should probably…", "I think I'm supposed to…", "good engineering practice says…"
+- Buzzwords as goals — when "modern", "scalable", "robust" are the answer instead of a specific outcome
+
+When you hear these, the question to ask is:
+
+> *"If you didn't have to justify this to anyone, what would you actually want?"*
+
+That single question often does more work than the previous five.
+
+### Step 4: Restate intent in the user's own words
+
+When your confidence is high, write back what you now think the user wants. Keep it tight (5–8 lines), use their language where possible, and structure it so the user can confirm or correct line by line:
+
+```
+Here's what I now think you want:
+
+- Outcome:      <one line>
+- User:         <one line — who benefits>
+- Why now:      <one line — what changed>
+- Success:      <one line — how we know it worked>
+- Constraint:   <one line — the binding limit>
+- Out of scope: <one line — what we're explicitly not doing>
+
+Yes / no / refine?
+```
+
+Including "Out of scope" is non-negotiable. Half of misalignment is silent disagreement about what is *not* being built.
+
+### Step 5: Confirm — explicit yes, not "whatever you think"
+
+The gate is an explicit "yes." The following are **not** yes:
+
+- "Whatever you think is best." → The user is delegating, which means they don't have 95% confidence either. Re-ask with two concrete options framed as a choice.
+- "Sounds good." → Ambiguous. Ask: "Anything you'd refine?" Silence isn't confirmation.
+- "Sure, let's go." → Often a polite exit, not an endorsement. Same follow-up.
+- Silence followed by "okay let's start." → The user has given up on the interview, not converged. Stop and ask whether you've missed something.
+
+If they correct you, fold the correction in and restate. Loop until you get an explicit yes.
+
+### The 95% Confidence Stop
+
+You're done when you can answer yes to this:
+
+> *Can I predict the user's reaction to the next three questions I would ask?*
+
+If yes, you have shared understanding. Stop interviewing and produce the restate. If no, you're not done; ask the next question.
+
+This is a checkable test, not a vibe. It also has a floor: if you've gone several rounds and still can't predict, that's information about the ask, not a reason to keep grinding. Stop and tell the user: "I've asked X questions and I still can't predict your reactions. Something foundational is missing. Want to step back?"
+
+## Output
+
+The output of this skill is a **confirmed statement of intent**: the restate from Step 4, with an explicit yes from Step 5. That's the deliverable. Specs, plans, and task lists are downstream; they consume the intent this skill produces.
+
+If the user wants the intent to persist (a multi-session project, a handoff to another collaborator), offer to save it to `docs/intent/[topic].md`. Only save if they confirm.
+
+## Example
+
+A short before-and-after.
+
+**Without `interview-me`:**
+
+```
+User:  build me a dashboard for our metrics
+Agent: <starts proposing chart libraries and layouts>
+```
+
+The agent has assumed: who it's for, what metrics, what "for our team" means, what success looks like. None of these are stated. Every assumption is a place the user can later say "that's not what I meant."
+
+**With `interview-me`:**
+
+```
+User: build me a dashboard for our metrics
+
+Agent:
+HYPOTHESIS: You want a way to answer "how are we doing?" in standup, and "dashboard" came to mind because that's the conventional answer.
+CONFIDENCE: ~30% — missing: who it's for, what "metrics" are, and what success looks like
+
+Q:     When you say "how are we doing?", who's asking — you alone, the engineering team in standup, or up the chain (e.g., your manager, an exec, a board)?
+GUESS: engineering team in standup, because "we" usually scopes that way and standups are where this question gets asked. If it's for execs the metrics and the framing change a lot.
+
+User: It's actually for me. I keep losing track of which experiments are running and what their early signal looks like.
+
+Agent:
+Updated read: not a team dashboard at all. It's a personal experiment tracker. Confidence: ~60% — still missing: what "early signal" means and what done looks like.
+
+Q:     Is the gap that you don't know which experiments exist, or that you can't see their results in one place?
+GUESS: the second one. You have a list of experiments somewhere, but their results live in five different tools, and reconciling them by hand is what you're tired of.
+
+User: First one actually. I literally don't have a list. They're spread across different docs.
+
+Agent: <continues>
+```
+
+Two questions in, the agent has discovered the actual ask isn't "a dashboard." It's "a list." Different artifact, different scope, different work. The dashboard would have been wrong.
+
+## Interaction with Other Skills
+
+- **`idea-refine`**: downstream. If the confirmed intent is "I want X but I don't know how to scope it," hand off to `idea-refine` to generate variations against the now-explicit intent.
+- **`spec-driven-development`**: downstream. If the confirmed intent is concrete ("I want X for Y users with Z success criteria"), hand off to `spec-driven-development` to write it down.
+- **`planning-and-task-breakdown`**: two hops downstream of this skill (after the spec).
+- **`doubt-driven-development`**: opposite end of the timeline. Interview-me is pre-decision intent extraction; doubt-driven is post-decision artifact review. Both catch divergence, but at different moments.
+- **`source-driven-development`**: orthogonal. Interview-me clarifies what the user wants; SDD verifies framework facts. They don't compete.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "The ask is clear enough" | If you can't write the user's desired outcome in one sentence right now, the ask isn't clear. Run Step 1 before deciding. |
+| "Asking too many questions wastes their time" | Time wasted by 4–6 targeted questions is small. Time wasted by building the wrong thing is enormous, and the user is the one bearing that cost. |
+| "I'll figure it out as I build" | Switching costs after code exists are 10x what they are now. Discovery during implementation is rework. |
+| "They said 'whatever you think,' so I should just decide" | "Whatever you think" is delegation, not decision. Re-ask with two concrete options as a choice. |
+| "I should give them several options to pick from" | Options work when the user knows what they want and is choosing between trade-offs. They don't know what they want yet. Listing options widens the search; asking narrows it. |
+| "If I attach my guess, I'm leading them" | Leading is the point. Reacting is faster than generating from scratch. The risk is sycophancy, not leading; mitigate by being visibly willing to be wrong. |
+| "We've talked enough, I get it" | Test it: can you predict their reaction to the next three questions? If not, you don't get it yet. |
+| "The user said yes, we're done" | If the yes followed a vague restate or an open-ended "sounds good," the yes is hollow. Restate concretely and re-confirm. |
+
+## Red Flags
+
+- Three or more questions in a single message: that's batching, not interviewing
+- A question without your hypothesis attached: that's surveying, not committing
+- Accepting "whatever you think is best" as a terminal answer
+- Producing a spec, plan, or task list before the user has explicitly confirmed your restate
+- Questions framed as "what would be best practice?" instead of "what do you actually want?"
+- The user gives a sophistication-signaling answer ("scalable", "clean", "modern") and you accept it without probing whether it's what they actually want
+- Three or more rounds without your confidence visibly rising: you're asking the wrong questions, step back and reframe
+- A confidence number below ~70% with no reason attached: the user can't help close the gap if they don't know what's missing
+- Saving the intent doc before the user has confirmed (the doc itself implies a yes the user didn't give)
+- Skipping the "Out of scope" line in the restate (silent disagreement about non-goals is half of misalignment)
+
+## Verification
+
+After applying interview-me:
+
+- [ ] An explicit hypothesis with a confidence number was stated in the first turn
+- [ ] Every confidence number below ~70% was accompanied by a one-line reason (what's still unresolved or missing)
+- [ ] Questions were asked one at a time, each with the agent's guess attached
+- [ ] At least one "what would you actually want if you didn't have to justify it?" probe ran when the user gave a sophistication-signaling or convention-signaling answer
+- [ ] A concrete restate (Outcome / User / Why now / Success / Constraint / Out of scope) was written back to the user
+- [ ] The user confirmed the restate with an explicit yes (not "whatever you think," not "sounds good," not silence)
+- [ ] At the stop point, the agent could predict reactions to the next three questions it would ask
+- [ ] Any handoff to a downstream skill (`idea-refine`, `spec-driven-development`) was framed in terms of the confirmed intent, not the original underspecified ask

--- a/profiles/addyosmani_agent-skills/for-forgecat/skills/performance-optimization/SKILL.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/skills/performance-optimization/SKILL.md
@@ -39,13 +39,18 @@ Measure before optimizing. Performance work without measurement is guessing — 
 
 ### Step 1: Measure
 
+Two complementary approaches — use both:
+
+- **Synthetic (Lighthouse, DevTools Performance tab):** Controlled conditions, reproducible. Best for CI regression detection and isolating specific issues.
+- **RUM (web-vitals library, CrUX):** Real user data in real conditions. Required to validate that a fix actually improved user experience.
+
 **Frontend:**
 ```bash
-# Lighthouse in Chrome DevTools (or CI)
+# Synthetic: Lighthouse in Chrome DevTools (or CI)
 # Chrome DevTools → Performance tab → Record
 # Chrome DevTools MCP → Performance trace
 
-# Web Vitals library in code
+# RUM: Web Vitals library in code
 import { onLCP, onINP, onCLS } from 'web-vitals';
 
 onLCP(console.log);
@@ -73,7 +78,10 @@ Use the symptom to decide what to measure first:
 What is slow?
 ├── First page load
 │   ├── Large bundle? --> Measure bundle size, check code splitting
-│   ├── Slow server response? --> Measure TTFB, check API/database
+│   ├── Slow server response? --> Measure TTFB in DevTools Network waterfall
+│   │   ├── DNS long? --> Add dns-prefetch / preconnect for known origins
+│   │   ├── TCP/TLS long? --> Enable HTTP/2, check edge deployment, keep-alive
+│   │   └── Waiting (server) long? --> Profile backend, check queries and caching
 │   └── Render-blocking resources? --> Check network waterfall for CSS/JS blocking
 ├── Interaction feels sluggish
 │   ├── UI freezes on click? --> Profile main thread, look for long tasks (>50ms)
@@ -144,18 +152,65 @@ const tasks = await db.tasks.findMany({
 #### Missing Image Optimization (Frontend)
 
 ```html
-<!-- BAD: No dimensions, no lazy loading, no responsive sizes -->
+<!-- BAD: No dimensions, no format optimization -->
 <img src="/hero.jpg" />
 
-<!-- GOOD: Responsive, lazy-loaded, properly sized -->
+<!-- GOOD: Hero / LCP image — art direction + resolution switching, high priority -->
+<!--
+  Two techniques combined:
+  - Art direction (media): different crop/composition per breakpoint
+  - Resolution switching (srcset + sizes): right file size per screen density
+-->
+<picture>
+  <!-- Mobile: portrait crop (8:10) -->
+  <source
+    media="(max-width: 767px)"
+    srcset="/hero-mobile-400.avif 400w, /hero-mobile-800.avif 800w"
+    sizes="100vw"
+    width="800"
+    height="1000"
+    type="image/avif"
+  />
+  <source
+    media="(max-width: 767px)"
+    srcset="/hero-mobile-400.webp 400w, /hero-mobile-800.webp 800w"
+    sizes="100vw"
+    width="800"
+    height="1000"
+    type="image/webp"
+  />
+  <!-- Desktop: landscape crop (2:1) -->
+  <source
+    srcset="/hero-800.avif 800w, /hero-1200.avif 1200w, /hero-1600.avif 1600w"
+    sizes="(max-width: 1200px) 100vw, 1200px"
+    width="1200"
+    height="600"
+    type="image/avif"
+  />
+  <source
+    srcset="/hero-800.webp 800w, /hero-1200.webp 1200w, /hero-1600.webp 1600w"
+    sizes="(max-width: 1200px) 100vw, 1200px"
+    width="1200"
+    height="600"
+    type="image/webp"
+  />
+  <img
+    src="/hero-desktop.jpg"
+    width="1200"
+    height="600"
+    fetchpriority="high"
+    alt="Hero image description"
+  />
+</picture>
+
+<!-- GOOD: Below-the-fold image — lazy loaded + async decoding -->
 <img
-  src="/hero.jpg"
-  srcset="/hero-400.webp 400w, /hero-800.webp 800w, /hero-1200.webp 1200w"
-  sizes="(max-width: 768px) 100vw, 50vw"
-  width="1200"
-  height="600"
+  src="/content.webp"
+  width="800"
+  height="400"
   loading="lazy"
-  alt="Hero image description"
+  decoding="async"
+  alt="Content image description"
 />
 ```
 
@@ -188,14 +243,23 @@ function TaskStats({ tasks }: Props) {
 #### Large Bundle Size
 
 ```typescript
-// BAD: Importing entire library
-import { format } from 'date-fns';
-
-// GOOD: Tree-shakable import (if the library supports it)
-import { format } from 'date-fns/format';
+// Modern bundlers (Vite, webpack 5+) handle named imports with tree-shaking automatically,
+// provided the dependency ships ESM and is marked `sideEffects: false` in package.json.
+// Profile before changing import styles — the real gains come from splitting and lazy loading.
 
 // GOOD: Dynamic import for heavy, rarely-used features
 const ChartLibrary = lazy(() => import('./ChartLibrary'));
+
+// GOOD: Route-level code splitting wrapped in Suspense
+const SettingsPage = lazy(() => import('./pages/Settings'));
+
+function App() {
+  return (
+    <Suspense fallback={<Spinner />}>
+      <SettingsPage />
+    </Suspense>
+  );
+}
 ```
 
 #### Missing Caching (Backend)

--- a/profiles/addyosmani_agent-skills/for-forgecat/skills/source-driven-development/SKILL.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/skills/source-driven-development/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: source-driven-development
+description: Grounds every implementation decision in official documentation. Use when you want authoritative, source-cited code free from outdated patterns. Use when building with any framework or library where correctness matters.
+---
+
+# Source-Driven Development
+
+## Overview
+
+Every framework-specific code decision must be backed by official documentation. Don't implement from memory — verify, cite, and let the user see your sources. Training data goes stale, APIs get deprecated, best practices evolve. This skill ensures the user gets code they can trust because every pattern traces back to an authoritative source they can check.
+
+## When to Use
+
+- The user wants code that follows current best practices for a given framework
+- Building boilerplate, starter code, or patterns that will be copied across a project
+- The user explicitly asks for documented, verified, or "correct" implementation
+- Implementing features where the framework's recommended approach matters (forms, routing, data fetching, state management, auth)
+- Reviewing or improving code that uses framework-specific patterns
+- Any time you are about to write framework-specific code from memory
+
+**When NOT to use:**
+
+- Correctness does not depend on a specific version (renaming variables, fixing typos, moving files)
+- Pure logic that works the same across all versions (loops, conditionals, data structures)
+- The user explicitly wants speed over verification ("just do it quickly")
+
+## The Process
+
+```
+DETECT ──→ FETCH ──→ IMPLEMENT ──→ CITE
+  │          │           │            │
+  ▼          ▼           ▼            ▼
+ What       Get the    Follow the   Show your
+ stack?     relevant   documented   sources
+            docs       patterns
+```
+
+### Step 1: Detect Stack and Versions
+
+Read the project's dependency file to identify exact versions:
+
+```
+package.json    → Node/React/Vue/Angular/Svelte
+composer.json   → PHP/Symfony/Laravel
+requirements.txt / pyproject.toml → Python/Django/Flask
+go.mod          → Go
+Cargo.toml      → Rust
+Gemfile         → Ruby/Rails
+```
+
+State what you found explicitly:
+
+```
+STACK DETECTED:
+- React 19.1.0 (from package.json)
+- Vite 6.2.0
+- Tailwind CSS 4.0.3
+→ Fetching official docs for the relevant patterns.
+```
+
+If versions are missing or ambiguous, **ask the user**. Don't guess — the version determines which patterns are correct.
+
+### Step 2: Fetch Official Documentation
+
+Fetch the specific documentation page for the feature you're implementing. Not the homepage, not the full docs — the relevant page.
+
+**Source hierarchy (in order of authority):**
+
+| Priority | Source | Example |
+|----------|--------|---------|
+| 1 | Official documentation | react.dev, docs.djangoproject.com, symfony.com/doc |
+| 2 | Official blog / changelog | react.dev/blog, nextjs.org/blog |
+| 3 | Web standards references | MDN, web.dev, html.spec.whatwg.org |
+| 4 | Browser/runtime compatibility | caniuse.com, node.green |
+
+**Not authoritative — never cite as primary sources:**
+
+- Stack Overflow answers
+- Blog posts or tutorials (even popular ones)
+- AI-generated documentation or summaries
+- Your own training data (that is the whole point — verify it)
+
+**Be precise with what you fetch:**
+
+```
+BAD:  Fetch the React homepage
+GOOD: Fetch react.dev/reference/react/useActionState
+
+BAD:  Search "django authentication best practices"
+GOOD: Fetch docs.djangoproject.com/en/6.0/topics/auth/
+```
+
+After fetching, extract the key patterns and note any deprecation warnings or migration guidance.
+
+When official sources conflict with each other (e.g. a migration guide contradicts the API reference), surface the discrepancy to the user and verify which pattern actually works against the detected version.
+
+### Step 3: Implement Following Documented Patterns
+
+Write code that matches what the documentation shows:
+
+- Use the API signatures from the docs, not from memory
+- If the docs show a new way to do something, use the new way
+- If the docs deprecate a pattern, don't use the deprecated version
+- If the docs don't cover something, flag it as unverified
+
+**When docs conflict with existing project code:**
+
+```
+CONFLICT DETECTED:
+The existing codebase uses useState for form loading state,
+but React 19 docs recommend useActionState for this pattern.
+(Source: react.dev/reference/react/useActionState)
+
+Options:
+A) Use the modern pattern (useActionState) — consistent with current docs
+B) Match existing code (useState) — consistent with codebase
+→ Which approach do you prefer?
+```
+
+Surface the conflict. Don't silently pick one.
+
+### Step 4: Cite Your Sources
+
+Every framework-specific pattern gets a citation. The user must be able to verify every decision.
+
+**In code comments:**
+
+```typescript
+// React 19 form handling with useActionState
+// Source: https://react.dev/reference/react/useActionState#usage
+const [state, formAction, isPending] = useActionState(submitOrder, initialState);
+```
+
+**In conversation:**
+
+```
+I'm using useActionState instead of manual useState for the
+form submission state. React 19 replaced the manual
+isPending/setIsPending pattern with this hook.
+
+Source: https://react.dev/blog/2024/12/05/react-19#actions
+"useTransition now supports async functions [...] to handle
+pending states automatically"
+```
+
+**Citation rules:**
+
+- Full URLs, not shortened
+- Prefer deep links with anchors where possible (e.g. `/useActionState#usage` over `/useActionState`) — anchors survive doc restructuring better than top-level pages
+- Quote the relevant passage when it supports a non-obvious decision
+- Include browser/runtime support data when recommending platform features
+- If you cannot find documentation for a pattern, say so explicitly:
+
+```
+UNVERIFIED: I could not find official documentation for this
+pattern. This is based on training data and may be outdated.
+Verify before using in production.
+```
+
+Honesty about what you couldn't verify is more valuable than false confidence.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "I'm confident about this API" | Confidence is not evidence. Training data contains outdated patterns that look correct but break against current versions. Verify. |
+| "Fetching docs wastes tokens" | Hallucinating an API wastes more. The user debugs for an hour, then discovers the function signature changed. One fetch prevents hours of rework. |
+| "The docs won't have what I need" | If the docs don't cover it, that's valuable information — the pattern may not be officially recommended. |
+| "I'll just mention it might be outdated" | A disclaimer doesn't help. Either verify and cite, or clearly flag it as unverified. Hedging is the worst option. |
+| "This is a simple task, no need to check" | Simple tasks with wrong patterns become templates. The user copies your deprecated form handler into ten components before discovering the modern approach exists. |
+
+## Red Flags
+
+- Writing framework-specific code without checking the docs for that version
+- Using "I believe" or "I think" about an API instead of citing the source
+- Implementing a pattern without knowing which version it applies to
+- Citing Stack Overflow or blog posts instead of official documentation
+- Using deprecated APIs because they appear in training data
+- Not reading `package.json` / dependency files before implementing
+- Delivering code without source citations for framework-specific decisions
+- Fetching an entire docs site when only one page is relevant
+
+## Verification
+
+After implementing with source-driven development:
+
+- [ ] Framework and library versions were identified from the dependency file
+- [ ] Official documentation was fetched for framework-specific patterns
+- [ ] All sources are official documentation, not blog posts or training data
+- [ ] Code follows the patterns shown in the current version's documentation
+- [ ] Non-trivial decisions include source citations with full URLs
+- [ ] No deprecated APIs are used (checked against migration guides)
+- [ ] Conflicts between docs and existing code were surfaced to the user
+- [ ] Anything that could not be verified is explicitly flagged as unverified

--- a/profiles/addyosmani_agent-skills/for-forgecat/skills/spec-driven-development/SKILL.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/skills/spec-driven-development/SKILL.md
@@ -160,7 +160,7 @@ Break the plan into discrete, implementable tasks:
 
 ### Phase 4: Implement
 
-Execute tasks one at a time following `incremental-implementation` and `test-driven-development` skills. Use `context-engineering` to load the right spec sections and source files at each step rather than flooding the agent with the entire spec.
+Execute tasks one at a time following `skills/incremental-implementation/SKILL.md` (`incremental-implementation`) and `skills/test-driven-development/SKILL.md` (`test-driven-development`). Use `skills/context-engineering/SKILL.md` (`context-engineering`) to load the right spec sections and source files at each step rather than flooding the agent with the entire spec.
 
 ## Keeping the Spec Alive
 

--- a/profiles/addyosmani_agent-skills/for-forgecat/skills/test-driven-development/SKILL.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/skills/test-driven-development/SKILL.md
@@ -356,6 +356,7 @@ For detailed testing patterns, examples, and anti-patterns across frameworks, se
 | "I tested it manually" | Manual testing doesn't persist. Tomorrow's change might break it with no way to know. |
 | "The code is self-explanatory" | Tests ARE the specification. They document what the code should do, not what it does. |
 | "It's just a prototype" | Prototypes become production code. Tests from day one prevent the "test debt" crisis. |
+| "Let me run the tests again just to be extra sure" | After a clean test run, repeating the same command adds nothing unless the code has changed since. Run again after subsequent edits, not as reassurance. |
 
 ## Red Flags
 
@@ -366,6 +367,7 @@ For detailed testing patterns, examples, and anti-patterns across frameworks, se
 - Tests that test framework behavior instead of application behavior
 - Test names that don't describe the expected behavior
 - Skipping tests to make the suite pass
+- Running the same test command twice in a row without any intervening code change
 
 ## Verification
 
@@ -377,3 +379,5 @@ After completing any implementation:
 - [ ] Test names describe the behavior being verified
 - [ ] No tests were skipped or disabled
 - [ ] Coverage hasn't decreased (if tracked)
+
+**Note:** Run each test command after a change that could affect the result. After a clean run, don't repeat the same command unless the code has changed since — re-running on unchanged code adds no confidence.

--- a/profiles/addyosmani_agent-skills/for-forgecat/skills/using-agent-skills/SKILL.md
+++ b/profiles/addyosmani_agent-skills/for-forgecat/skills/using-agent-skills/SKILL.md
@@ -16,13 +16,16 @@ When a task arrives, identify the development phase and apply the corresponding 
 ```
 Task arrives
     │
-    ├── Vague idea/need refinement? ──→ idea-refine
+    ├── Don't know what you want yet? ──────→ interview-me
+    ├── Have a rough concept, need variants? → idea-refine
     ├── New project/feature/change? ──→ spec-driven-development
     ├── Have a spec, need tasks? ──────→ planning-and-task-breakdown
     ├── Implementing code? ────────────→ incremental-implementation
     │   ├── UI work? ─────────────────→ frontend-ui-engineering
     │   ├── API work? ────────────────→ api-and-interface-design
-    │   └── Need better context? ─────→ context-engineering
+    │   ├── Need better context? ─────→ context-engineering
+    │   ├── Need doc-verified code? ───→ source-driven-development
+    │   └── Stakes high / unfamiliar code? ──→ doubt-driven-development
     ├── Writing/running tests? ────────→ test-driven-development
     │   └── Browser-based? ───────────→ browser-testing-with-devtools
     ├── Something broke? ──────────────→ debugging-and-error-recovery
@@ -134,16 +137,19 @@ These are the subtle errors that look like productivity but create problems:
 For a complete feature, the typical skill sequence is:
 
 ```
-1. idea-refine                 → Refine vague ideas
-2. spec-driven-development     → Define what we're building
-3. planning-and-task-breakdown → Break into verifiable chunks
-4. context-engineering         → Load the right context
-5. incremental-implementation  → Build slice by slice
-6. test-driven-development     → Prove each slice works
-7. code-review-and-quality     → Review before merge
-8. git-workflow-and-versioning → Clean commit history
-9. documentation-and-adrs      → Document decisions
-10. shipping-and-launch        → Deploy safely
+1.  interview-me                → Extract what the user actually wants
+2.  idea-refine                 → Refine vague ideas
+3.  spec-driven-development     → Define what we're building
+4.  planning-and-task-breakdown → Break into verifiable chunks
+5.  context-engineering         → Load the right context
+6.  source-driven-development   → Verify against official docs
+7.  incremental-implementation  → Build slice by slice
+8.  doubt-driven-development    → Cross-examine non-trivial decisions in-flight
+9.  test-driven-development     → Prove each slice works
+10. code-review-and-quality     → Review before merge
+11. git-workflow-and-versioning → Clean commit history
+12. documentation-and-adrs      → Document decisions
+13. shipping-and-launch         → Deploy safely
 ```
 
 Not every task needs every skill. A bug fix might only need: `debugging-and-error-recovery` → `test-driven-development` → `code-review-and-quality`.
@@ -152,10 +158,13 @@ Not every task needs every skill. A bug fix might only need: `debugging-and-erro
 
 | Phase | Skill | One-Line Summary |
 |-------|-------|-----------------|
+| Define | interview-me | Surface what the user actually wants before any plan, spec, or code exists |
 | Define | idea-refine | Refine ideas through structured divergent and convergent thinking |
 | Define | spec-driven-development | Requirements and acceptance criteria before code |
 | Plan | planning-and-task-breakdown | Decompose into small, verifiable tasks |
 | Build | incremental-implementation | Thin vertical slices, test each before expanding |
+| Build | source-driven-development | Verify against official docs before implementing |
+| Build | doubt-driven-development | Adversarial fresh-context review of every non-trivial decision |
 | Build | context-engineering | Right context at the right time |
 | Build | frontend-ui-engineering | Production-quality UI with accessibility |
 | Build | api-and-interface-design | Stable interfaces with clear contracts |


### PR DESCRIPTION
## Summary
- bump `profiles/addyosmani_agent-skills` to `0.0.1`
- add Forgecat hook manifest entries for the Claude Code session-start and simplify-ignore lifecycle hooks
- include executable hook scripts under `profiles/addyosmani_agent-skills/for-forgecat/hooks`
- update profile READMEs to list the included hooks

## Validation
- `bash -n profiles/addyosmani_agent-skills/for-forgecat/hooks/session-start.sh`
- `bash -n profiles/addyosmani_agent-skills/for-forgecat/hooks/simplify-ignore.sh`
- `profiles/addyosmani_agent-skills/for-forgecat/hooks/session-start.sh | jq -e .`
- `printf '{"tool_name":"Read","tool_input":{"file_path":"no-such-file.md"}}' | profiles/addyosmani_agent-skills/for-forgecat/hooks/simplify-ignore.sh`
- `git diff --check`
- `forgecat push --dry-run` from `for-forgecat` completed; existing warnings only in `browser-testing-with-devtools` and `security-and-hardening` skill docs
