### PR TITLE
Fix obra superpowers SessionStart hook

### DIFF
--- a/profiles/obra_superpowers/README.md
+++ b/profiles/obra_superpowers/README.md
@@ -45,7 +45,7 @@ npx forgecat install @forgecat/obra_superpowers
 |---|---|
 | Author | Jesse Vincent |
 | Original repository | https://github.com/obra/superpowers |
-| Version | `0.0.0` |
+| Version | `0.0.1` |
 | Original commit | `f2cbfbe` |
 | License | MIT |
 | Source platform | Multi-host |

--- a/profiles/obra_superpowers/README.md
+++ b/profiles/obra_superpowers/README.md
@@ -45,7 +45,7 @@ npx forgecat install @forgecat/obra_superpowers
 |---|---|
 | Author | Jesse Vincent |
 | Original repository | https://github.com/obra/superpowers |
-| Version | `0.0.1` |
+| Version | `0.0.2` |
 | Original commit | `f2cbfbe` |
 | License | MIT |
 | Source platform | Multi-host |

--- a/profiles/obra_superpowers/for-forgecat/hooks/run-hook.cmd
+++ b/profiles/obra_superpowers/for-forgecat/hooks/run-hook.cmd
@@ -1,0 +1,46 @@
+: << 'CMDBLOCK'
+@echo off
+REM Cross-platform polyglot wrapper for hook scripts.
+REM On Windows: cmd.exe runs the batch portion, which finds and calls bash.
+REM On Unix: the shell interprets this as a script (: is a no-op in bash).
+REM
+REM Hook scripts use extensionless filenames (e.g. "session-start" not
+REM "session-start.sh") so Claude Code's Windows auto-detection -- which
+REM prepends "bash" to any command containing .sh -- doesn't interfere.
+REM
+REM Usage: run-hook.cmd <script-name> [args...]
+
+if "%~1"=="" (
+    echo run-hook.cmd: missing script name >&2
+    exit /b 1
+)
+
+set "HOOK_DIR=%~dp0"
+
+REM Try Git for Windows bash in standard locations
+if exist "C:\Program Files\Git\bin\bash.exe" (
+    "C:\Program Files\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+if exist "C:\Program Files (x86)\Git\bin\bash.exe" (
+    "C:\Program Files (x86)\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+
+REM Try bash on PATH (e.g. user-installed Git Bash, MSYS2, Cygwin)
+where bash >nul 2>nul
+if %ERRORLEVEL% equ 0 (
+    bash "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+
+REM No bash found - exit silently rather than error
+REM (plugin still works, just without SessionStart context injection)
+exit /b 0
+CMDBLOCK
+
+# Unix: run the named script directly
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_NAME="$1"
+shift
+exec bash "${SCRIPT_DIR}/${SCRIPT_NAME}" "$@"

--- a/profiles/obra_superpowers/for-forgecat/hooks/session-start.sh
+++ b/profiles/obra_superpowers/for-forgecat/hooks/session-start.sh
@@ -1,67 +1,25 @@
 #!/usr/bin/env bash
-# SessionStart hook for the Superpowers profile.
+# SessionStart hook for superpowers plugin
 
 set -euo pipefail
 
+# Determine plugin root directory
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PROFILE_DIR="$(dirname "$SCRIPT_DIR")"
-PROJECT_DIR="${CLAUDE_PROJECT_DIR:-${PWD}}"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-detect_platform() {
-  if [ -n "${FORGECAT_HOOK_PLATFORM:-}" ]; then
-    printf '%s\n' "$FORGECAT_HOOK_PLATFORM"
-    return 0
-  fi
-  if [ -n "${FORGECAT_PLATFORM:-}" ]; then
-    printf '%s\n' "$FORGECAT_PLATFORM"
-    return 0
-  fi
+# Check if legacy skills directory exists and build warning
+warning_message=""
+legacy_skills_dir="${HOME}/.config/superpowers/skills"
+if [ -d "$legacy_skills_dir" ]; then
+  warning_message="\n\n<important-reminder>IN YOUR FIRST REPLY AFTER SEEING THIS MESSAGE YOU MUST TELL THE USER: WARNING: Superpowers now uses Claude Code's skills system. Custom skills in ~/.config/superpowers/skills will not be read. Move custom skills to ~/.claude/skills instead. To make this message go away, remove ~/.config/superpowers/skills</important-reminder>"
+fi
 
-  # Forgecat 0.2.2 passes the platform to _fc_wrap.sh but does not export it to
-  # the user script. Keep one hook file by reading the parent wrapper argv when
-  # the hook is launched through Forgecat.
-  parent_args="$(ps -p "${PPID:-0}" -o args= 2>/dev/null || true)"
-  case "$parent_args" in
-    *"_fc_wrap.sh claude-code "*)
-      printf 'claude-code\n'
-      return 0
-      ;;
-    *"_fc_wrap.sh cursor "*)
-      printf 'cursor\n'
-      return 0
-      ;;
-    *"_fc_wrap.sh codex "*)
-      printf 'codex\n'
-      return 0
-      ;;
-  esac
+# Read using-superpowers content
+using_superpowers_content=$(cat "${PLUGIN_ROOT}/skills/using-superpowers/SKILL.md" 2>&1 || echo "Error reading using-superpowers skill")
 
