### PR TITLE
Sync caveman registry metadata

### DIFF
--- a/profiles/juliusbrussee_caveman/README.md
+++ b/profiles/juliusbrussee_caveman/README.md
@@ -40,7 +40,7 @@ npx forgecat install @forgecat/juliusbrussee_caveman
 |---|---|
 | Author | Julius Brussee |
 | Original repository | https://github.com/JuliusBrussee/caveman |
-| Version | `0.1.4` |
+| Version | `0.1.5` |
 | Original commit | `655b7d9c5431f822264b7732e9901c5578ac84cf` |
 | License | MIT |
 | Source platform | Multi-platform: Claude Code plugin, Codex plugin/config, Gemini extension, opencode plugin, and skills installer |
@@ -52,7 +52,7 @@ npx forgecat install @forgecat/juliusbrussee_caveman
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
+| Cursor | Tested |
 | Codex | Partial |
 
 ### Models

--- a/profiles/juliusbrussee_caveman/for-forgecat/README.md
+++ b/profiles/juliusbrussee_caveman/for-forgecat/README.md
@@ -40,7 +40,7 @@ npx forgecat install @forgecat/juliusbrussee_caveman
 |---|---|
 | Author | Julius Brussee |
 | Original repository | https://github.com/JuliusBrussee/caveman |
-| Version | `0.1.3` |
+| Version | `0.1.5` |
 | Original commit | `655b7d9c5431f822264b7732e9901c5578ac84cf` |
 | License | MIT |
 | Source platform | Multi-platform: Claude Code plugin, Codex plugin/config, Gemini extension, opencode plugin, and skills installer |
@@ -52,7 +52,7 @@ npx forgecat install @forgecat/juliusbrussee_caveman
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
+| Cursor | Tested |
 | Codex | Partial |
 
 ### Models

--- a/profiles/juliusbrussee_caveman/for-forgecat/profile.yml
+++ b/profiles/juliusbrussee_caveman/for-forgecat/profile.yml
@@ -1,5 +1,5 @@
 name: "@forgecat/juliusbrussee_caveman"
-version: 0.1.4
+version: 0.1.5
 description: Ultra-compressed communication mode for coding agents, including caveman response style, terse commit/review helpers, memory-file compression, Cavecrew subagents, and Claude/Codex session-start activation hooks.
 repository: https://github.com/JuliusBrussee/caveman
 license: MIT
@@ -9,9 +9,9 @@ compatibility:
   platforms:
     tested:
     - claude-code
+    - cursor
     partial:
     - codex
-    - cursor
   models:
     recommended:
     - haiku


### PR DESCRIPTION
## Summary

- Sync `juliusbrussee_caveman` repo metadata to the already-published Forgecat registry version `0.1.5`
- Match latest registry platform status: Claude Code and Cursor tested, Codex partial
- Align root README, for-forgecat README, and profile.yml version metadata

## Verification

- `forgecat view @forgecat/juliusbrussee_caveman` shows registry `0.1.5` with Claude Code and Cursor tested
- `forgecat validate --json` passes for the profile
- Targeted registry/repo sync gate passes with zero version/platform drift
