### PR TITLE
Sync continual learning cursor profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ This repository hosts a curated set of **AI Agent Profiles** for [ForgeCat](http
 | [anthropics_claude-code](./profiles/anthropics_claude-code) | 1 | Claude Code profile conversion |
 | [anthropics_knowledge-work-plugins](./profiles/anthropics_knowledge-work-plugins) | 14 | Knowledge work plugins — legal, finance, HR, marketing, operations, and more |
 | [awslabs_aidlc-workflows](./profiles/awslabs_aidlc-workflows) | 1 | AWS AI-DLC workflow rules profile for planning, construction, and governance workflows |
-| [cursor_plugins](./profiles/cursor_plugins) | 2 | Plugins for Cursor — team workflows and iterative agent loops |
+| [cursor_plugins](./profiles/cursor_plugins) | 3 | Plugins for Cursor — team workflows, continual learning, and iterative agent loops |
 | [everyinc_compound-engineering-plugin](./profiles/everyinc_compound-engineering-plugin) | 1 | AI-powered development profile with deep workflows for review, research, and design |
 | [garrytan_gstack](./profiles/garrytan_gstack) | 1 | Garry's Stack — 35+ AI engineering workflow skills for planning, QA, review, and deployment |
 | [gemini-skills](./profiles/gemini-skills) | 3 | Google Gemini skills set converted into installable Forgecat profiles (API dev, interactions API, live API) |
 | [microsoft_azure-skills](./profiles/microsoft_azure-skills) | 20 | Microsoft Azure skills converted from `microsoft/azure-skills`, including the full Azure plugin profile plus split legacy skill profiles |
 | [msitarzewski_agency-agents](./profiles/msitarzewski_agency-agents) | 13 | Team role agents for agencies — academic, design, engineering, marketing, sales, and more |
+| [multica-ai_andrej-karpathy-skills](./profiles/multica-ai_andrej-karpathy-skills) | 1 | Andrej Karpathy coding guidelines for focused, verifiable agent work |
 | [obra_superpowers](./profiles/obra_superpowers) | 1 | Superpowers profile with hook-backed startup context |
 | [openai-skills](./profiles/openai-skills) | 45 | Skills for OpenAI platforms — ASP.NET Core, Figma, Playwright, and more |
 | [tldraw_tldraw](./profiles/tldraw_tldraw) | 1 | Visual collaboration profile powered by the tldraw MCP server |
@@ -35,7 +36,7 @@ This repository hosts a curated set of **AI Agent Profiles** for [ForgeCat](http
 | [vercel-labs_agent-skills](./profiles/vercel-labs_agent-skills) | 7 | Vercel agent skill collection split into installable profiles (deploy, React, UI audit, and workflow skills) |
 | [voltagent_awesome-codex-subagents](./profiles/voltagent_awesome-codex-subagents) | 10 | Subagents for OpenAI Codex — development, infrastructure, security, research |
 
-Total profiles: **155** across **18** collections.
+Total profiles: **157** across **19** collections.
 
 ---
 

--- a/profiles/cursor_plugins/cursor_plugins_continual-learning/README.md
+++ b/profiles/cursor_plugins/cursor_plugins_continual-learning/README.md
@@ -1,0 +1,49 @@
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+
+# Continual Learning
+
+Incrementally keeps AGENTS.md up to date from transcript changes.
+
+## Tags
+- Agent Memory
+- Automation
+- Transcripts
+- Cursor
+
+## Installation
+```bash
+npx forgecat install @forgecat/cursor_plugins_continual-learning
+```
+
+## Agents
+- **agents-memory-updater** — Mine high-signal transcript deltas, update AGENTS.md, and keep the incremental transcript index in sync. `inherit` `Memory`
+
+## Skills
+- **continual-learning** — Orchestrate continual learning by delegating transcript mining and AGENTS.md updates to agents-memory-updater. `Memory`
+
+## Details
+| Field | Value |
+|---|---|
+| Author | `Cursor` |
+| Original repository | `https://github.com/cursor/plugins` |
+| Version | `0.0.4` |
+| Original commit | `9c39b57` (2026-03-13) |
+| License | `MIT` |
+| Source platform | `cursor` |
+
+## Compatibility
+### Platforms
+| Platform | Status |
+|---|---|
+| Cursor | Tested |
+| Claude Code | Tested |
+| Codex | Partial |
+
+### Models
+| Model | Role |
+|---|---|
+| None specified | recommended |
+| None specified | minimum |
+
+## Dependencies
+- Requires Bun for the stop hook runtime.

--- a/profiles/cursor_plugins/cursor_plugins_continual-learning/for-forgecat/LICENSE
+++ b/profiles/cursor_plugins/cursor_plugins_continual-learning/for-forgecat/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Cursor
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/profiles/cursor_plugins/cursor_plugins_continual-learning/for-forgecat/README.md
+++ b/profiles/cursor_plugins/cursor_plugins_continual-learning/for-forgecat/README.md
@@ -1,0 +1,51 @@
+*written by Forgecat*
+
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+
+# Continual Learning
+
+Incrementally keeps AGENTS.md up to date from transcript changes.
+
+## Tags
+- Agent Memory
+- Automation
+- Transcripts
+- Cursor
+
+## Installation
+```bash
+npx forgecat install @forgecat/cursor_plugins_continual-learning
+```
+
+## Agents
+- **agents-memory-updater** — Mine high-signal transcript deltas, update AGENTS.md, and keep the incremental transcript index in sync. `inherit` `Memory`
+
+## Skills
+- **continual-learning** — Orchestrate continual learning by delegating transcript mining and AGENTS.md updates to agents-memory-updater. `Memory`
+
+## Details
+| Field | Value |
+|---|---|
+| Author | `Cursor` |
+| Original repository | `https://github.com/cursor/plugins` |
+| Version | `0.0.4` |
+| Original commit | `9c39b57` (2026-03-13) |
+| License | `MIT` |
+| Source platform | `cursor` |
+
+## Compatibility
+### Platforms
+| Platform | Status |
+|---|---|
+| Cursor | Tested |
+| Claude Code | Tested |
+| Codex | Partial |
+
+### Models
+| Model | Role |
+|---|---|
+| None specified | recommended |
+| None specified | minimum |
+
+## Dependencies
+- Requires Bun for the stop hook runtime.

--- a/profiles/cursor_plugins/cursor_plugins_continual-learning/for-forgecat/agents/agents-memory-updater.md
+++ b/profiles/cursor_plugins/cursor_plugins_continual-learning/for-forgecat/agents/agents-memory-updater.md
@@ -1,0 +1,47 @@
+---
+name: agents-memory-updater
+description: Mine high-signal transcript deltas, update `AGENTS.md`, and keep the incremental transcript index in sync.
+model: inherit
+---
+
+# AGENTS.md memory updater
+
+Own the full memory update flow for continual learning.
+
+## Trigger
+
+Use from `continual-learning` when transcript deltas may produce durable memory updates.
+
+## Workflow
+
+1. Read existing `AGENTS.md` first. If it does not exist, create it with only:
+   - `## Learned User Preferences`
+   - `## Learned Workspace Facts`
+2. Load the incremental index if present.
+3. Inspect only transcript files under `~/.cursor/projects/<workspace-slug>/agent-transcripts/` that are new or have newer mtimes than the index.
+4. Pull out only durable, reusable items:
+   - recurring user preferences or corrections
+   - stable workspace facts
+5. Update `AGENTS.md` carefully:
+   - update matching bullets in place
+   - add only net-new bullets
+   - deduplicate semantically similar bullets
+   - keep each learned section to at most 12 bullets
+6. Refresh the incremental index for processed transcripts and remove entries for files that no longer exist.
+7. If the merge produces no `AGENTS.md` changes, leave `AGENTS.md` unchanged but still refresh the index.
+8. If no meaningful updates exist, respond exactly: `No high-signal memory updates.`
+
+## Guardrails
+
+- Use plain bullet points only.
+- Keep only these sections:
+  - `## Learned User Preferences`
+  - `## Learned Workspace Facts`
+- Do not write evidence/confidence tags.
+- Do not write process instructions, rationale, or metadata blocks.
+- Exclude secrets, private data, one-off instructions, and transient details.
+
+## Output
+
+- Updated `AGENTS.md` and the hook-provided incremental transcript index when needed
+- Otherwise exactly `No high-signal memory updates.`

--- a/profiles/cursor_plugins/cursor_plugins_continual-learning/for-forgecat/hooks/continual-learning-stop.ts
+++ b/profiles/cursor_plugins/cursor_plugins_continual-learning/for-forgecat/hooks/continual-learning-stop.ts
@@ -1,0 +1,250 @@
+#!/usr/bin/env bun
+/// <reference types="bun-types-no-globals/lib/index.d.ts" />
+
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { stdin } from "bun";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const PROFILE_DIR = resolve(SCRIPT_DIR, "..");
+const STATE_DIR = resolve(PROFILE_DIR, "state");
+const STATE_PATH = resolve(STATE_DIR, "continual-learning.json");
+const INCREMENTAL_INDEX_PATH = resolve(STATE_DIR, "continual-learning-index.json");
+const DEFAULT_MIN_TURNS = 10;
+const DEFAULT_MIN_MINUTES = 120;
+const TRIAL_DEFAULT_MIN_TURNS = 3;
+const TRIAL_DEFAULT_MIN_MINUTES = 15;
+const TRIAL_DEFAULT_DURATION_MINUTES = 24 * 60;
+
+const FOLLOWUP_MESSAGE =
+  `Run the \`continual-learning\` skill now. Use the \`agents-memory-updater\` subagent for the full memory update flow. Use incremental transcript processing with index file \`${INCREMENTAL_INDEX_PATH}\`: only consider transcripts not in the index or transcripts whose mtime is newer than indexed mtime. Have the subagent refresh index mtimes, remove entries for deleted transcripts, and update \`AGENTS.md\` only for high-signal recurring user corrections and durable workspace facts. Exclude one-off/transient details and secrets. If no meaningful updates exist, respond exactly: No high-signal memory updates.`;
+
+interface StopHookInput {
+  conversation_id: string;
+  generation_id?: string;
+  status: "completed" | "aborted" | "error" | string;
+  loop_count: number;
+  transcript_path?: string | null;
+}
+
+interface ContinuousLearningState {
+  version: 1;
+  lastRunAtMs: number;
+  turnsSinceLastRun: number;
+  lastTranscriptMtimeMs: number | null;
+  lastProcessedGenerationId: string | null;
+  trialStartedAtMs: number | null;
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
+function parseBoolean(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  return (
+    normalized === "1" ||
+    normalized === "true" ||
+    normalized === "yes" ||
+    normalized === "on"
+  );
+}
+
+function readEnvValue(primary: string, legacy: string): string | undefined {
+  return process.env[primary] ?? process.env[legacy];
+}
+
+function loadState(): ContinuousLearningState {
+  const fallback: ContinuousLearningState = {
+    version: 1,
+    lastRunAtMs: 0,
+    turnsSinceLastRun: 0,
+    lastTranscriptMtimeMs: null,
+    lastProcessedGenerationId: null,
+    trialStartedAtMs: null,
+  };
+
+  if (!existsSync(STATE_PATH)) {
+    return fallback;
+  }
+
+  try {
+    const raw = readFileSync(STATE_PATH, "utf-8");
+    const parsed = JSON.parse(raw) as Partial<ContinuousLearningState>;
+    if (parsed.version !== 1) {
+      return fallback;
+    }
+    return {
+      version: 1,
+      lastRunAtMs:
+        typeof parsed.lastRunAtMs === "number" && Number.isFinite(parsed.lastRunAtMs)
+          ? parsed.lastRunAtMs
+          : 0,
+      turnsSinceLastRun:
+        typeof parsed.turnsSinceLastRun === "number" &&
+        Number.isFinite(parsed.turnsSinceLastRun) &&
+        parsed.turnsSinceLastRun >= 0
+          ? parsed.turnsSinceLastRun
+          : 0,
+      lastTranscriptMtimeMs:
+        typeof parsed.lastTranscriptMtimeMs === "number" &&
+        Number.isFinite(parsed.lastTranscriptMtimeMs)
+          ? parsed.lastTranscriptMtimeMs
+          : null,
+      lastProcessedGenerationId:
+        typeof parsed.lastProcessedGenerationId === "string"
+          ? parsed.lastProcessedGenerationId
+          : null,
+      trialStartedAtMs:
+        typeof parsed.trialStartedAtMs === "number" &&
+        Number.isFinite(parsed.trialStartedAtMs)
+          ? parsed.trialStartedAtMs
+          : null,
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+function saveState(state: ContinuousLearningState): void {
+  const directory = dirname(STATE_PATH);
+  if (!existsSync(directory)) {
+    mkdirSync(directory, { recursive: true });
+  }
+  writeFileSync(STATE_PATH, `${JSON.stringify(state, null, 2)}\n`, "utf-8");
+}
+
+function getTranscriptMtimeMs(transcriptPath: string | null | undefined): number | null {
+  if (!transcriptPath) {
+    return null;
+  }
+
+  try {
+    return statSync(transcriptPath).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+function shouldCountTurn(input: StopHookInput): boolean {
+  return input.status === "completed" && input.loop_count === 0;
+}
+
+async function parseHookInput<T>(): Promise<T> {
+  const text = await stdin.text();
+  return JSON.parse(text) as T;
+}
+
+async function main(): Promise<number> {
+  try {
+    const input = await parseHookInput<StopHookInput>();
+    const state = loadState();
+
+    if (input.generation_id && input.generation_id === state.lastProcessedGenerationId) {
+      console.log(JSON.stringify({}));
+      return 0;
+    }
+    state.lastProcessedGenerationId = input.generation_id ?? null;
+
+    const countedTurn = shouldCountTurn(input);
+    const turnIncrement = countedTurn ? 1 : 0;
+    const turnsSinceLastRun = state.turnsSinceLastRun + turnIncrement;
+    const now = Date.now();
+
+    const trialEnabled = parseBoolean(
+      readEnvValue("CONTINUAL_LEARNING_TRIAL_MODE", "CONTINUOUS_LEARNING_TRIAL_MODE")
+    );
+    if (trialEnabled && countedTurn && state.trialStartedAtMs === null) {
+      state.trialStartedAtMs = now;
+    }
+
+    const trialDurationMinutes = parsePositiveInt(
+      readEnvValue(
+        "CONTINUAL_LEARNING_TRIAL_DURATION_MINUTES",
+        "CONTINUOUS_LEARNING_TRIAL_DURATION_MINUTES"
+      ),
+      TRIAL_DEFAULT_DURATION_MINUTES
+    );
+    const trialMinTurns = parsePositiveInt(
+      readEnvValue(
+        "CONTINUAL_LEARNING_TRIAL_MIN_TURNS",
+        "CONTINUOUS_LEARNING_TRIAL_MIN_TURNS"
+      ),
+      TRIAL_DEFAULT_MIN_TURNS
+    );
+    const trialMinMinutes = parsePositiveInt(
+      readEnvValue(
+        "CONTINUAL_LEARNING_TRIAL_MIN_MINUTES",
+        "CONTINUOUS_LEARNING_TRIAL_MIN_MINUTES"
+      ),
+      TRIAL_DEFAULT_MIN_MINUTES
+    );
+    const inTrialWindow =
+      trialEnabled &&
+      state.trialStartedAtMs !== null &&
+      now - state.trialStartedAtMs < trialDurationMinutes * 60_000;
+
+    const minTurns = parsePositiveInt(
+      readEnvValue("CONTINUAL_LEARNING_MIN_TURNS", "CONTINUOUS_LEARNING_MIN_TURNS"),
+      DEFAULT_MIN_TURNS
+    );
+    const minMinutes = parsePositiveInt(
+      readEnvValue("CONTINUAL_LEARNING_MIN_MINUTES", "CONTINUOUS_LEARNING_MIN_MINUTES"),
+      DEFAULT_MIN_MINUTES
+    );
+
+    const effectiveMinTurns = inTrialWindow ? trialMinTurns : minTurns;
+    const effectiveMinMinutes = inTrialWindow ? trialMinMinutes : minMinutes;
+    const minutesSinceLastRun =
+      state.lastRunAtMs > 0
+        ? Math.floor((now - state.lastRunAtMs) / 60000)
+        : Number.POSITIVE_INFINITY;
+    const transcriptMtimeMs = getTranscriptMtimeMs(input.transcript_path);
+    const hasTranscriptAdvanced =
+      transcriptMtimeMs !== null &&
+      (state.lastTranscriptMtimeMs === null || transcriptMtimeMs > state.lastTranscriptMtimeMs);
+
+    const shouldTrigger =
+      countedTurn &&
+      turnsSinceLastRun >= effectiveMinTurns &&
+      minutesSinceLastRun >= effectiveMinMinutes &&
+      hasTranscriptAdvanced;
+
+    if (shouldTrigger) {
+      state.lastRunAtMs = now;
+      state.turnsSinceLastRun = 0;
+      state.lastTranscriptMtimeMs = transcriptMtimeMs;
+      saveState(state);
+
+      console.log(
+        JSON.stringify({
+          followup_message: FOLLOWUP_MESSAGE,
+        })
+      );
+      return 0;
+    }
+
+    state.turnsSinceLastRun = turnsSinceLastRun;
+    saveState(state);
+    console.log(JSON.stringify({}));
+    return 0;
+  } catch (error) {
+    console.error("[continual-learning-stop] failed", error);
+    console.log(JSON.stringify({}));
+    return 0;
+  }
+}
+
+const exitCode = await main();
+process.exit(exitCode);

--- a/profiles/cursor_plugins/cursor_plugins_continual-learning/for-forgecat/profile.yml
+++ b/profiles/cursor_plugins/cursor_plugins_continual-learning/for-forgecat/profile.yml
@@ -1,0 +1,36 @@
+name: "@forgecat/cursor_plugins_continual-learning"
+version: 0.0.4
+description: Incrementally learns durable user preferences and workspace facts from
+  transcript changes and keeps AGENTS.md up to date with plain bullet points.
+repository: https://github.com/cursor/plugins
+license: MIT
+visibility: public
+sourcePlatform: cursor
+compatibility:
+  platforms:
+    tested:
+    - cursor
+    - claude-code
+    partial:
+    - codex
+  models:
+    recommended: []
+    minimum: []
+agents:
+- name: agents-memory-updater
+  path: agents/agents-memory-updater.md
+  description: Mine high-signal transcript deltas, update AGENTS.md, and keep the
+    incremental transcript index in sync.
+  model: inherit
+skills:
+- name: continual-learning
+  path: skills/continual-learning/SKILL.md
+  description: Orchestrate continual learning by delegating transcript mining and
+    AGENTS.md updates to agents-memory-updater.
+hooks:
+- id: continual-learning-stop
+  trigger: stop
+  command: ./hooks/continual-learning-stop.ts
+  timeout: 30
+  description: Checks stop events for transcript changes and asks the agent to run
+    the continual-learning skill when cadence thresholds are met.

--- a/profiles/cursor_plugins/cursor_plugins_continual-learning/for-forgecat/skills/continual-learning/SKILL.md
+++ b/profiles/cursor_plugins/cursor_plugins_continual-learning/for-forgecat/skills/continual-learning/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: continual-learning
+description: Orchestrate continual learning by delegating transcript mining and AGENTS.md updates to `agents-memory-updater`.
+disable-model-invocation: true
+---
+
+# Continual Learning
+
+Keep `AGENTS.md` current by delegating the memory update flow to one subagent.
+
+## Trigger
+
+Use when the user asks to mine prior chats, maintain `AGENTS.md`, or run the continual-learning loop.
+
+## Workflow
+
+1. Call `agents-memory-updater`.
+2. Return the updater result.
+
+## Guardrails
+
+- Keep the parent skill orchestration-only.
+- Do not mine transcripts or edit files in the parent flow.
+- Do not bypass the subagent.


### PR DESCRIPTION
## Summary
- Add the registry-only `@forgecat/cursor_plugins_continual-learning@0.0.4` profile to `profiles/cursor_plugins/`.
- Update the root README collection table and profile totals.

## Verification
- `forgecat validate` in `profiles/cursor_plugins/cursor_plugins_continual-learning/for-forgecat`
- `git diff --cached --check` before commit
- Confirmed repo profile count is 157 and continual-learning metadata matches registry 0.0.4.

Note: `forgecat install <local path> --dry-run` is still blocked by the current CLI with `Only registry sources are supported... Got: local`, so local install dry-run was not usable for this repo-source check.