-  if [ -n "${CURSOR_PLUGIN_ROOT:-}" ]; then
-    printf 'cursor\n'
-  elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -z "${COPILOT_CLI:-}" ]; then
-    printf 'claude-code\n'
-  elif [ -n "${CODEX_HOME:-}" ]; then
-    printf 'codex\n'
-  else
-    printf 'unknown\n'
-  fi
-}
-
-find_using_superpowers() {
-  for candidate in \
-    "$PROFILE_DIR/skills/using-superpowers/SKILL.md" \
-    "$PROJECT_DIR/.claude/skills/using-superpowers/SKILL.md" \
-    "$PROJECT_DIR/.agents/skills/using-superpowers/SKILL.md" \
-    "$PROJECT_DIR/.cursor/skills/using-superpowers/SKILL.md"
-  do
-    if [ -f "$candidate" ]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-  return 1
-}
-
+# Escape string for JSON embedding using bash parameter substitution.
+# Each ${s//old/new} is a single C-level pass - orders of magnitude
+# faster than the character-by-character loop this replaces.
 escape_for_json() {
   local s="$1"
   s="${s//\\/\\\\}"
@@ -72,33 +30,27 @@ escape_for_json() {
   printf '%s' "$s"
 }
 
-warning_message=""
-legacy_skills_dir="${HOME}/.config/superpowers/skills"
-if [ -d "$legacy_skills_dir" ]; then
-  warning_message="\n\n<important-reminder>IN YOUR FIRST REPLY AFTER SEEING THIS MESSAGE YOU MUST TELL THE USER: WARNING: Superpowers now uses agent skill directories. Custom skills in ~/.config/superpowers/skills will not be read. Move custom skills to ~/.claude/skills or ~/.agents/skills. To make this message go away, remove ~/.config/superpowers/skills</important-reminder>"
-fi
-
-if using_superpowers_path="$(find_using_superpowers)"; then
-  using_superpowers_content="$(cat "$using_superpowers_path" 2>&1)"
-else
-  using_superpowers_content="Error reading using-superpowers skill from installed Forgecat profile."
-fi
-
 using_superpowers_escaped="$(escape_for_json "$using_superpowers_content")"
 warning_escaped="$(escape_for_json "$warning_message")"
-session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the Skill tool:**\n\n${using_superpowers_escaped}\n\n${warning_escaped}\n</EXTREMELY_IMPORTANT>"
+session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**\n\n${using_superpowers_escaped}\n\n${warning_escaped}\n</EXTREMELY_IMPORTANT>"
 
-case "$(detect_platform)" in
-  cursor)
-    printf '{\n  "additional_context": "%s"\n}\n' "$session_context"
-    ;;
-  codex)
-    printf '{\n  "additionalContext": "%s"\n}\n' "$session_context"
-    ;;
-  claude-code)
-    printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$session_context"
-    ;;
-  *)
-    printf '{\n  "additionalContext": "%s"\n}\n' "$session_context"
-    ;;
-esac
+# Output context injection as JSON.
+# Cursor hooks expect additional_context (snake_case).
+# Claude Code and Codex SessionStart hooks expect
+# hookSpecificOutput.additionalContext (nested).
+# Copilot CLI (v1.0.11+) expects additionalContext (top-level, SDK standard).
+#
+# Uses printf instead of heredoc to work around bash 5.3+ heredoc hang.
+# See: https://github.com/obra/superpowers/issues/571
+if [ -n "${CURSOR_PLUGIN_ROOT:-}" ] || [ "${FORGECAT_HOOK_PLATFORM:-}" = "cursor" ] || [ "${FORGECAT_PLATFORM:-}" = "cursor" ]; then
+  # Cursor sets CURSOR_PLUGIN_ROOT (may also set CLAUDE_PLUGIN_ROOT).
+  printf '{\n  "additional_context": "%s"\n}\n' "$session_context"
+elif [ -n "${COPILOT_CLI:-}" ]; then
+  # Copilot CLI uses the SDK standard format from the upstream hook.
+  printf '{\n  "additionalContext": "%s"\n}\n' "$session_context"
+else
+  # Claude Code and Codex both accept the nested SessionStart output shape.
+  printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$session_context"
+fi
+
+exit 0

