### PR TITLE
fix: mark skill installer as codex tested only

### DIFF
--- a/profiles/openai-skills/openai_skills_system-skill-installer/README.md
+++ b/profiles/openai-skills/openai_skills_system-skill-installer/README.md
@@ -31,8 +31,8 @@ npx forgecat install @forgecat/openai_skills_system-skill-installer
 
 | Platform | Status |
 |---|---|
-| Claude Code | Tested |
-| Cursor | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 | Codex | Tested |
 
 ### Models

--- a/profiles/openai-skills/openai_skills_system-skill-installer/for-forgecat/README.md
+++ b/profiles/openai-skills/openai_skills_system-skill-installer/for-forgecat/README.md
@@ -33,8 +33,8 @@ npx forgecat install @forgecat/openai_skills_system-skill-installer
 
 | Platform | Status |
 |---|---|
-| Claude Code | Tested |
-| Cursor | Tested |
+| Claude Code | Partial |
+| Cursor | Partial |
 | Codex | Tested |
 
 ### Models

--- a/profiles/openai-skills/openai_skills_system-skill-installer/for-forgecat/profile.yml
+++ b/profiles/openai-skills/openai_skills_system-skill-installer/for-forgecat/profile.yml
@@ -10,10 +10,10 @@ sourcePlatform: codex
 compatibility:
   platforms:
     tested:
-      - claude-code
       - codex
+    partial:
+      - claude-code
       - cursor
-    partial: []
   models:
     recommended:
     - gpt-5.4


### PR DESCRIPTION
## Summary
- Marks `@forgecat/openai_skills_system-skill-installer` as Codex-tested only.
- Moves Claude Code and Cursor from tested to partial in `profile.yml`.
- Updates both README compatibility tables to match the manifest.

## Validation
- `forgecat validate` passed for `profiles/openai-skills/openai_skills_system-skill-installer/for-forgecat`.
- Only expected note: deprecated `version` field is ignored by Forgecat push.
