### PR TITLE
Mark oh-my-claudecode agents all-platform tested

### DIFF
--- a/profiles/yeachan-heo/oh-my-claudecode_agents/README.md
+++ b/profiles/yeachan-heo/oh-my-claudecode_agents/README.md
@@ -48,7 +48,7 @@ npx forgecat install @forgecat/yeachan-heo_oh-my-claudecode_agents
 |---|---|
 | Author | Yeachan Heo |
 | Original repository | https://github.com/Yeachan-Heo/oh-my-claudecode/tree/main/agents |
-| Registry version | `0.1.0` |
+| Registry version | `0.1.2` |
 | Original commit | `deee3a446dadc9bfea31cdc8b19b00b16718082e` (2026-06-09) |
 | License | MIT |
 | Source platform | Claude Code |

--- a/profiles/yeachan-heo/oh-my-claudecode_agents/README.md
+++ b/profiles/yeachan-heo/oh-my-claudecode_agents/README.md
@@ -48,7 +48,7 @@ npx forgecat install @forgecat/yeachan-heo_oh-my-claudecode_agents
 |---|---|
 | Author | Yeachan Heo |
 | Original repository | https://github.com/Yeachan-Heo/oh-my-claudecode/tree/main/agents |
-| Registry version | `0.1.2` |
+| Registry version | `0.1.3` |
 | Original commit | `deee3a446dadc9bfea31cdc8b19b00b16718082e` (2026-06-09) |
 | License | MIT |
 | Source platform | Claude Code |
@@ -60,7 +60,7 @@ npx forgecat install @forgecat/yeachan-heo_oh-my-claudecode_agents
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial - install/materialization passes; `codex exec` did not recognize project-scoped custom agent types from `.codex/agents` in runtime smoke |
+| Codex | Tested |
 | Cursor | Tested |
 
 ### Models

--- a/profiles/yeachan-heo/oh-my-claudecode_agents/for-forgecat/README.md
+++ b/profiles/yeachan-heo/oh-my-claudecode_agents/for-forgecat/README.md
@@ -9,7 +9,7 @@ This profile packages only the upstream `agents/` directory from `Yeachan-Heo/oh
 | Field | Value |
 |---|---|
 | Original repository | https://github.com/Yeachan-Heo/oh-my-claudecode/tree/main/agents |
-| Registry version | `0.1.2` |
+| Registry version | `0.1.3` |
 | Original commit | `deee3a446dadc9bfea31cdc8b19b00b16718082e` (2026-06-09) |
 | License | MIT |
 | Source platform | claude-code |
@@ -21,7 +21,7 @@ This profile packages only the upstream `agents/` directory from `Yeachan-Heo/oh
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial - install/materialization passes; `codex exec` did not recognize project-scoped custom agent types from `.codex/agents` in runtime smoke |
+| Codex | Tested |
 | Cursor | Tested |
 
 ## Included

--- a/profiles/yeachan-heo/oh-my-claudecode_agents/for-forgecat/README.md
+++ b/profiles/yeachan-heo/oh-my-claudecode_agents/for-forgecat/README.md
@@ -9,7 +9,7 @@ This profile packages only the upstream `agents/` directory from `Yeachan-Heo/oh
 | Field | Value |
 |---|---|
 | Original repository | https://github.com/Yeachan-Heo/oh-my-claudecode/tree/main/agents |
-| Registry version | `0.1.0` |
+| Registry version | `0.1.2` |
 | Original commit | `deee3a446dadc9bfea31cdc8b19b00b16718082e` (2026-06-09) |
 | License | MIT |
 | Source platform | claude-code |

--- a/profiles/yeachan-heo/oh-my-claudecode_agents/for-forgecat/profile.yml
+++ b/profiles/yeachan-heo/oh-my-claudecode_agents/for-forgecat/profile.yml
@@ -11,9 +11,9 @@ compatibility:
   platforms:
     tested:
     - claude-code
-    - cursor
-    partial:
     - codex
+    - cursor
+    partial: []
   models:
     recommended:
     - opus


### PR DESCRIPTION
## Summary
- Update `@forgecat/yeachan-heo_oh-my-claudecode_agents` metadata to registry version `0.1.3`.
- Move `codex` from partial to tested after user-confirmed runtime testing on Codex, Cursor, and the bundled agents.
- Registry now shows `claude-code ✓`, `codex ✓`, and `cursor ✓`.

## Validation
- `forgecat validate --json`
- `ruby scripts/check-profile-layout.rb`
- `forgecat push --json --visibility public --bump patch` -> `0.1.3`, integrity `sha256-369da2334e3ac32d3ca8075c0acfe522bbb1677878b66e046d5e3697cceb7739`
- `forgecat view @forgecat/yeachan-heo_oh-my-claudecode_agents` confirms all three tested platforms
- Fresh install/status checks for `@forgecat/yeachan-heo_oh-my-claudecode_agents@0.1.3` on `claude-code`, `cursor`, and `codex`; each materialized 19 agent files and had clean forgecat status

## Profile Conversion PR Review Checklist
| Area | Status | Notes |
| --- | --- | --- |
| Internal file edits | Pass | Metadata-only update: README version/status and `profile.yml` platform status. |
| Behavior parity risk | Pass | Agent instruction content unchanged. |
| Platform install/runtime | Pass | `claude-code`, `cursor`, and `codex` are now tested. Codex/Cursor runtime status is based on user-confirmed agent testing; local verification confirmed clean 0.1.3 installs and 19 materialized agent files per platform. |
| Notes / special cases | Pass | The previous 0.1.2 Codex partial note is superseded by 0.1.3 tested metadata. |