### PR TITLE
Profile: sync remotion cursor tested metadata

### DIFF
--- a/profiles/remotion-dev/skills/remotion-dev_skills_remotion/README.md
+++ b/profiles/remotion-dev/skills/remotion-dev_skills_remotion/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/remotion-dev_skills_remotion
 |---|---|
 | Author | Remotion |
 | Original repository | https://github.com/remotion-dev/skills |
-| Version | `0.1.2` |
+| Version | `0.1.3` |
 | Original commit | `277510e78245ac0fa275d7cb6520d52e0ac2e212` |
 | License | None |
 | Source platform | Claude Code |
@@ -40,7 +40,7 @@ npx forgecat install @forgecat/remotion-dev_skills_remotion
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
+| Cursor | Tested |
 | Codex | Tested |
 
 ## Dependencies

--- a/profiles/remotion-dev/skills/remotion-dev_skills_remotion/for-forgecat/README.md
+++ b/profiles/remotion-dev/skills/remotion-dev_skills_remotion/for-forgecat/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/remotion-dev_skills_remotion
 |---|---|
 | Author | Remotion |
 | Original repository | https://github.com/remotion-dev/skills |
-| Version | `0.1.2` |
+| Version | `0.1.3` |
 | Original commit | `277510e78245ac0fa275d7cb6520d52e0ac2e212` |
 | License | None |
 | Source platform | Claude Code |
@@ -42,7 +42,7 @@ npx forgecat install @forgecat/remotion-dev_skills_remotion
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
+| Cursor | Tested |
 | Codex | Tested |
 
 ## Dependencies

--- a/profiles/remotion-dev/skills/remotion-dev_skills_remotion/for-forgecat/profile.yml
+++ b/profiles/remotion-dev/skills/remotion-dev_skills_remotion/for-forgecat/profile.yml
@@ -9,8 +9,8 @@ compatibility:
     tested:
       - claude-code
       - codex
-    partial:
       - cursor
+    partial: []
   models:
     recommended: []
     minimum: []


### PR DESCRIPTION
## Summary

- Sync `@forgecat/remotion-dev_skills_remotion` repo metadata after PR #100 merged at `2e79b007`.
- Move Cursor from partial to tested in `for-forgecat/profile.yml`.
- Update both README version rows from `0.1.2` to registry version `0.1.3` and mark Cursor as Tested.

## Validation

- `npx forgecat validate --json` in `for-forgecat`: pass
- `npx forgecat scan --json`: pass, `untracked: []`
- `BASE_DIR=/tmp/forgecat-agent-profiles-remotion-cursor-tested/profiles bash /Users/openclawuser/.openclaw/workspace-forgecat/scripts/validate-profile.sh remotion-dev/skills remotion-dev_skills_remotion`: pass, all 27 active checks
- `check-registry-repo-sync-gate.sh --repo-profiles-dir /tmp/forgecat-agent-profiles-remotion-cursor-tested/profiles --profile @forgecat/remotion-dev_skills_remotion`: `SYNC_GATE_PASS`
- `scripts/check-profile-layout.rb`: not present in this repo checkout

## Profile Conversion Checklist

| Check | Status | Notes |
|---|---|---|
| Internal file edits | Done | Only three remotion metadata files changed. |
| Behavior parity risk | Low | No source payload or installed skill files changed. |
| Platform install/runtime | Done | Cursor completion was operator-confirmed after Claude Code and Codex runtime tests; this PR only syncs repo metadata to registry state. |
| Notes / special cases | Done | PR #100 merged before the Cursor-tested sync commit, so this PR carries only the missing follow-up metadata. |
