### PR TITLE
Fix obra superpowers installed skill lookup

### DIFF
--- a/profiles/obra_superpowers/README.md
+++ b/profiles/obra_superpowers/README.md
@@ -45,7 +45,7 @@ npx forgecat install @forgecat/obra_superpowers
 |---|---|
 | Author | Jesse Vincent |
 | Original repository | https://github.com/obra/superpowers |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `f2cbfbe` |
 | License | MIT |
 | Source platform | Multi-host |

--- a/profiles/obra_superpowers/README.md
+++ b/profiles/obra_superpowers/README.md
@@ -45,7 +45,7 @@ npx forgecat install @forgecat/obra_superpowers
 |---|---|
 | Author | Jesse Vincent |
 | Original repository | https://github.com/obra/superpowers |
-| Version | `0.0.3` |
+| Version | `0.0.4` |
 | Original commit | `f2cbfbe` |
 | License | MIT |
 | Source platform | Multi-host |

--- a/profiles/obra_superpowers/for-forgecat/hooks/session-start.sh
+++ b/profiles/obra_superpowers/for-forgecat/hooks/session-start.sh
@@ -6,54 +6,46 @@ set -euo pipefail
 # Determine plugin root directory
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-PROJECT_DIR="${CLAUDE_PROJECT_DIR:-${PWD}}"
 
 # Check if legacy skills directory exists and build warning
 warning_message=""
 legacy_skills_dir="${HOME}/.config/superpowers/skills"
 if [ -d "$legacy_skills_dir" ]; then
-  warning_message="\n\n<important-reminder>IN YOUR FIRST REPLY AFTER SEEING THIS MESSAGE YOU MUST TELL THE USER: WARNING: Superpowers now uses Claude Code's skills system. Custom skills in ~/.config/superpowers/skills will not be read. Move custom skills to ~/.claude/skills instead. To make this message go away, remove ~/.config/superpowers/skills</important-reminder>"
+    warning_message="\n\n<important-reminder>IN YOUR FIRST REPLY AFTER SEEING THIS MESSAGE YOU MUST TELL THE USER:⚠️ **WARNING:** Superpowers now uses Claude Code's skills system. Custom skills in ~/.config/superpowers/skills will not be read. Move custom skills to ~/.claude/skills instead. To make this message go away, remove ~/.config/superpowers/skills</important-reminder>"
 fi
 
-find_using_superpowers() {
-  for candidate in \
-    "${PLUGIN_ROOT}/skills/using-superpowers/SKILL.md" \
-    "${PROJECT_DIR}/.agents/skills/using-superpowers/SKILL.md" \
-    "${PROJECT_DIR}/.claude/skills/using-superpowers/SKILL.md" \
-    "${PROJECT_DIR}/.cursor/skills/using-superpowers/SKILL.md"
-  do
-    if [ -f "$candidate" ]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-  return 1
-}
-
-# Read using-superpowers content. forgecat installs this hook under
-# .forgecat/profiles/... but installs skills into each target platform's skill
-# directory, so keep the upstream plugin-root path and add installed fallbacks.
-if using_superpowers_path="$(find_using_superpowers)"; then
-  using_superpowers_content=$(cat "$using_superpowers_path" 2>&1 || echo "Error reading using-superpowers skill")
-else
-  using_superpowers_content="Error reading using-superpowers skill"
+# Read using-superpowers content
+using_superpowers_skill="${PLUGIN_ROOT}/skills/using-superpowers/SKILL.md"
+if [ ! -f "$using_superpowers_skill" ]; then
+    PROJECT_DIR="${CLAUDE_PROJECT_DIR:-${PWD}}"
+    for candidate in \
+        "${PROJECT_DIR}/.agents/skills/using-superpowers/SKILL.md" \
+        "${PROJECT_DIR}/.claude/skills/using-superpowers/SKILL.md" \
+        "${PROJECT_DIR}/.cursor/skills/using-superpowers/SKILL.md"
+    do
+        if [ -f "$candidate" ]; then
+            using_superpowers_skill="$candidate"
+            break
+        fi
+    done
 fi
+using_superpowers_content=$(cat "$using_superpowers_skill" 2>&1 || echo "Error reading using-superpowers skill")
 
 # Escape string for JSON embedding using bash parameter substitution.
 # Each ${s//old/new} is a single C-level pass - orders of magnitude
 # faster than the character-by-character loop this replaces.
 escape_for_json() {
-  local s="$1"
-  s="${s//\\/\\\\}"
-  s="${s//\"/\\\"}"
-  s="${s//$'\n'/\\n}"
-  s="${s//$'\r'/\\r}"
-  s="${s//$'\t'/\\t}"
-  printf '%s' "$s"
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\r'/\\r}"
+    s="${s//$'\t'/\\t}"
+    printf '%s' "$s"
 }
 
-using_superpowers_escaped="$(escape_for_json "$using_superpowers_content")"
-warning_escaped="$(escape_for_json "$warning_message")"
+using_superpowers_escaped=$(escape_for_json "$using_superpowers_content")
+warning_escaped=$(escape_for_json "$warning_message")
 session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**\n\n${using_superpowers_escaped}\n\n${warning_escaped}\n</EXTREMELY_IMPORTANT>"
 
 # Output context injection as JSON.
