### PR TITLE
Reset Azure profile version to 0.0.0

### DIFF
--- a/profiles/azure-skills/microsoft-azure_skills/README.md
+++ b/profiles/azure-skills/microsoft-azure_skills/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/microsoft-azure_skills
 |---|---|
 | Author | `Microsoft` |
 | Original repository | `https://github.com/microsoft/azure-skills` |
-| Version | `1.1.57` |
+| Version | `0.0.0` |
 | Original commit | `7cb89c2` (2026-05-28) |
 | License | `MIT` |
 | Source platform | `multi-host` |

--- a/profiles/azure-skills/microsoft-azure_skills/for-forgecat/profile.yml
+++ b/profiles/azure-skills/microsoft-azure_skills/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: microsoft-azure_skills
-version: 1.1.57
+version: 0.0.0
 description: Microsoft Azure MCP and Skills integration for cloud resource management, deployments, diagnostics, AI, identity, storage, messaging, Kubernetes, and Microsoft Foundry workflows.
 repository: https://github.com/microsoft/azure-skills
 license: MIT


### PR DESCRIPTION
## Summary
- reset `microsoft-azure_skills` forgecat profile version from upstream-derived `1.1.57` to profile-managed initial version `0.0.0`
- update the Azure profile README version table to match `for-forgecat/profile.yml`

## Validation
- `validate-profile.sh azure-skills microsoft-azure_skills` passed all 27 active checks
- unpublished `@forgecat/microsoft-azure_skills@1.1.57`
- published `@forgecat/microsoft-azure_skills@0.0.0` to the forgecat registry
- registry view confirms `Version: 0.0.0`, tags `azure, cloud, mcp`, integrity `sha256-b4bba6e4c862f5ea0981880edb9d4d45ad92aeb1fd1ca8bcb4bcc817e455949a`
- registry install smoke passed for Codex CLI: `@forgecat/microsoft-azure_skills@0.0.0` installed 683 files, including `.agents/skills`, `.codex/config.toml`, and `.codex/hooks.json`

## Notes
- The earlier `1.1.57` version incorrectly followed the upstream source repository version; forgecat profile versioning is independent and starts here at `0.0.0`.
- Azure publish still reports generic secret-scan warnings in upstream example/reference docs; no blocking publish errors were produced.