--- a/profiles/obra_superpowers/for-forgecat/profile.yml
+++ b/profiles/obra_superpowers/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: obra_superpowers
-version: 0.0.1
+version: 0.0.2
 description: Superpowers software development methodology for coding agents, including planning, TDD, debugging, subagent execution, review, and session-start skill bootstrap hooks.
 repository: https://github.com/obra/superpowers
 license: MIT

--- a/profiles/obra_superpowers/for-forgecat/profile.yml
+++ b/profiles/obra_superpowers/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: obra_superpowers
-version: 0.0.0
+version: 0.0.1
 description: Superpowers software development methodology for coding agents, including planning, TDD, debugging, subagent execution, review, and session-start skill bootstrap hooks.
 repository: https://github.com/obra/superpowers
 license: MIT


### PR DESCRIPTION
## Summary
- Reconvert the obra_superpowers SessionStart hook around the upstream handler instead of the previous platform dispatcher workaround.
- Remove parent-process argv detection from the profile hook.
- Emit the Codex-compatible nested SessionStart output shape by default.
- Preserve the upstream `hooks/run-hook.cmd` wrapper in the profile package for source fidelity.
- Load `using-superpowers` from forgecat's installed platform skill directories when the profile cache does not contain `skills/`.
- Bump the profile version to 0.0.3.

## Conversion Notes
- `hooks/run-hook.cmd` is preserved because it is part of the source hook runtime design.
- The current Forgecat hook command is still `./hooks/session-start.sh`, so `run-hook.cmd` may not be installed or invoked by the current Forgecat installer/runtime. It is included first for source completeness, and the runtime limitation should be carried into the conversion history after merge.
- forgecat installs hook scripts under `.forgecat/profiles/.../hooks/`, but installs Codex skills under `.agents/skills/`; the SessionStart hook now checks both the upstream plugin-root path and the installed platform skill paths.

## Validation
- `bash -n profiles/obra_superpowers/for-forgecat/hooks/session-start.sh`
- `bash scripts/validate-profile.sh obra_superpowers`
- Installed-layout fallback test: hook reads `.agents/skills/using-superpowers/SKILL.md` without missing-file errors
- Direct hook output check: Codex default and Claude => `hookSpecificOutput/SessionStart`, Cursor => `additional_context`, Copilot => `additionalContext`
- `forgecat push --dry-run`
- Published `@forgecat/obra_superpowers@0.0.3`
- Installed `@forgecat/obra_superpowers@0.0.3` for Codex and verified hook output shape as `hookSpecificOutput/SessionStart` with no missing `using-superpowers` file error