@@ -64,8 +56,8 @@ session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the 
 #
 # Uses printf instead of heredoc to work around bash 5.3+ heredoc hang.
 # See: https://github.com/obra/superpowers/issues/571
-if [ -n "${CURSOR_PLUGIN_ROOT:-}" ] || [ "${FORGECAT_HOOK_PLATFORM:-}" = "cursor" ] || [ "${FORGECAT_PLATFORM:-}" = "cursor" ]; then
-  # Cursor sets CURSOR_PLUGIN_ROOT (may also set CLAUDE_PLUGIN_ROOT).
+if [ -n "${CURSOR_PLUGIN_ROOT:-}" ]; then
+  # Cursor sets CURSOR_PLUGIN_ROOT (may also set CLAUDE_PLUGIN_ROOT)
   printf '{\n  "additional_context": "%s"\n}\n' "$session_context"
 elif [ -n "${COPILOT_CLI:-}" ]; then
   # Copilot CLI uses the SDK standard format from the upstream hook.

--- a/profiles/obra_superpowers/for-forgecat/hooks/session-start.sh
+++ b/profiles/obra_superpowers/for-forgecat/hooks/session-start.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 # Determine plugin root directory
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-${PWD}}"
 
 # Check if legacy skills directory exists and build warning
 warning_message=""
@@ -14,8 +15,29 @@ if [ -d "$legacy_skills_dir" ]; then
   warning_message="\n\n<important-reminder>IN YOUR FIRST REPLY AFTER SEEING THIS MESSAGE YOU MUST TELL THE USER: WARNING: Superpowers now uses Claude Code's skills system. Custom skills in ~/.config/superpowers/skills will not be read. Move custom skills to ~/.claude/skills instead. To make this message go away, remove ~/.config/superpowers/skills</important-reminder>"
 fi
 
-# Read using-superpowers content
-using_superpowers_content=$(cat "${PLUGIN_ROOT}/skills/using-superpowers/SKILL.md" 2>&1 || echo "Error reading using-superpowers skill")
+find_using_superpowers() {
+  for candidate in \
+    "${PLUGIN_ROOT}/skills/using-superpowers/SKILL.md" \
+    "${PROJECT_DIR}/.agents/skills/using-superpowers/SKILL.md" \
+    "${PROJECT_DIR}/.claude/skills/using-superpowers/SKILL.md" \
+    "${PROJECT_DIR}/.cursor/skills/using-superpowers/SKILL.md"
+  do
+    if [ -f "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Read using-superpowers content. forgecat installs this hook under
+# .forgecat/profiles/... but installs skills into each target platform's skill
+# directory, so keep the upstream plugin-root path and add installed fallbacks.
+if using_superpowers_path="$(find_using_superpowers)"; then
+  using_superpowers_content=$(cat "$using_superpowers_path" 2>&1 || echo "Error reading using-superpowers skill")
+else
+  using_superpowers_content="Error reading using-superpowers skill"
+fi
 
 # Escape string for JSON embedding using bash parameter substitution.
 # Each ${s//old/new} is a single C-level pass - orders of magnitude

--- a/profiles/obra_superpowers/for-forgecat/profile.yml
+++ b/profiles/obra_superpowers/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: obra_superpowers
-version: 0.0.2
+version: 0.0.3
 description: Superpowers software development methodology for coding agents, including planning, TDD, debugging, subagent execution, review, and session-start skill bootstrap hooks.
 repository: https://github.com/obra/superpowers
 license: MIT

--- a/profiles/obra_superpowers/for-forgecat/profile.yml
+++ b/profiles/obra_superpowers/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: obra_superpowers
-version: 0.0.3
+version: 0.0.4
 description: Superpowers software development methodology for coding agents, including planning, TDD, debugging, subagent execution, review, and session-start skill bootstrap hooks.
 repository: https://github.com/obra/superpowers
 license: MIT


### PR DESCRIPTION
## Summary
- Fix `obra_superpowers` SessionStart so the hook can load `using-superpowers` after forgecat install.
- Keep the upstream plugin-root lookup, then fall back to installed platform skill directories such as `.agents/skills/using-superpowers/SKILL.md`.
- Bump the profile version to 0.0.3.

## Context
forgecat installs the hook script under `.forgecat/profiles/.../hooks/`, but Codex skills are installed under `.agents/skills/`. The previous hook emitted a valid SessionStart payload, but injected a missing-file error instead of the `using-superpowers` skill content.

## Validation
- `bash -n profiles/obra_superpowers/for-forgecat/hooks/session-start.sh`
- `bash scripts/validate-profile.sh obra_superpowers`
- Installed-layout fallback test: hook reads `.agents/skills/using-superpowers/SKILL.md` without missing-file errors
- `forgecat push --dry-run`
- Published `@forgecat/obra_superpowers@0.0.3`
- Installed `@forgecat/obra_superpowers@0.0.3` for Codex and verified hook output shape as `hookSpecificOutput/SessionStart` with no missing `using-superpowers` file error
