### PR TITLE
fix: store gstack prompt markers in project state

### DIFF
--- a/profiles/garrytan_gstack/for-forgecat/README.md
+++ b/profiles/garrytan_gstack/for-forgecat/README.md
@@ -91,7 +91,7 @@ npx forgecat install @forgecat/garrytan_gstack
 |---|---|
 | Author | `Garry Tan` |
 | Original repository | `https://github.com/garrytan/gstack` |
-| Version | `0.0.6` |
+| Version | `0.0.7` |
 | Original commit | `22f8c7f` (2026-05-26) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/garrytan_gstack/for-forgecat/profile.yml
+++ b/profiles/garrytan_gstack/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: garrytan_gstack
-version: 0.0.6
+version: 0.0.7
 description: "Garry's Stack: a self-contained AI engineering workflow profile with browser QA, planning, review, security, design, deployment, iOS, documentation, and OpenClaw companion skills."
 repository: https://github.com/garrytan/gstack
 license: MIT

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/SKILL.md
@@ -132,9 +132,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/autoplan/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/autoplan/SKILL.md
@@ -141,9 +141,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/benchmark-models/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/benchmark-models/SKILL.md
@@ -135,9 +135,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/benchmark/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/benchmark/SKILL.md
@@ -135,9 +135,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/browse/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/browse/SKILL.md
@@ -133,9 +133,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/canary/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/canary/SKILL.md
@@ -133,9 +133,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/codex/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/codex/SKILL.md
@@ -136,9 +136,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/connect-chrome/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/connect-chrome/SKILL.md
@@ -132,9 +132,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/context-restore/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/context-restore/SKILL.md
@@ -137,9 +137,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/context-save/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/context-save/SKILL.md
@@ -136,9 +136,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/cso/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/cso/SKILL.md
@@ -139,9 +139,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/design-consultation/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/design-consultation/SKILL.md
@@ -159,9 +159,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/design-html/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/design-html/SKILL.md
@@ -140,9 +140,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/design-review/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/design-review/SKILL.md
@@ -137,9 +137,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/design-shotgun/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/design-shotgun/SKILL.md
@@ -154,9 +154,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/devex-review/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/devex-review/SKILL.md
@@ -139,9 +139,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/document-generate/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/document-generate/SKILL.md
@@ -139,9 +139,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/document-release/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/document-release/SKILL.md
@@ -137,9 +137,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/health/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/health/SKILL.md
@@ -135,9 +135,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/investigate/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/investigate/SKILL.md
@@ -174,9 +174,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/ios-clean/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/ios-clean/SKILL.md
@@ -137,9 +137,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/ios-design-review/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/ios-design-review/SKILL.md
@@ -139,9 +139,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/ios-fix/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/ios-fix/SKILL.md
@@ -140,9 +140,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/ios-qa/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/ios-qa/SKILL.md
@@ -143,9 +143,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/ios-sync/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/ios-sync/SKILL.md
@@ -137,9 +137,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/land-and-deploy/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/land-and-deploy/SKILL.md
@@ -132,9 +132,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/landing-report/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/landing-report/SKILL.md
@@ -133,9 +133,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/learn/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/learn/SKILL.md
@@ -135,9 +135,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/make-pdf/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/make-pdf/SKILL.md
@@ -170,9 +170,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/office-hours/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/office-hours/SKILL.md
@@ -170,9 +170,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/open-gstack-browser/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/open-gstack-browser/SKILL.md
@@ -132,9 +132,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/pair-agent/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/pair-agent/SKILL.md
@@ -134,9 +134,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/plan-ceo-review/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/plan-ceo-review/SKILL.md
@@ -164,9 +164,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/plan-design-review/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/plan-design-review/SKILL.md
@@ -136,9 +136,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/plan-devex-review/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/plan-devex-review/SKILL.md
@@ -142,9 +142,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/plan-eng-review/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/plan-eng-review/SKILL.md
@@ -140,9 +140,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/plan-tune/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/plan-tune/SKILL.md
@@ -145,9 +145,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/qa-only/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/qa-only/SKILL.md
@@ -135,9 +135,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/qa/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/qa/SKILL.md
@@ -141,9 +141,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/retro/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/retro/SKILL.md
@@ -152,9 +152,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/review/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/review/SKILL.md
@@ -137,9 +137,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/scrape/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/scrape/SKILL.md
@@ -133,9 +133,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/scripts/resolvers/preamble/generate-upgrade-check.ts
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/scripts/resolvers/preamble/generate-upgrade-check.ts
@@ -9,9 +9,9 @@ If output shows \`UPGRADE_AVAILABLE <old> <new>\`: read \`${ctx.paths.skillRoot}
 
 If output shows \`JUST_UPGRADED <from> <to>\`: print "Running gstack v{to} (just updated!)". If \`SPAWNED_SESSION\` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing \`${ctx.paths.skillRoot}/.feature-prompted-continuous-checkpoint\`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run \`${ctx.paths.binDir}/gstack-config set checkpoint_mode continuous\`. Always touch marker.
-- Missing \`${ctx.paths.skillRoot}/.feature-prompted-model-overlay\`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker \`.gstack/.feature-prompted-continuous-checkpoint\`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run \`${ctx.paths.binDir}/gstack-config set checkpoint_mode continuous\`. Always create \`.gstack/\` if needed and touch this marker.
+- Missing project marker \`.gstack/.feature-prompted-model-overlay\`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create \`.gstack/\` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.`;
 }

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/setup-browser-cookies/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/setup-browser-cookies/SKILL.md
@@ -129,9 +129,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/setup-deploy/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/setup-deploy/SKILL.md
@@ -136,9 +136,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/setup-gbrain/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/setup-gbrain/SKILL.md
@@ -135,9 +135,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/ship/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/ship/SKILL.md
@@ -137,9 +137,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/skillify/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/skillify/SKILL.md
@@ -133,9 +133,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 

--- a/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/sync-gbrain/SKILL.md
+++ b/profiles/garrytan_gstack/for-forgecat/skills/garrytan-gstack/sync-gbrain/SKILL.md
@@ -135,9 +135,9 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgra
 
 If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
 
-Feature discovery, max one prompt per session:
-- Missing `$GSTACK_ROOT/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.
-- Missing `$GSTACK_ROOT/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always touch marker.
+Feature discovery, max one prompt per project:
+- Missing project marker `.gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `$GSTACK_ROOT/bin/gstack-config set checkpoint_mode continuous`. Always create `.gstack/` if needed and touch this marker.
+- Missing project marker `.gstack/.feature-prompted-model-overlay`: inform "Model overlays are active. MODEL_OVERLAY shows the patch." Always create `.gstack/` if needed and touch this marker.
 
 After upgrade prompts, continue workflow.
 


### PR DESCRIPTION
## Summary
- Move gstack feature prompt marker state to project-local `.gstack/` markers so the instructions are platform-agnostic.
- Keep helper command execution resolved through `$GSTACK_ROOT/bin/gstack-config`, because the helper binary still lives inside the installed profile root.
- Bump `garrytan_gstack` to `0.0.7`.

## Notes
- Local conversion notes were written under `docs/gstack-conversion-progress.md` for team tracking, but intentionally left uncommitted because this repo PR should contain profile files only.

## Verification
- `git diff --check -- profiles/garrytan_gstack/for-forgecat`
- `forgecat push --dry-run` from `profiles/garrytan_gstack/for-forgecat`
- Grep confirmed no feature prompt markers remain under `.claude/skills/garrytan-gstack`, `.agents/skills/garrytan-gstack`, or `$GSTACK_ROOT/.feature-prompted...`.