### PR TITLE
Fix obra superpowers source platform and publish 0.0.5

### DIFF
--- a/profiles/obra_superpowers/README.md
+++ b/profiles/obra_superpowers/README.md
@@ -45,10 +45,10 @@ npx forgecat install @forgecat/obra_superpowers
 |---|---|
 | Author | Jesse Vincent |
 | Original repository | https://github.com/obra/superpowers |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `f2cbfbe` |
 | License | MIT |
-| Source platform | Multi-host |
+| Source platform | Claude Code |
 
 ## Compatibility
 

--- a/profiles/obra_superpowers/for-forgecat/profile.yml
+++ b/profiles/obra_superpowers/for-forgecat/profile.yml
@@ -1,10 +1,10 @@
 name: obra_superpowers
-version: 0.0.4
+version: 0.0.5
 description: Superpowers software development methodology for coding agents, including planning, TDD, debugging, subagent execution, review, and session-start skill bootstrap hooks.
 repository: https://github.com/obra/superpowers
 license: MIT
 visibility: public
-sourcePlatform: multi-host
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:


### PR DESCRIPTION
## Summary
- Change `obra_superpowers` `sourcePlatform` from invalid `multi-host` to `claude-code`
- Bump profile version to `0.0.5`
- Keep README metadata in sync

## Validation
- `bash /Users/openclawuser/.openclaw/workspace-forgecat/scripts/validate-profile.sh obra_superpowers` passed
- `forgecat push --dry-run` passed: 49 profile files collected, security scan passed
- Published `@forgecat/obra_superpowers@0.0.5` to the forgecat registry
- Verified registry latest version is `0.0.5`
- Installed `@forgecat/obra_superpowers@0.0.5` for Codex and Claude Code in temp workspaces
- Verified installed SessionStart hook configs and hook wrapper output for both platforms

Conversion history update intentionally skipped for this version-sync-only change.