### PR TITLE
Sync oh-my-claudecode agents registry version 0.1.4

### DIFF
--- a/profiles/yeachan-heo/oh-my-claudecode_agents/README.md
+++ b/profiles/yeachan-heo/oh-my-claudecode_agents/README.md
@@ -48,7 +48,7 @@ npx forgecat install @forgecat/yeachan-heo_oh-my-claudecode_agents
 |---|---|
 | Author | Yeachan Heo |
 | Original repository | https://github.com/Yeachan-Heo/oh-my-claudecode/tree/main/agents |
-| Registry version | `0.1.3` |
+| Registry version | `0.1.4` |
 | Original commit | `deee3a446dadc9bfea31cdc8b19b00b16718082e` (2026-06-09) |
 | License | MIT |
 | Source platform | Claude Code |

--- a/profiles/yeachan-heo/oh-my-claudecode_agents/for-forgecat/README.md
+++ b/profiles/yeachan-heo/oh-my-claudecode_agents/for-forgecat/README.md
@@ -9,7 +9,7 @@ This profile packages only the upstream `agents/` directory from `Yeachan-Heo/oh
 | Field | Value |
 |---|---|
 | Original repository | https://github.com/Yeachan-Heo/oh-my-claudecode/tree/main/agents |
-| Registry version | `0.1.3` |
+| Registry version | `0.1.4` |
 | Original commit | `deee3a446dadc9bfea31cdc8b19b00b16718082e` (2026-06-09) |
 | License | MIT |
 | Source platform | claude-code |


### PR DESCRIPTION
## Summary
- Sync `@forgecat/yeachan-heo_oh-my-claudecode_agents` README metadata to registry version `0.1.4`.
- This follow-up is needed because PR #96 merged before the 0.1.4 version-sync commit landed on that branch.
- Current `main` already has the accidental root `scripts/` folder removed.

## ForgeCat Publish
- Published `@forgecat/yeachan-heo_oh-my-claudecode_agents@0.1.4`.
- Integrity: `sha256-d605b66eb9e8c682a933ee9c28129cb398330a7b2db4ca9a450106a60986c3c5`.
- Registry platforms: `claude-code ✓`, `codex ✓`, `cursor ✓`.

## Validation
- `forgecat validate --json`
- `forgecat view @forgecat/yeachan-heo_oh-my-claudecode_agents`
- Fresh install/status checks for 0.1.4 on `claude-code`, `cursor`, and `codex`; each materialized 19 agent files and had clean forgecat status.