### PR TITLE
chore: normalize ForgeCat readme label and backfill sourcePlatform

### DIFF
--- a/profiles/addyosmani/agent-skills/for-claude/.forgecat/profiles/@forgecat/addyosmani_agent-skills/README.md
+++ b/profiles/addyosmani/agent-skills/for-claude/.forgecat/profiles/@forgecat/addyosmani_agent-skills/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/addyosmani/agent-skills/for-codex/.forgecat/profiles/@forgecat/addyosmani_agent-skills/README.md
+++ b/profiles/addyosmani/agent-skills/for-codex/.forgecat/profiles/@forgecat/addyosmani_agent-skills/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/addyosmani/agent-skills/for-cursor/.forgecat/profiles/@forgecat/addyosmani_agent-skills/README.md
+++ b/profiles/addyosmani/agent-skills/for-cursor/.forgecat/profiles/@forgecat/addyosmani_agent-skills/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-code/anthropics_claude-code_ralph-wiggum/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-code_ralph-wiggum/README.md
+++ b/profiles/anthropics/claude-code/anthropics_claude-code_ralph-wiggum/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-code_ralph-wiggum/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-code/anthropics_claude-code_ralph-wiggum/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-code_ralph-wiggum/README.md
+++ b/profiles/anthropics/claude-code/anthropics_claude-code_ralph-wiggum/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-code_ralph-wiggum/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-code/anthropics_claude-code_ralph-wiggum/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-code_ralph-wiggum/README.md
+++ b/profiles/anthropics/claude-code/anthropics_claude-code_ralph-wiggum/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-code_ralph-wiggum/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_agent-sdk-dev/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_agent-sdk-dev/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_agent-sdk-dev/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_agent-sdk-dev/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_agent-sdk-dev/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_agent-sdk-dev/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_agent-sdk-dev/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_agent-sdk-dev/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_agent-sdk-dev/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_agent-sdk-dev/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_agent-sdk-dev/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_agent-sdk-dev/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_agent-sdk-dev/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_agent-sdk-dev/for-forgecat/profile.yml
@@ -4,6 +4,7 @@ description: Claude Agent SDK Development Plugin
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/agent-sdk-dev
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-code-setup/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_claude-code-setup/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-code-setup/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_claude-code-setup/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-code-setup/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_claude-code-setup/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-code-setup/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_claude-code-setup/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-code-setup/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_claude-code-setup/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-code-setup/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_claude-code-setup/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-code-setup/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-code-setup/for-forgecat/profile.yml
@@ -5,6 +5,7 @@ description: Analyze codebases and recommend tailored Claude Code automations su
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/claude-code-setup
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-md-management/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_claude-md-management/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-md-management/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_claude-md-management/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-md-management/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_claude-md-management/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-md-management/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_claude-md-management/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-md-management/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_claude-md-management/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-md-management/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_claude-md-management/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-md-management/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-md-management/for-forgecat/profile.yml
@@ -5,6 +5,7 @@ description: Tools to maintain and improve CLAUDE.md files - audit quality, capt
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/claude-md-management
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-review/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_code-review/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-review/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_code-review/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-review/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_code-review/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-review/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_code-review/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-review/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-review/for-forgecat/profile.yml
@@ -5,6 +5,7 @@ description: Automated code review for pull requests using multiple specialized 
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-simplifier/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_code-simplifier/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-simplifier/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_code-simplifier/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-simplifier/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_code-simplifier/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-simplifier/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_code-simplifier/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-simplifier/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_code-simplifier/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-simplifier/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_code-simplifier/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-simplifier/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-simplifier/for-forgecat/profile.yml
@@ -5,6 +5,7 @@ description: Agent that simplifies and refines code for clarity, consistency, an
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-simplifier
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_commit-commands/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_commit-commands/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_commit-commands/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_commit-commands/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_commit-commands/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_commit-commands/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_commit-commands/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_commit-commands/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_commit-commands/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_commit-commands/for-forgecat/profile.yml
@@ -5,6 +5,7 @@ description: Streamline your git workflow with simple commands for committing, p
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/commit-commands
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_example-plugin/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_example-plugin/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_example-plugin/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_example-plugin/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_example-plugin/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_example-plugin/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_example-plugin/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_example-plugin/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_example-plugin/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_example-plugin/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_example-plugin/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_example-plugin/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_example-plugin/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_example-plugin/for-forgecat/profile.yml
@@ -5,6 +5,7 @@ description: A comprehensive example plugin demonstrating all Claude Code extens
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/example-plugin
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_feature-dev/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_feature-dev/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_feature-dev/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_feature-dev/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_feature-dev/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_feature-dev/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_feature-dev/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_feature-dev/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_feature-dev/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_feature-dev/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_feature-dev/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_feature-dev/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_feature-dev/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_feature-dev/for-forgecat/profile.yml
@@ -5,6 +5,7 @@ description: Comprehensive feature development workflow with specialized agents 
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/feature-dev
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_frontend-design/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_frontend-design/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_frontend-design/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_frontend-design/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_frontend-design/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_frontend-design/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_frontend-design/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_frontend-design/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_frontend-design/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_frontend-design/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_frontend-design/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_frontend-design/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_frontend-design/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_frontend-design/for-forgecat/profile.yml
@@ -4,6 +4,7 @@ description: Frontend design skill for UI/UX implementation
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/frontend-design
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_math-olympiad/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_math-olympiad/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_math-olympiad/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_math-olympiad/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_math-olympiad/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_math-olympiad/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_math-olympiad/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_math-olympiad/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_math-olympiad/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_math-olympiad/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_math-olympiad/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_math-olympiad/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_math-olympiad/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_math-olympiad/for-forgecat/profile.yml
@@ -6,6 +6,7 @@ description: Solve competition math (IMO, Putnam, USAMO) with adversarial verifi
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/math-olympiad
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_mcp-server-dev/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_mcp-server-dev/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_mcp-server-dev/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_mcp-server-dev/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_mcp-server-dev/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_mcp-server-dev/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_mcp-server-dev/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_mcp-server-dev/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_mcp-server-dev/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_mcp-server-dev/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_mcp-server-dev/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_mcp-server-dev/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_mcp-server-dev/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_mcp-server-dev/for-forgecat/profile.yml
@@ -6,6 +6,7 @@ description: Skills for designing and building MCP servers that work seamlessly 
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/mcp-server-dev
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_playground/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_playground/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_playground/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_playground/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_playground/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_playground/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_playground/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_playground/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_playground/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_playground/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_playground/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_playground/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_playground/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_playground/for-forgecat/profile.yml
@@ -5,6 +5,7 @@ description: Creates interactive HTML playgrounds — self-contained single-file
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/playground
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_plugin-dev/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_plugin-dev/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_plugin-dev/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_plugin-dev/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_plugin-dev/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_plugin-dev/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-forgecat/profile.yml
@@ -5,6 +5,7 @@ description: Plugin development toolkit with skills for creating agents, command
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/plugin-dev
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_pr-review-toolkit/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_pr-review-toolkit/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_pr-review-toolkit/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_pr-review-toolkit/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_pr-review-toolkit/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_pr-review-toolkit/for-forgecat/profile.yml
@@ -5,6 +5,7 @@ description: Comprehensive PR review agents specializing in comments, tests, err
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/pr-review-toolkit
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_session-report/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_session-report/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_session-report/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_session-report/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_session-report/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_session-report/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_session-report/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_session-report/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_session-report/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_session-report/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_session-report/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_session-report/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_session-report/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_session-report/for-forgecat/profile.yml
@@ -5,6 +5,7 @@ description: Generate an explorable HTML report of Claude Code session usage (to
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/session-report
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_skill-creator/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_skill-creator/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_skill-creator/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_skill-creator/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_skill-creator/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_skill-creator/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_skill-creator/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_skill-creator/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_skill-creator/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_skill-creator/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_skill-creator/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_skill-creator/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_skill-creator/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_skill-creator/for-forgecat/profile.yml
@@ -6,6 +6,7 @@ description: Create new skills, improve existing skills, and measure skill perfo
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/skill-creator
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_bio-research/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_bio-research/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_bio-research/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_bio-research/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_bio-research/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_bio-research/for-forgecat/profile.yml
@@ -6,6 +6,7 @@ description: Connect to preclinical research tools and databases (literature sea
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/bio-research
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-forgecat/profile.yml
@@ -5,6 +5,7 @@ description: Triage tickets, draft responses, escalate issues, and build your kn
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/customer-support
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_data/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_data/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_data/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_data/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_data/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_data/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_data/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_data/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_data/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_data/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_data/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_data/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_data/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_data/for-forgecat/profile.yml
@@ -5,6 +5,7 @@ description: Write SQL, explore datasets, and generate insights faster. Build vi
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/data
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-forgecat/profile.yml
@@ -6,6 +6,7 @@ description: Accelerate design workflows — critique, design system management,
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/design
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-forgecat/profile.yml
@@ -6,6 +6,7 @@ description: Streamline engineering workflows — standups, code review, archite
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/engineering
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-forgecat/profile.yml
@@ -5,6 +5,7 @@ description: Search across all of your company's tools in one place. Find anythi
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/enterprise-search
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-forgecat/profile.yml
@@ -6,6 +6,7 @@ description: Streamline finance and accounting workflows, from journal entries a
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/finance
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-forgecat/profile.yml
@@ -6,6 +6,7 @@ description: Streamline people operations — recruiting, onboarding, performanc
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/human-resources
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/profile.yml
@@ -6,6 +6,7 @@ description: Speed up contract review, NDA triage, and compliance workflows for 
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/legal
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/profile.yml
@@ -6,6 +6,7 @@ description: Create content, plan campaigns, and analyze performance across mark
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/marketing
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-forgecat/profile.yml
@@ -6,6 +6,7 @@ description: Optimize business operations — vendor management, process documen
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/operations
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/profile.yml
@@ -5,6 +5,7 @@ description: Write feature specs, plan roadmaps, and synthesize user research fa
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/product-management
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_productivity/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_productivity/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_productivity/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_productivity/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_productivity/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_productivity/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_productivity/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_productivity/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_productivity/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_productivity/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_productivity/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_productivity/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_productivity/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_productivity/for-forgecat/profile.yml
@@ -6,6 +6,7 @@ description: Manage tasks, plan your day, and build up memory of important conte
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/productivity
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-forgecat/profile.yml
@@ -5,6 +5,7 @@ description: Prospect, craft outreach, and build deal strategy faster. Prep for 
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/sales
 license: Apache-2.0
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_small-business/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_small-business/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_small-business/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_small-business/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_small-business/for-forgecat/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_small-business/for-forgecat/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_algorithmic-art/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_algorithmic-art/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_algorithmic-art/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_algorithmic-art/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_algorithmic-art/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_algorithmic-art/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_algorithmic-art/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_algorithmic-art/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_algorithmic-art/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_algorithmic-art/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_algorithmic-art/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_algorithmic-art/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_algorithmic-art/for-forgecat/profile.yml
+++ b/profiles/anthropics/skills/anthropics_skills_algorithmic-art/for-forgecat/profile.yml
@@ -7,6 +7,7 @@ description: Creating algorithmic art using p5.js with seeded randomness and int
 repository: https://github.com/anthropics/skills
 license: Complete terms in LICENSE.txt
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_brand-guidelines/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_brand-guidelines/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_brand-guidelines/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_brand-guidelines/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_brand-guidelines/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_brand-guidelines/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-forgecat/profile.yml
+++ b/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-forgecat/profile.yml
@@ -7,6 +7,7 @@ description: Applies Anthropic's official brand colors and typography to any sor
 repository: https://github.com/anthropics/skills
 license: Complete terms in LICENSE.txt
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/skills/anthropics_skills_canvas-design/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_canvas-design/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_canvas-design/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_canvas-design/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_canvas-design/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_canvas-design/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_canvas-design/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_canvas-design/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_canvas-design/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_canvas-design/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_canvas-design/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_canvas-design/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_canvas-design/for-forgecat/profile.yml
+++ b/profiles/anthropics/skills/anthropics_skills_canvas-design/for-forgecat/profile.yml
@@ -7,6 +7,7 @@ description: Create beautiful visual art in .png and .pdf documents using design
 repository: https://github.com/anthropics/skills
 license: Complete terms in LICENSE.txt
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/skills/anthropics_skills_claude-api/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_claude-api/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_claude-api/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_claude-api/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_claude-api/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_claude-api/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_claude-api/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_claude-api/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_claude-api/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_claude-api/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_claude-api/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_claude-api/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_claude-api/for-forgecat/profile.yml
+++ b/profiles/anthropics/skills/anthropics_skills_claude-api/for-forgecat/profile.yml
@@ -12,6 +12,7 @@ description: 'Build, debug, and optimize Claude API / Anthropic SDK apps. Apps b
 repository: https://github.com/anthropics/skills
 license: Complete terms in LICENSE.txt
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/skills/anthropics_skills_doc-coauthoring/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_doc-coauthoring/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_doc-coauthoring/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_doc-coauthoring/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_doc-coauthoring/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_doc-coauthoring/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_doc-coauthoring/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_doc-coauthoring/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_doc-coauthoring/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_doc-coauthoring/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_doc-coauthoring/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_doc-coauthoring/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_doc-coauthoring/for-forgecat/profile.yml
+++ b/profiles/anthropics/skills/anthropics_skills_doc-coauthoring/for-forgecat/profile.yml
@@ -9,6 +9,7 @@ description: Guide users through a structured workflow for co-authoring document
 repository: https://github.com/anthropics/skills
 license: MIT
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/skills/anthropics_skills_docx/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_docx/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_docx/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_docx/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_docx/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_docx/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_docx/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_docx/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_docx/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_docx/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_docx/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_docx/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_docx/for-forgecat/profile.yml
+++ b/profiles/anthropics/skills/anthropics_skills_docx/for-forgecat/profile.yml
@@ -13,6 +13,7 @@ description: 'Use this skill whenever the user wants to create, read, edit, or m
 repository: https://github.com/anthropics/skills
 license: Proprietary. LICENSE.txt has complete terms
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/skills/anthropics_skills_frontend-design/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_frontend-design/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_frontend-design/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_frontend-design/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_frontend-design/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_frontend-design/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_frontend-design/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_frontend-design/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_frontend-design/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_frontend-design/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_frontend-design/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_frontend-design/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_frontend-design/for-forgecat/profile.yml
+++ b/profiles/anthropics/skills/anthropics_skills_frontend-design/for-forgecat/profile.yml
@@ -8,6 +8,7 @@ description: Create distinctive, production-grade frontend interfaces with high 
 repository: https://github.com/anthropics/skills
 license: Complete terms in LICENSE.txt
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/skills/anthropics_skills_internal-comms/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_internal-comms/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_internal-comms/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_internal-comms/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_internal-comms/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_internal-comms/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_internal-comms/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_internal-comms/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_internal-comms/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_internal-comms/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_internal-comms/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_internal-comms/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_internal-comms/for-forgecat/profile.yml
+++ b/profiles/anthropics/skills/anthropics_skills_internal-comms/for-forgecat/profile.yml
@@ -8,6 +8,7 @@ description: A set of resources to help me write all kinds of internal communica
 repository: https://github.com/anthropics/skills
 license: Complete terms in LICENSE.txt
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/skills/anthropics_skills_mcp-builder/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_mcp-builder/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_mcp-builder/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_mcp-builder/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_mcp-builder/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_mcp-builder/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_mcp-builder/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_mcp-builder/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_mcp-builder/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_mcp-builder/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_mcp-builder/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_mcp-builder/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_mcp-builder/for-forgecat/profile.yml
+++ b/profiles/anthropics/skills/anthropics_skills_mcp-builder/for-forgecat/profile.yml
@@ -7,6 +7,7 @@ description: Guide for creating high-quality MCP (Model Context Protocol) server
 repository: https://github.com/anthropics/skills
 license: Complete terms in LICENSE.txt
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/skills/anthropics_skills_pdf/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_pdf/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_pdf/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_pdf/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_pdf/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_pdf/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_pdf/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_pdf/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_pdf/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_pdf/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_pdf/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_pdf/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_pdf/for-forgecat/profile.yml
+++ b/profiles/anthropics/skills/anthropics_skills_pdf/for-forgecat/profile.yml
@@ -9,6 +9,7 @@ description: Use this skill whenever the user wants to do anything with PDF file
 repository: https://github.com/anthropics/skills
 license: Proprietary. LICENSE.txt has complete terms
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/skills/anthropics_skills_pptx/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_pptx/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_pptx/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_pptx/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_pptx/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_pptx/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_pptx/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_pptx/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_pptx/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_pptx/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_pptx/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_pptx/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_pptx/for-forgecat/profile.yml
+++ b/profiles/anthropics/skills/anthropics_skills_pptx/for-forgecat/profile.yml
@@ -12,6 +12,7 @@ description: 'Use this skill any time a .pptx file is involved in any way — as
 repository: https://github.com/anthropics/skills
 license: Proprietary. LICENSE.txt has complete terms
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/skills/anthropics_skills_skill-creator/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_skill-creator/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_skill-creator/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_skill-creator/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_skill-creator/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_skill-creator/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_skill-creator/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_skill-creator/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_skill-creator/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_skill-creator/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_skill-creator/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_skill-creator/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_skill-creator/for-forgecat/profile.yml
+++ b/profiles/anthropics/skills/anthropics_skills_skill-creator/for-forgecat/profile.yml
@@ -7,6 +7,7 @@ description: Create new skills, modify and improve existing skills, and measure 
 repository: https://github.com/anthropics/skills
 license: MIT
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/skills/anthropics_skills_slack-gif-creator/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_slack-gif-creator/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_slack-gif-creator/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_slack-gif-creator/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_slack-gif-creator/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_slack-gif-creator/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_slack-gif-creator/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_slack-gif-creator/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_slack-gif-creator/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_slack-gif-creator/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_slack-gif-creator/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_slack-gif-creator/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_slack-gif-creator/for-forgecat/profile.yml
+++ b/profiles/anthropics/skills/anthropics_skills_slack-gif-creator/for-forgecat/profile.yml
@@ -6,6 +6,7 @@ description: Knowledge and utilities for creating animated GIFs optimized for Sl
 repository: https://github.com/anthropics/skills
 license: Complete terms in LICENSE.txt
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/skills/anthropics_skills_theme-factory/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_theme-factory/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_theme-factory/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_theme-factory/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_theme-factory/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_theme-factory/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_theme-factory/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_theme-factory/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_theme-factory/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_theme-factory/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_theme-factory/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_theme-factory/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_theme-factory/for-forgecat/profile.yml
+++ b/profiles/anthropics/skills/anthropics_skills_theme-factory/for-forgecat/profile.yml
@@ -7,6 +7,7 @@ description: Toolkit for styling artifacts with a theme. These artifacts can be 
 repository: https://github.com/anthropics/skills
 license: Complete terms in LICENSE.txt
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/skills/anthropics_skills_web-artifacts-builder/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_web-artifacts-builder/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_web-artifacts-builder/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_web-artifacts-builder/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_web-artifacts-builder/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_web-artifacts-builder/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_web-artifacts-builder/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_web-artifacts-builder/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_web-artifacts-builder/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_web-artifacts-builder/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_web-artifacts-builder/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_web-artifacts-builder/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_web-artifacts-builder/for-forgecat/profile.yml
+++ b/profiles/anthropics/skills/anthropics_skills_web-artifacts-builder/for-forgecat/profile.yml
@@ -7,6 +7,7 @@ description: Suite of tools for creating elaborate, multi-component claude.ai HT
 repository: https://github.com/anthropics/skills
 license: Complete terms in LICENSE.txt
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/skills/anthropics_skills_webapp-testing/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_webapp-testing/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_webapp-testing/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_webapp-testing/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_webapp-testing/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_webapp-testing/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_webapp-testing/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_webapp-testing/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_webapp-testing/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_webapp-testing/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_webapp-testing/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_webapp-testing/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_webapp-testing/for-forgecat/profile.yml
+++ b/profiles/anthropics/skills/anthropics_skills_webapp-testing/for-forgecat/profile.yml
@@ -6,6 +6,7 @@ description: Toolkit for interacting with and testing local web applications usi
 repository: https://github.com/anthropics/skills
 license: Complete terms in LICENSE.txt
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/anthropics/skills/anthropics_skills_xlsx/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_xlsx/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_xlsx/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_xlsx/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_xlsx/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_xlsx/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_xlsx/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_xlsx/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_xlsx/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_xlsx/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_xlsx/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_xlsx/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/anthropics/skills/anthropics_skills_xlsx/for-forgecat/profile.yml
+++ b/profiles/anthropics/skills/anthropics_skills_xlsx/for-forgecat/profile.yml
@@ -15,6 +15,7 @@ description: 'Use this skill any time a spreadsheet file is the primary input or
 repository: https://github.com/anthropics/skills
 license: Proprietary. LICENSE.txt has complete terms
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/awslabs/aidlc-workflows/for-claude/.forgecat/profiles/@forgecat/awslabs_aidlc-workflows/README.md
+++ b/profiles/awslabs/aidlc-workflows/for-claude/.forgecat/profiles/@forgecat/awslabs_aidlc-workflows/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/awslabs/aidlc-workflows/for-codex/.forgecat/profiles/@forgecat/awslabs_aidlc-workflows/README.md
+++ b/profiles/awslabs/aidlc-workflows/for-codex/.forgecat/profiles/@forgecat/awslabs_aidlc-workflows/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/awslabs/aidlc-workflows/for-cursor/.forgecat/profiles/@forgecat/awslabs_aidlc-workflows/README.md
+++ b/profiles/awslabs/aidlc-workflows/for-cursor/.forgecat/profiles/@forgecat/awslabs_aidlc-workflows/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/awslabs/aidlc-workflows/for-forgecat/profile.yml
+++ b/profiles/awslabs/aidlc-workflows/for-forgecat/profile.yml
@@ -5,6 +5,7 @@ description: AI-DLC adaptive workflow rules profile for project-level agent guid
 repository: https://github.com/awslabs/aidlc-workflows
 license: MIT-0
 visibility: public
+sourcePlatform: multi-host
 compatibility:
   platforms:
     tested:

--- a/profiles/cursor/plugins/cursor_plugins_continual-learning/for-codex/.forgecat/profiles/@forgecat/cursor_plugins_continual-learning/README.md
+++ b/profiles/cursor/plugins/cursor_plugins_continual-learning/for-codex/.forgecat/profiles/@forgecat/cursor_plugins_continual-learning/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/cursor/plugins/cursor_plugins_ralph-loop/for-claude/.forgecat/profiles/@forgecat/cursor_plugins_ralph-loop/README.md
+++ b/profiles/cursor/plugins/cursor_plugins_ralph-loop/for-claude/.forgecat/profiles/@forgecat/cursor_plugins_ralph-loop/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 # Ralph Loop
 

--- a/profiles/cursor/plugins/cursor_plugins_ralph-loop/for-codex/.forgecat/profiles/@forgecat/cursor_plugins_ralph-loop/README.md
+++ b/profiles/cursor/plugins/cursor_plugins_ralph-loop/for-codex/.forgecat/profiles/@forgecat/cursor_plugins_ralph-loop/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 # Ralph Loop
 

--- a/profiles/cursor/plugins/cursor_plugins_ralph-loop/for-cursor/.forgecat/profiles/@forgecat/cursor_plugins_ralph-loop/README.md
+++ b/profiles/cursor/plugins/cursor_plugins_ralph-loop/for-cursor/.forgecat/profiles/@forgecat/cursor_plugins_ralph-loop/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 # Ralph Loop
 

--- a/profiles/cursor/plugins/cursor_plugins_team-kit/for-claude/.forgecat/profiles/@forgecat/cursor_plugins_team-kit/README.md
+++ b/profiles/cursor/plugins/cursor_plugins_team-kit/for-claude/.forgecat/profiles/@forgecat/cursor_plugins_team-kit/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/cursor/plugins/cursor_plugins_team-kit/for-codex/.forgecat/profiles/@forgecat/cursor_plugins_team-kit/README.md
+++ b/profiles/cursor/plugins/cursor_plugins_team-kit/for-codex/.forgecat/profiles/@forgecat/cursor_plugins_team-kit/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/cursor/plugins/cursor_plugins_team-kit/for-cursor/.forgecat/profiles/@forgecat/cursor_plugins_team-kit/README.md
+++ b/profiles/cursor/plugins/cursor_plugins_team-kit/for-cursor/.forgecat/profiles/@forgecat/cursor_plugins_team-kit/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/everyinc/compound-engineering-plugin/for-claude/.forgecat/profiles/@forgecat/everyinc_compound-engineering-plugin/README.md
+++ b/profiles/everyinc/compound-engineering-plugin/for-claude/.forgecat/profiles/@forgecat/everyinc_compound-engineering-plugin/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/everyinc/compound-engineering-plugin/for-codex/.forgecat/profiles/@forgecat/everyinc_compound-engineering-plugin/README.md
+++ b/profiles/everyinc/compound-engineering-plugin/for-codex/.forgecat/profiles/@forgecat/everyinc_compound-engineering-plugin/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/everyinc/compound-engineering-plugin/for-cursor/.forgecat/profiles/@forgecat/everyinc_compound-engineering-plugin/README.md
+++ b/profiles/everyinc/compound-engineering-plugin/for-cursor/.forgecat/profiles/@forgecat/everyinc_compound-engineering-plugin/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/everyinc/compound-engineering-plugin/for-forgecat/profile.yml
+++ b/profiles/everyinc/compound-engineering-plugin/for-forgecat/profile.yml
@@ -5,6 +5,7 @@ description: AI-powered development tools for code review, research, design, and
 repository: https://github.com/EveryInc/compound-engineering-plugin
 license: MIT
 visibility: public
+sourcePlatform: cursor
 compatibility:
   platforms:
     tested:

--- a/profiles/garrytan/gstack/for-claude/.forgecat/profiles/@forgecat/garrytan_gstack/README.md
+++ b/profiles/garrytan/gstack/for-claude/.forgecat/profiles/@forgecat/garrytan_gstack/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/garrytan/gstack/for-codex/.forgecat/profiles/@forgecat/garrytan_gstack/README.md
+++ b/profiles/garrytan/gstack/for-codex/.forgecat/profiles/@forgecat/garrytan_gstack/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/garrytan/gstack/for-cursor/.forgecat/profiles/@forgecat/garrytan_gstack/README.md
+++ b/profiles/garrytan/gstack/for-cursor/.forgecat/profiles/@forgecat/garrytan_gstack/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/garrytan/gstack/for-forgecat/profile.yml
+++ b/profiles/garrytan/gstack/for-forgecat/profile.yml
@@ -4,6 +4,7 @@ description: "Garry's Stack: a self-contained AI engineering workflow profile wi
 repository: https://github.com/garrytan/gstack
 license: MIT
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/google-gemini/gemini-skills/google-gemini_gemini-skills_gemini-api-dev/for-claude/.forgecat/profiles/@forgecat/google-gemini_gemini-skills_gemini-api-dev/README.md
+++ b/profiles/google-gemini/gemini-skills/google-gemini_gemini-skills_gemini-api-dev/for-claude/.forgecat/profiles/@forgecat/google-gemini_gemini-skills_gemini-api-dev/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/google-gemini/gemini-skills/google-gemini_gemini-skills_gemini-api-dev/for-codex/.forgecat/profiles/@forgecat/google-gemini_gemini-skills_gemini-api-dev/README.md
+++ b/profiles/google-gemini/gemini-skills/google-gemini_gemini-skills_gemini-api-dev/for-codex/.forgecat/profiles/@forgecat/google-gemini_gemini-skills_gemini-api-dev/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/google-gemini/gemini-skills/google-gemini_gemini-skills_gemini-api-dev/for-cursor/.forgecat/profiles/@forgecat/google-gemini_gemini-skills_gemini-api-dev/README.md
+++ b/profiles/google-gemini/gemini-skills/google-gemini_gemini-skills_gemini-api-dev/for-cursor/.forgecat/profiles/@forgecat/google-gemini_gemini-skills_gemini-api-dev/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/google-gemini/gemini-skills/google-gemini_gemini-skills_gemini-api-dev/for-forgecat/profile.yml
+++ b/profiles/google-gemini/gemini-skills/google-gemini_gemini-skills_gemini-api-dev/for-forgecat/profile.yml
@@ -9,6 +9,7 @@ description: Use this skill when building applications with Gemini API hosted mo
 repository: https://github.com/google-gemini/gemini-skills
 license: Apache 2.0
 visibility: public
+sourcePlatform: multi-host
 compatibility:
   platforms:
     tested:

--- a/profiles/google-gemini/gemini-skills/google-gemini_gemini-skills_gemini-interactions-api/for-claude/.forgecat/profiles/@forgecat/google-gemini_gemini-skills_gemini-interactions-api/README.md
+++ b/profiles/google-gemini/gemini-skills/google-gemini_gemini-skills_gemini-interactions-api/for-claude/.forgecat/profiles/@forgecat/google-gemini_gemini-skills_gemini-interactions-api/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/google-gemini/gemini-skills/google-gemini_gemini-skills_gemini-interactions-api/for-codex/.forgecat/profiles/@forgecat/google-gemini_gemini-skills_gemini-interactions-api/README.md
+++ b/profiles/google-gemini/gemini-skills/google-gemini_gemini-skills_gemini-interactions-api/for-codex/.forgecat/profiles/@forgecat/google-gemini_gemini-skills_gemini-interactions-api/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/google-gemini/gemini-skills/google-gemini_gemini-skills_gemini-interactions-api/for-cursor/.forgecat/profiles/@forgecat/google-gemini_gemini-skills_gemini-interactions-api/README.md
+++ b/profiles/google-gemini/gemini-skills/google-gemini_gemini-skills_gemini-interactions-api/for-cursor/.forgecat/profiles/@forgecat/google-gemini_gemini-skills_gemini-interactions-api/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/google-gemini/gemini-skills/google-gemini_gemini-skills_gemini-interactions-api/for-forgecat/profile.yml
+++ b/profiles/google-gemini/gemini-skills/google-gemini_gemini-skills_gemini-interactions-api/for-forgecat/profile.yml
@@ -8,6 +8,7 @@ description: Use this skill when writing code that calls the Gemini API for text
 repository: https://github.com/google-gemini/gemini-skills
 license: Apache 2.0
 visibility: public
+sourcePlatform: multi-host
 compatibility:
   platforms:
     tested:

--- a/profiles/google-gemini/gemini-skills/google-gemini_gemini-skills_gemini-live-api-dev/for-claude/.forgecat/profiles/@forgecat/google-gemini_gemini-skills_gemini-live-api-dev/README.md
+++ b/profiles/google-gemini/gemini-skills/google-gemini_gemini-skills_gemini-live-api-dev/for-claude/.forgecat/profiles/@forgecat/google-gemini_gemini-skills_gemini-live-api-dev/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/google-gemini/gemini-skills/google-gemini_gemini-skills_gemini-live-api-dev/for-codex/.forgecat/profiles/@forgecat/google-gemini_gemini-skills_gemini-live-api-dev/README.md
+++ b/profiles/google-gemini/gemini-skills/google-gemini_gemini-skills_gemini-live-api-dev/for-codex/.forgecat/profiles/@forgecat/google-gemini_gemini-skills_gemini-live-api-dev/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/google-gemini/gemini-skills/google-gemini_gemini-skills_gemini-live-api-dev/for-cursor/.forgecat/profiles/@forgecat/google-gemini_gemini-skills_gemini-live-api-dev/README.md
+++ b/profiles/google-gemini/gemini-skills/google-gemini_gemini-skills_gemini-live-api-dev/for-cursor/.forgecat/profiles/@forgecat/google-gemini_gemini-skills_gemini-live-api-dev/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/google-gemini/gemini-skills/google-gemini_gemini-skills_gemini-live-api-dev/for-forgecat/profile.yml
+++ b/profiles/google-gemini/gemini-skills/google-gemini_gemini-skills_gemini-live-api-dev/for-forgecat/profile.yml
@@ -8,6 +8,7 @@ description: Use this skill when building real-time, bidirectional streaming app
 repository: https://github.com/google-gemini/gemini-skills
 license: Apache 2.0
 visibility: public
+sourcePlatform: multi-host
 compatibility:
   platforms:
     tested:

--- a/profiles/kepano/obsidian-skills/for-claude/.forgecat/profiles/@forgecat/kepano_obsidian-skills/README.md
+++ b/profiles/kepano/obsidian-skills/for-claude/.forgecat/profiles/@forgecat/kepano_obsidian-skills/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/kepano/obsidian-skills/for-codex/.forgecat/profiles/@forgecat/kepano_obsidian-skills/README.md
+++ b/profiles/kepano/obsidian-skills/for-codex/.forgecat/profiles/@forgecat/kepano_obsidian-skills/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/kepano/obsidian-skills/for-forgecat/README.md
+++ b/profiles/kepano/obsidian-skills/for-forgecat/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/leonxlnx/taste-skill/README.md
+++ b/profiles/leonxlnx/taste-skill/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/leonxlnx/taste-skill/for-forgecat/README.md
+++ b/profiles/leonxlnx/taste-skill/for-forgecat/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/mattpocock/skills/for-forgecat/README.md
+++ b/profiles/mattpocock/skills/for-forgecat/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-appinsights-instrumentation/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-appinsights-instrumentation/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-appinsights-instrumentation/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-appinsights-instrumentation/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-appinsights-instrumentation/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-appinsights-instrumentation/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-appinsights-instrumentation/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-appinsights-instrumentation/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-appinsights-instrumentation/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-appinsights-instrumentation/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-appinsights-instrumentation/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-appinsights-instrumentation/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-appinsights-instrumentation/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-appinsights-instrumentation/for-forgecat/profile.yml
@@ -7,6 +7,7 @@ description: 'Guidance for instrumenting webapps with Azure Application Insights
 repository: https://github.com/microsoft/azure-skills
 license: MIT
 visibility: public
+sourcePlatform: multi-host
 compatibility:
   platforms:
     tested:

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-ai/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-ai/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-ai/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-ai/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-ai/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-ai/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-ai/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-ai/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-ai/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-ai/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-ai/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-ai/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-ai/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-ai/for-forgecat/profile.yml
@@ -7,6 +7,7 @@ description: 'Use for Azure AI: Search, Speech, OpenAI, Document Intelligence. H
 repository: https://github.com/microsoft/azure-skills
 license: MIT
 visibility: public
+sourcePlatform: multi-host
 compatibility:
   platforms:
     tested:

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-aigateway/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-aigateway/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-aigateway/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-aigateway/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-aigateway/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-aigateway/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-aigateway/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-aigateway/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-aigateway/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-aigateway/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-aigateway/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-aigateway/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-aigateway/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-aigateway/for-forgecat/profile.yml
@@ -8,6 +8,7 @@ description: 'Configure Azure API Management as an AI Gateway for AI models, MCP
 repository: https://github.com/microsoft/azure-skills
 license: MIT
 visibility: public
+sourcePlatform: multi-host
 compatibility:
   platforms:
     tested:

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-compliance/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-compliance/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-compliance/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-compliance/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-compliance/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-compliance/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-compliance/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-compliance/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-compliance/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-compliance/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-compliance/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-compliance/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-compliance/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-compliance/for-forgecat/profile.yml
@@ -8,6 +8,7 @@ description: 'Run Azure compliance and security audits with azqr plus Key Vault 
 repository: https://github.com/microsoft/azure-skills
 license: MIT
 visibility: public
+sourcePlatform: multi-host
 compatibility:
   platforms:
     tested:

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-cost-optimization/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-cost-optimization/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-cost-optimization/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-cost-optimization/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-cost-optimization/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-cost-optimization/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-cost-optimization/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-cost-optimization/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-cost-optimization/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-cost-optimization/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-cost-optimization/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-cost-optimization/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-cost-optimization/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-cost-optimization/for-forgecat/profile.yml
@@ -15,6 +15,7 @@ description: 'Unified Azure cost management: query historical costs, forecast fu
 repository: https://github.com/microsoft/azure-skills
 license: MIT
 visibility: public
+sourcePlatform: multi-host
 compatibility:
   platforms:
     tested:

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-deploy/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-deploy/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-deploy/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-deploy/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-deploy/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-deploy/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-deploy/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-deploy/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-deploy/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-deploy/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-deploy/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-deploy/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-deploy/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-deploy/for-forgecat/profile.yml
@@ -13,6 +13,7 @@ description: 'Execute Azure deployments for ALREADY-PREPARED applications that h
 repository: https://github.com/microsoft/azure-skills
 license: MIT
 visibility: public
+sourcePlatform: multi-host
 compatibility:
   platforms:
     tested:

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-diagnostics/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-diagnostics/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-diagnostics/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-diagnostics/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-diagnostics/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-diagnostics/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-diagnostics/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-diagnostics/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-diagnostics/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-diagnostics/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-diagnostics/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-diagnostics/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-diagnostics/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-diagnostics/for-forgecat/profile.yml
@@ -12,6 +12,7 @@ description: 'Debug Azure production issues on Azure using AppLens, Azure Monito
 repository: https://github.com/microsoft/azure-skills
 license: MIT
 visibility: public
+sourcePlatform: multi-host
 compatibility:
   platforms:
     tested:

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-hosted-copilot-sdk/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-hosted-copilot-sdk/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-hosted-copilot-sdk/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-hosted-copilot-sdk/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-hosted-copilot-sdk/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-hosted-copilot-sdk/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-hosted-copilot-sdk/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-hosted-copilot-sdk/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-hosted-copilot-sdk/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-hosted-copilot-sdk/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-hosted-copilot-sdk/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-hosted-copilot-sdk/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-hosted-copilot-sdk/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-hosted-copilot-sdk/for-forgecat/profile.yml
@@ -10,6 +10,7 @@ description: 'Build, deploy, modify GitHub Copilot SDK apps on Azure. MANDATORY 
 repository: https://github.com/microsoft/azure-skills
 license: MIT
 visibility: public
+sourcePlatform: multi-host
 compatibility:
   platforms:
     tested:

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-kusto/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-kusto/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-kusto/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-kusto/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-kusto/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-kusto/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-kusto/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-kusto/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-kusto/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-kusto/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-kusto/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-kusto/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-kusto/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-kusto/for-forgecat/profile.yml
@@ -7,6 +7,7 @@ description: 'Query and analyze data in Azure Data Explorer (Kusto/ADX) using KQ
 repository: https://github.com/microsoft/azure-skills
 license: MIT
 visibility: public
+sourcePlatform: multi-host
 compatibility:
   platforms:
     tested:

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-messaging/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-messaging/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-messaging/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-messaging/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-messaging/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-messaging/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-messaging/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-messaging/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-messaging/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-messaging/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-messaging/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-messaging/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-messaging/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-messaging/for-forgecat/profile.yml
@@ -15,6 +15,7 @@ description: 'Troubleshoot and resolve issues with Azure Messaging SDKs for Even
 repository: https://github.com/microsoft/azure-skills
 license: MIT
 visibility: public
+sourcePlatform: multi-host
 compatibility:
   platforms:
     tested:

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-observability/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-observability/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-observability/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-observability/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-observability/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-observability/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-observability/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-observability/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-observability/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-observability/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-observability/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-observability/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-observability/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-observability/for-forgecat/profile.yml
@@ -12,6 +12,7 @@ description: 'Debug Azure production issues on Azure using AppLens, Azure Monito
 repository: https://github.com/microsoft/azure-skills
 license: MIT
 visibility: public
+sourcePlatform: multi-host
 compatibility:
   platforms:
     tested:

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-prepare/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-prepare/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-prepare/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-prepare/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-prepare/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-prepare/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-prepare/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-prepare/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-prepare/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-prepare/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-prepare/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-prepare/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-prepare/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-prepare/for-forgecat/profile.yml
@@ -15,6 +15,7 @@ description: 'Prepare Azure apps for deployment (infra Bicep/Terraform, azure.ya
 repository: https://github.com/microsoft/azure-skills
 license: MIT
 visibility: public
+sourcePlatform: multi-host
 compatibility:
   platforms:
     tested:

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-rbac/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-rbac/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-rbac/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-rbac/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-rbac/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-rbac/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-rbac/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-rbac/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-rbac/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-rbac/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-rbac/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-rbac/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-rbac/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-rbac/for-forgecat/profile.yml
@@ -9,6 +9,7 @@ description: 'Helps users find the right Azure RBAC role for an identity with le
 repository: https://github.com/microsoft/azure-skills
 license: MIT
 visibility: public
+sourcePlatform: multi-host
 compatibility:
   platforms:
     tested:

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-lookup/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-resource-lookup/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-lookup/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-resource-lookup/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-lookup/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-resource-lookup/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-lookup/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-resource-lookup/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-lookup/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-resource-lookup/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-lookup/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-resource-lookup/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-lookup/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-lookup/for-forgecat/profile.yml
@@ -12,6 +12,7 @@ description: 'List, find, and show Azure resources across subscriptions or resou
 repository: https://github.com/microsoft/azure-skills
 license: MIT
 visibility: public
+sourcePlatform: multi-host
 compatibility:
   platforms:
     tested:

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-visualizer/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-resource-visualizer/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-visualizer/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-resource-visualizer/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-visualizer/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-resource-visualizer/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-visualizer/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-resource-visualizer/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-visualizer/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-resource-visualizer/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-visualizer/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-resource-visualizer/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-visualizer/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-visualizer/for-forgecat/profile.yml
@@ -8,6 +8,7 @@ description: 'Analyze Azure resource groups and generate detailed Mermaid archit
 repository: https://github.com/microsoft/azure-skills
 license: MIT
 visibility: public
+sourcePlatform: multi-host
 compatibility:
   platforms:
     tested:

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-storage/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-storage/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-storage/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-storage/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-storage/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-storage/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-storage/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-storage/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-storage/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-storage/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-storage/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-storage/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-storage/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-storage/for-forgecat/profile.yml
@@ -13,6 +13,7 @@ description: 'Azure Storage Services including Blob Storage, File Shares, Queue 
 repository: https://github.com/microsoft/azure-skills
 license: MIT
 visibility: public
+sourcePlatform: multi-host
 compatibility:
   platforms:
     tested:

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-validate/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-validate/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-validate/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-validate/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-validate/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-validate/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-validate/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-validate/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-validate/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-validate/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-validate/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-validate/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-validate/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-validate/for-forgecat/profile.yml
@@ -11,6 +11,7 @@ description: 'Pre-deployment validation for Azure readiness. Run deep checks on 
 repository: https://github.com/microsoft/azure-skills
 license: MIT
 visibility: public
+sourcePlatform: multi-host
 compatibility:
   platforms:
     tested:

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-entra-app-registration/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-entra-app-registration/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-entra-app-registration/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-entra-app-registration/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-entra-app-registration/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-entra-app-registration/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-entra-app-registration/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-entra-app-registration/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-entra-app-registration/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-entra-app-registration/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-entra-app-registration/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-entra-app-registration/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-entra-app-registration/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-entra-app-registration/for-forgecat/profile.yml
@@ -9,6 +9,7 @@ description: 'Guides Microsoft Entra ID app registration, OAuth 2.0 authenticati
 repository: https://github.com/microsoft/azure-skills
 license: MIT
 visibility: public
+sourcePlatform: multi-host
 compatibility:
   platforms:
     tested:

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-microsoft-foundry/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-microsoft-foundry/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-microsoft-foundry/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-microsoft-foundry/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-microsoft-foundry/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-microsoft-foundry/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-microsoft-foundry/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-microsoft-foundry/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-microsoft-foundry/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-microsoft-foundry/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-microsoft-foundry/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-microsoft-foundry/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-microsoft-foundry/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-microsoft-foundry/for-forgecat/profile.yml
@@ -16,6 +16,7 @@ description: 'Deploy, evaluate, and manage Foundry agents end-to-end: Docker bui
 repository: https://github.com/microsoft/azure-skills
 license: MIT
 visibility: public
+sourcePlatform: multi-host
 compatibility:
   platforms:
     tested:

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 # Azure Skills Plugin
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 # Azure Skills Plugin
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 # Azure Skills Plugin
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-academic/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-academic/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-academic/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-academic/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-academic/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-academic/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-academic/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-academic/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-academic/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-academic/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-academic/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-academic/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-design/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-design/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-design/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-design/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-design/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-design/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-design/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-design/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-design/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-design/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-design/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-design/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-engineering/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-engineering/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-engineering/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-engineering/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-engineering/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-engineering/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-engineering/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-engineering/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-engineering/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-engineering/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-engineering/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-engineering/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-game-development/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-game-development/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-game-development/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-game-development/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-game-development/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-game-development/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-game-development/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-game-development/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-game-development/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-game-development/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-game-development/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-game-development/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-marketing/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-marketing/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-marketing/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-marketing/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-marketing/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-marketing/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-marketing/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-marketing/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-marketing/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-marketing/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-marketing/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-marketing/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-paid-media/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-paid-media/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-paid-media/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-paid-media/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-paid-media/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-paid-media/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-paid-media/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-paid-media/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-paid-media/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-paid-media/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-paid-media/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-paid-media/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-product/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-product/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-product/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-product/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-product/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-product/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-product/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-product/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-product/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-product/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-product/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-product/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-project-management/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-project-management/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-project-management/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-project-management/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-project-management/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-project-management/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-project-management/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-project-management/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-project-management/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-project-management/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-project-management/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-project-management/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-sales/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-sales/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-sales/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-sales/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-sales/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-sales/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-sales/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-sales/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-sales/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-sales/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-sales/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-sales/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-spatial-computing/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-spatial-computing/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-spatial-computing/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-spatial-computing/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-spatial-computing/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-spatial-computing/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-spatial-computing/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-spatial-computing/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-spatial-computing/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-spatial-computing/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-spatial-computing/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-spatial-computing/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-specialized/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-specialized/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-specialized/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-specialized/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-specialized/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-specialized/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-specialized/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-specialized/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-support/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-support/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-support/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-support/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-support/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-support/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-support/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-support/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-support/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-support/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-support/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-support/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-testing/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-testing/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-testing/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-testing/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-testing/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-testing/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-testing/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-testing/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-testing/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-testing/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-testing/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-testing/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/multica-ai/andrej-karpathy-skills/for-codex/.forgecat/profiles/@forgecat/andrej-karpathy-skills/README.md
+++ b/profiles/multica-ai/andrej-karpathy-skills/for-codex/.forgecat/profiles/@forgecat/andrej-karpathy-skills/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 # Andrej Karpathy Skills
 

--- a/profiles/multica-ai/andrej-karpathy-skills/for-cursor/.forgecat/profiles/@forgecat/andrej-karpathy-skills/README.md
+++ b/profiles/multica-ai/andrej-karpathy-skills/for-cursor/.forgecat/profiles/@forgecat/andrej-karpathy-skills/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 # Andrej Karpathy Skills
 

--- a/profiles/obra/superpowers/for-claude/.forgecat/profiles/@forgecat/obra_superpowers/README.md
+++ b/profiles/obra/superpowers/for-claude/.forgecat/profiles/@forgecat/obra_superpowers/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/obra/superpowers/for-codex/.forgecat/profiles/@forgecat/obra_superpowers/README.md
+++ b/profiles/obra/superpowers/for-codex/.forgecat/profiles/@forgecat/obra_superpowers/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/obra/superpowers/for-cursor/.forgecat/profiles/@forgecat/obra_superpowers/README.md
+++ b/profiles/obra/superpowers/for-cursor/.forgecat/profiles/@forgecat/obra_superpowers/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_aspnet-core/for-claude/.forgecat/profiles/@forgecat/openai_skills_aspnet-core/README.md
+++ b/profiles/openai/skills/openai_skills_aspnet-core/for-claude/.forgecat/profiles/@forgecat/openai_skills_aspnet-core/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_aspnet-core/for-codex/.forgecat/profiles/@forgecat/openai_skills_aspnet-core/README.md
+++ b/profiles/openai/skills/openai_skills_aspnet-core/for-codex/.forgecat/profiles/@forgecat/openai_skills_aspnet-core/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_aspnet-core/for-cursor/.forgecat/profiles/@forgecat/openai_skills_aspnet-core/README.md
+++ b/profiles/openai/skills/openai_skills_aspnet-core/for-cursor/.forgecat/profiles/@forgecat/openai_skills_aspnet-core/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_chatgpt-apps/for-claude/.forgecat/profiles/@forgecat/openai_skills_chatgpt-apps/README.md
+++ b/profiles/openai/skills/openai_skills_chatgpt-apps/for-claude/.forgecat/profiles/@forgecat/openai_skills_chatgpt-apps/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_chatgpt-apps/for-codex/.forgecat/profiles/@forgecat/openai_skills_chatgpt-apps/README.md
+++ b/profiles/openai/skills/openai_skills_chatgpt-apps/for-codex/.forgecat/profiles/@forgecat/openai_skills_chatgpt-apps/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_chatgpt-apps/for-cursor/.forgecat/profiles/@forgecat/openai_skills_chatgpt-apps/README.md
+++ b/profiles/openai/skills/openai_skills_chatgpt-apps/for-cursor/.forgecat/profiles/@forgecat/openai_skills_chatgpt-apps/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_cloudflare-deploy/for-claude/.forgecat/profiles/@forgecat/openai_skills_cloudflare-deploy/README.md
+++ b/profiles/openai/skills/openai_skills_cloudflare-deploy/for-claude/.forgecat/profiles/@forgecat/openai_skills_cloudflare-deploy/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_cloudflare-deploy/for-codex/.forgecat/profiles/@forgecat/openai_skills_cloudflare-deploy/README.md
+++ b/profiles/openai/skills/openai_skills_cloudflare-deploy/for-codex/.forgecat/profiles/@forgecat/openai_skills_cloudflare-deploy/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_cloudflare-deploy/for-cursor/.forgecat/profiles/@forgecat/openai_skills_cloudflare-deploy/README.md
+++ b/profiles/openai/skills/openai_skills_cloudflare-deploy/for-cursor/.forgecat/profiles/@forgecat/openai_skills_cloudflare-deploy/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_develop-web-game/for-claude/.forgecat/profiles/@forgecat/openai_skills_develop-web-game/README.md
+++ b/profiles/openai/skills/openai_skills_develop-web-game/for-claude/.forgecat/profiles/@forgecat/openai_skills_develop-web-game/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_develop-web-game/for-codex/.forgecat/profiles/@forgecat/openai_skills_develop-web-game/README.md
+++ b/profiles/openai/skills/openai_skills_develop-web-game/for-codex/.forgecat/profiles/@forgecat/openai_skills_develop-web-game/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_develop-web-game/for-cursor/.forgecat/profiles/@forgecat/openai_skills_develop-web-game/README.md
+++ b/profiles/openai/skills/openai_skills_develop-web-game/for-cursor/.forgecat/profiles/@forgecat/openai_skills_develop-web-game/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_doc/for-claude/.forgecat/profiles/@forgecat/openai_skills_doc/README.md
+++ b/profiles/openai/skills/openai_skills_doc/for-claude/.forgecat/profiles/@forgecat/openai_skills_doc/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_doc/for-codex/.forgecat/profiles/@forgecat/openai_skills_doc/README.md
+++ b/profiles/openai/skills/openai_skills_doc/for-codex/.forgecat/profiles/@forgecat/openai_skills_doc/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_doc/for-cursor/.forgecat/profiles/@forgecat/openai_skills_doc/README.md
+++ b/profiles/openai/skills/openai_skills_doc/for-cursor/.forgecat/profiles/@forgecat/openai_skills_doc/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_figma-code-connect-components/for-claude/.forgecat/profiles/@forgecat/openai_skills_figma-code-connect-components/README.md
+++ b/profiles/openai/skills/openai_skills_figma-code-connect-components/for-claude/.forgecat/profiles/@forgecat/openai_skills_figma-code-connect-components/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_figma-code-connect-components/for-codex/.forgecat/profiles/@forgecat/openai_skills_figma-code-connect-components/README.md
+++ b/profiles/openai/skills/openai_skills_figma-code-connect-components/for-codex/.forgecat/profiles/@forgecat/openai_skills_figma-code-connect-components/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_figma-code-connect-components/for-cursor/.forgecat/profiles/@forgecat/openai_skills_figma-code-connect-components/README.md
+++ b/profiles/openai/skills/openai_skills_figma-code-connect-components/for-cursor/.forgecat/profiles/@forgecat/openai_skills_figma-code-connect-components/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_figma-create-design-system-rules/for-claude/.forgecat/profiles/@forgecat/openai_skills_figma-create-design-system-rules/README.md
+++ b/profiles/openai/skills/openai_skills_figma-create-design-system-rules/for-claude/.forgecat/profiles/@forgecat/openai_skills_figma-create-design-system-rules/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_figma-create-design-system-rules/for-codex/.forgecat/profiles/@forgecat/openai_skills_figma-create-design-system-rules/README.md
+++ b/profiles/openai/skills/openai_skills_figma-create-design-system-rules/for-codex/.forgecat/profiles/@forgecat/openai_skills_figma-create-design-system-rules/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_figma-create-design-system-rules/for-cursor/.forgecat/profiles/@forgecat/openai_skills_figma-create-design-system-rules/README.md
+++ b/profiles/openai/skills/openai_skills_figma-create-design-system-rules/for-cursor/.forgecat/profiles/@forgecat/openai_skills_figma-create-design-system-rules/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_figma-create-new-file/for-claude/.forgecat/profiles/@forgecat/openai_skills_figma-create-new-file/README.md
+++ b/profiles/openai/skills/openai_skills_figma-create-new-file/for-claude/.forgecat/profiles/@forgecat/openai_skills_figma-create-new-file/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_figma-create-new-file/for-codex/.forgecat/profiles/@forgecat/openai_skills_figma-create-new-file/README.md
+++ b/profiles/openai/skills/openai_skills_figma-create-new-file/for-codex/.forgecat/profiles/@forgecat/openai_skills_figma-create-new-file/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_figma-create-new-file/for-cursor/.forgecat/profiles/@forgecat/openai_skills_figma-create-new-file/README.md
+++ b/profiles/openai/skills/openai_skills_figma-create-new-file/for-cursor/.forgecat/profiles/@forgecat/openai_skills_figma-create-new-file/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_figma-generate-design/for-claude/.forgecat/profiles/@forgecat/openai_skills_figma-generate-design/README.md
+++ b/profiles/openai/skills/openai_skills_figma-generate-design/for-claude/.forgecat/profiles/@forgecat/openai_skills_figma-generate-design/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_figma-generate-design/for-codex/.forgecat/profiles/@forgecat/openai_skills_figma-generate-design/README.md
+++ b/profiles/openai/skills/openai_skills_figma-generate-design/for-codex/.forgecat/profiles/@forgecat/openai_skills_figma-generate-design/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_figma-generate-design/for-cursor/.forgecat/profiles/@forgecat/openai_skills_figma-generate-design/README.md
+++ b/profiles/openai/skills/openai_skills_figma-generate-design/for-cursor/.forgecat/profiles/@forgecat/openai_skills_figma-generate-design/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_figma-generate-library/for-claude/.forgecat/profiles/@forgecat/openai_skills_figma-generate-library/README.md
+++ b/profiles/openai/skills/openai_skills_figma-generate-library/for-claude/.forgecat/profiles/@forgecat/openai_skills_figma-generate-library/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_figma-generate-library/for-codex/.forgecat/profiles/@forgecat/openai_skills_figma-generate-library/README.md
+++ b/profiles/openai/skills/openai_skills_figma-generate-library/for-codex/.forgecat/profiles/@forgecat/openai_skills_figma-generate-library/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_figma-generate-library/for-cursor/.forgecat/profiles/@forgecat/openai_skills_figma-generate-library/README.md
+++ b/profiles/openai/skills/openai_skills_figma-generate-library/for-cursor/.forgecat/profiles/@forgecat/openai_skills_figma-generate-library/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_figma-implement-design/for-claude/.forgecat/profiles/@forgecat/openai_skills_figma-implement-design/README.md
+++ b/profiles/openai/skills/openai_skills_figma-implement-design/for-claude/.forgecat/profiles/@forgecat/openai_skills_figma-implement-design/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_figma-implement-design/for-codex/.forgecat/profiles/@forgecat/openai_skills_figma-implement-design/README.md
+++ b/profiles/openai/skills/openai_skills_figma-implement-design/for-codex/.forgecat/profiles/@forgecat/openai_skills_figma-implement-design/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_figma-implement-design/for-cursor/.forgecat/profiles/@forgecat/openai_skills_figma-implement-design/README.md
+++ b/profiles/openai/skills/openai_skills_figma-implement-design/for-cursor/.forgecat/profiles/@forgecat/openai_skills_figma-implement-design/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_figma-use/for-claude/.forgecat/profiles/@forgecat/openai_skills_figma-use/README.md
+++ b/profiles/openai/skills/openai_skills_figma-use/for-claude/.forgecat/profiles/@forgecat/openai_skills_figma-use/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_figma-use/for-codex/.forgecat/profiles/@forgecat/openai_skills_figma-use/README.md
+++ b/profiles/openai/skills/openai_skills_figma-use/for-codex/.forgecat/profiles/@forgecat/openai_skills_figma-use/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_figma-use/for-cursor/.forgecat/profiles/@forgecat/openai_skills_figma-use/README.md
+++ b/profiles/openai/skills/openai_skills_figma-use/for-cursor/.forgecat/profiles/@forgecat/openai_skills_figma-use/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_frontend-skill/for-claude/.forgecat/profiles/@forgecat/openai_skills_frontend-skill/README.md
+++ b/profiles/openai/skills/openai_skills_frontend-skill/for-claude/.forgecat/profiles/@forgecat/openai_skills_frontend-skill/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_frontend-skill/for-codex/.forgecat/profiles/@forgecat/openai_skills_frontend-skill/README.md
+++ b/profiles/openai/skills/openai_skills_frontend-skill/for-codex/.forgecat/profiles/@forgecat/openai_skills_frontend-skill/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_frontend-skill/for-cursor/.forgecat/profiles/@forgecat/openai_skills_frontend-skill/README.md
+++ b/profiles/openai/skills/openai_skills_frontend-skill/for-cursor/.forgecat/profiles/@forgecat/openai_skills_frontend-skill/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_gh-address-comments/for-claude/.forgecat/profiles/@forgecat/openai_skills_gh-address-comments/README.md
+++ b/profiles/openai/skills/openai_skills_gh-address-comments/for-claude/.forgecat/profiles/@forgecat/openai_skills_gh-address-comments/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_gh-address-comments/for-codex/.forgecat/profiles/@forgecat/openai_skills_gh-address-comments/README.md
+++ b/profiles/openai/skills/openai_skills_gh-address-comments/for-codex/.forgecat/profiles/@forgecat/openai_skills_gh-address-comments/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_gh-address-comments/for-cursor/.forgecat/profiles/@forgecat/openai_skills_gh-address-comments/README.md
+++ b/profiles/openai/skills/openai_skills_gh-address-comments/for-cursor/.forgecat/profiles/@forgecat/openai_skills_gh-address-comments/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_gh-fix-ci/for-claude/.forgecat/profiles/@forgecat/openai_skills_gh-fix-ci/README.md
+++ b/profiles/openai/skills/openai_skills_gh-fix-ci/for-claude/.forgecat/profiles/@forgecat/openai_skills_gh-fix-ci/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_gh-fix-ci/for-codex/.forgecat/profiles/@forgecat/openai_skills_gh-fix-ci/README.md
+++ b/profiles/openai/skills/openai_skills_gh-fix-ci/for-codex/.forgecat/profiles/@forgecat/openai_skills_gh-fix-ci/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_gh-fix-ci/for-cursor/.forgecat/profiles/@forgecat/openai_skills_gh-fix-ci/README.md
+++ b/profiles/openai/skills/openai_skills_gh-fix-ci/for-cursor/.forgecat/profiles/@forgecat/openai_skills_gh-fix-ci/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_imagegen/for-claude/.forgecat/profiles/@forgecat/openai_skills_imagegen/README.md
+++ b/profiles/openai/skills/openai_skills_imagegen/for-claude/.forgecat/profiles/@forgecat/openai_skills_imagegen/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_imagegen/for-codex/.forgecat/profiles/@forgecat/openai_skills_imagegen/README.md
+++ b/profiles/openai/skills/openai_skills_imagegen/for-codex/.forgecat/profiles/@forgecat/openai_skills_imagegen/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_imagegen/for-cursor/.forgecat/profiles/@forgecat/openai_skills_imagegen/README.md
+++ b/profiles/openai/skills/openai_skills_imagegen/for-cursor/.forgecat/profiles/@forgecat/openai_skills_imagegen/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_jupyter-notebook/for-claude/.forgecat/profiles/@forgecat/openai_skills_jupyter-notebook/README.md
+++ b/profiles/openai/skills/openai_skills_jupyter-notebook/for-claude/.forgecat/profiles/@forgecat/openai_skills_jupyter-notebook/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_jupyter-notebook/for-codex/.forgecat/profiles/@forgecat/openai_skills_jupyter-notebook/README.md
+++ b/profiles/openai/skills/openai_skills_jupyter-notebook/for-codex/.forgecat/profiles/@forgecat/openai_skills_jupyter-notebook/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_jupyter-notebook/for-cursor/.forgecat/profiles/@forgecat/openai_skills_jupyter-notebook/README.md
+++ b/profiles/openai/skills/openai_skills_jupyter-notebook/for-cursor/.forgecat/profiles/@forgecat/openai_skills_jupyter-notebook/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_linear/for-claude/.forgecat/profiles/@forgecat/openai_skills_linear/README.md
+++ b/profiles/openai/skills/openai_skills_linear/for-claude/.forgecat/profiles/@forgecat/openai_skills_linear/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_linear/for-codex/.forgecat/profiles/@forgecat/openai_skills_linear/README.md
+++ b/profiles/openai/skills/openai_skills_linear/for-codex/.forgecat/profiles/@forgecat/openai_skills_linear/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_linear/for-cursor/.forgecat/profiles/@forgecat/openai_skills_linear/README.md
+++ b/profiles/openai/skills/openai_skills_linear/for-cursor/.forgecat/profiles/@forgecat/openai_skills_linear/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_netlify-deploy/for-claude/.forgecat/profiles/@forgecat/openai_skills_netlify-deploy/README.md
+++ b/profiles/openai/skills/openai_skills_netlify-deploy/for-claude/.forgecat/profiles/@forgecat/openai_skills_netlify-deploy/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_netlify-deploy/for-codex/.forgecat/profiles/@forgecat/openai_skills_netlify-deploy/README.md
+++ b/profiles/openai/skills/openai_skills_netlify-deploy/for-codex/.forgecat/profiles/@forgecat/openai_skills_netlify-deploy/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_netlify-deploy/for-cursor/.forgecat/profiles/@forgecat/openai_skills_netlify-deploy/README.md
+++ b/profiles/openai/skills/openai_skills_netlify-deploy/for-cursor/.forgecat/profiles/@forgecat/openai_skills_netlify-deploy/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_notion-knowledge-capture/for-claude/.forgecat/profiles/@forgecat/openai_skills_notion-knowledge-capture/README.md
+++ b/profiles/openai/skills/openai_skills_notion-knowledge-capture/for-claude/.forgecat/profiles/@forgecat/openai_skills_notion-knowledge-capture/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_notion-knowledge-capture/for-codex/.forgecat/profiles/@forgecat/openai_skills_notion-knowledge-capture/README.md
+++ b/profiles/openai/skills/openai_skills_notion-knowledge-capture/for-codex/.forgecat/profiles/@forgecat/openai_skills_notion-knowledge-capture/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_notion-knowledge-capture/for-cursor/.forgecat/profiles/@forgecat/openai_skills_notion-knowledge-capture/README.md
+++ b/profiles/openai/skills/openai_skills_notion-knowledge-capture/for-cursor/.forgecat/profiles/@forgecat/openai_skills_notion-knowledge-capture/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_notion-meeting-intelligence/for-claude/.forgecat/profiles/@forgecat/openai_skills_notion-meeting-intelligence/README.md
+++ b/profiles/openai/skills/openai_skills_notion-meeting-intelligence/for-claude/.forgecat/profiles/@forgecat/openai_skills_notion-meeting-intelligence/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_notion-meeting-intelligence/for-codex/.forgecat/profiles/@forgecat/openai_skills_notion-meeting-intelligence/README.md
+++ b/profiles/openai/skills/openai_skills_notion-meeting-intelligence/for-codex/.forgecat/profiles/@forgecat/openai_skills_notion-meeting-intelligence/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_notion-meeting-intelligence/for-cursor/.forgecat/profiles/@forgecat/openai_skills_notion-meeting-intelligence/README.md
+++ b/profiles/openai/skills/openai_skills_notion-meeting-intelligence/for-cursor/.forgecat/profiles/@forgecat/openai_skills_notion-meeting-intelligence/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_notion-research-documentation/for-claude/.forgecat/profiles/@forgecat/openai_skills_notion-research-documentation/README.md
+++ b/profiles/openai/skills/openai_skills_notion-research-documentation/for-claude/.forgecat/profiles/@forgecat/openai_skills_notion-research-documentation/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_notion-research-documentation/for-codex/.forgecat/profiles/@forgecat/openai_skills_notion-research-documentation/README.md
+++ b/profiles/openai/skills/openai_skills_notion-research-documentation/for-codex/.forgecat/profiles/@forgecat/openai_skills_notion-research-documentation/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_notion-research-documentation/for-cursor/.forgecat/profiles/@forgecat/openai_skills_notion-research-documentation/README.md
+++ b/profiles/openai/skills/openai_skills_notion-research-documentation/for-cursor/.forgecat/profiles/@forgecat/openai_skills_notion-research-documentation/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_notion-spec-to-implementation/for-claude/.forgecat/profiles/@forgecat/openai_skills_notion-spec-to-implementation/README.md
+++ b/profiles/openai/skills/openai_skills_notion-spec-to-implementation/for-claude/.forgecat/profiles/@forgecat/openai_skills_notion-spec-to-implementation/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_notion-spec-to-implementation/for-codex/.forgecat/profiles/@forgecat/openai_skills_notion-spec-to-implementation/README.md
+++ b/profiles/openai/skills/openai_skills_notion-spec-to-implementation/for-codex/.forgecat/profiles/@forgecat/openai_skills_notion-spec-to-implementation/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_notion-spec-to-implementation/for-cursor/.forgecat/profiles/@forgecat/openai_skills_notion-spec-to-implementation/README.md
+++ b/profiles/openai/skills/openai_skills_notion-spec-to-implementation/for-cursor/.forgecat/profiles/@forgecat/openai_skills_notion-spec-to-implementation/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_openai-docs/for-claude/.forgecat/profiles/@forgecat/openai_skills_openai-docs/README.md
+++ b/profiles/openai/skills/openai_skills_openai-docs/for-claude/.forgecat/profiles/@forgecat/openai_skills_openai-docs/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_openai-docs/for-codex/.forgecat/profiles/@forgecat/openai_skills_openai-docs/README.md
+++ b/profiles/openai/skills/openai_skills_openai-docs/for-codex/.forgecat/profiles/@forgecat/openai_skills_openai-docs/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_openai-docs/for-cursor/.forgecat/profiles/@forgecat/openai_skills_openai-docs/README.md
+++ b/profiles/openai/skills/openai_skills_openai-docs/for-cursor/.forgecat/profiles/@forgecat/openai_skills_openai-docs/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_pdf/for-claude/.forgecat/profiles/@forgecat/openai_skills_pdf/README.md
+++ b/profiles/openai/skills/openai_skills_pdf/for-claude/.forgecat/profiles/@forgecat/openai_skills_pdf/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_pdf/for-codex/.forgecat/profiles/@forgecat/openai_skills_pdf/README.md
+++ b/profiles/openai/skills/openai_skills_pdf/for-codex/.forgecat/profiles/@forgecat/openai_skills_pdf/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_pdf/for-cursor/.forgecat/profiles/@forgecat/openai_skills_pdf/README.md
+++ b/profiles/openai/skills/openai_skills_pdf/for-cursor/.forgecat/profiles/@forgecat/openai_skills_pdf/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_playwright-interactive/for-claude/.forgecat/profiles/@forgecat/openai_skills_playwright-interactive/README.md
+++ b/profiles/openai/skills/openai_skills_playwright-interactive/for-claude/.forgecat/profiles/@forgecat/openai_skills_playwright-interactive/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_playwright-interactive/for-codex/.forgecat/profiles/@forgecat/openai_skills_playwright-interactive/README.md
+++ b/profiles/openai/skills/openai_skills_playwright-interactive/for-codex/.forgecat/profiles/@forgecat/openai_skills_playwright-interactive/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_playwright-interactive/for-cursor/.forgecat/profiles/@forgecat/openai_skills_playwright-interactive/README.md
+++ b/profiles/openai/skills/openai_skills_playwright-interactive/for-cursor/.forgecat/profiles/@forgecat/openai_skills_playwright-interactive/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_playwright/for-claude/.forgecat/profiles/@forgecat/openai_skills_playwright/README.md
+++ b/profiles/openai/skills/openai_skills_playwright/for-claude/.forgecat/profiles/@forgecat/openai_skills_playwright/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_playwright/for-codex/.forgecat/profiles/@forgecat/openai_skills_playwright/README.md
+++ b/profiles/openai/skills/openai_skills_playwright/for-codex/.forgecat/profiles/@forgecat/openai_skills_playwright/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_playwright/for-cursor/.forgecat/profiles/@forgecat/openai_skills_playwright/README.md
+++ b/profiles/openai/skills/openai_skills_playwright/for-cursor/.forgecat/profiles/@forgecat/openai_skills_playwright/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_screenshot/for-claude/.forgecat/profiles/@forgecat/openai_skills_screenshot/README.md
+++ b/profiles/openai/skills/openai_skills_screenshot/for-claude/.forgecat/profiles/@forgecat/openai_skills_screenshot/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_screenshot/for-codex/.forgecat/profiles/@forgecat/openai_skills_screenshot/README.md
+++ b/profiles/openai/skills/openai_skills_screenshot/for-codex/.forgecat/profiles/@forgecat/openai_skills_screenshot/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_screenshot/for-cursor/.forgecat/profiles/@forgecat/openai_skills_screenshot/README.md
+++ b/profiles/openai/skills/openai_skills_screenshot/for-cursor/.forgecat/profiles/@forgecat/openai_skills_screenshot/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_security-best-practices/for-claude/.forgecat/profiles/@forgecat/openai_skills_security-best-practices/README.md
+++ b/profiles/openai/skills/openai_skills_security-best-practices/for-claude/.forgecat/profiles/@forgecat/openai_skills_security-best-practices/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_security-best-practices/for-codex/.forgecat/profiles/@forgecat/openai_skills_security-best-practices/README.md
+++ b/profiles/openai/skills/openai_skills_security-best-practices/for-codex/.forgecat/profiles/@forgecat/openai_skills_security-best-practices/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_security-best-practices/for-cursor/.forgecat/profiles/@forgecat/openai_skills_security-best-practices/README.md
+++ b/profiles/openai/skills/openai_skills_security-best-practices/for-cursor/.forgecat/profiles/@forgecat/openai_skills_security-best-practices/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_security-ownership-map/for-claude/.forgecat/profiles/@forgecat/openai_skills_security-ownership-map/README.md
+++ b/profiles/openai/skills/openai_skills_security-ownership-map/for-claude/.forgecat/profiles/@forgecat/openai_skills_security-ownership-map/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_security-ownership-map/for-codex/.forgecat/profiles/@forgecat/openai_skills_security-ownership-map/README.md
+++ b/profiles/openai/skills/openai_skills_security-ownership-map/for-codex/.forgecat/profiles/@forgecat/openai_skills_security-ownership-map/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_security-ownership-map/for-cursor/.forgecat/profiles/@forgecat/openai_skills_security-ownership-map/README.md
+++ b/profiles/openai/skills/openai_skills_security-ownership-map/for-cursor/.forgecat/profiles/@forgecat/openai_skills_security-ownership-map/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_security-threat-model/for-claude/.forgecat/profiles/@forgecat/openai_skills_security-threat-model/README.md
+++ b/profiles/openai/skills/openai_skills_security-threat-model/for-claude/.forgecat/profiles/@forgecat/openai_skills_security-threat-model/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_security-threat-model/for-codex/.forgecat/profiles/@forgecat/openai_skills_security-threat-model/README.md
+++ b/profiles/openai/skills/openai_skills_security-threat-model/for-codex/.forgecat/profiles/@forgecat/openai_skills_security-threat-model/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_security-threat-model/for-cursor/.forgecat/profiles/@forgecat/openai_skills_security-threat-model/README.md
+++ b/profiles/openai/skills/openai_skills_security-threat-model/for-cursor/.forgecat/profiles/@forgecat/openai_skills_security-threat-model/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_sentry/for-claude/.forgecat/profiles/@forgecat/openai_skills_sentry/README.md
+++ b/profiles/openai/skills/openai_skills_sentry/for-claude/.forgecat/profiles/@forgecat/openai_skills_sentry/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_sentry/for-codex/.forgecat/profiles/@forgecat/openai_skills_sentry/README.md
+++ b/profiles/openai/skills/openai_skills_sentry/for-codex/.forgecat/profiles/@forgecat/openai_skills_sentry/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_sentry/for-cursor/.forgecat/profiles/@forgecat/openai_skills_sentry/README.md
+++ b/profiles/openai/skills/openai_skills_sentry/for-cursor/.forgecat/profiles/@forgecat/openai_skills_sentry/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_slides/for-claude/.forgecat/profiles/@forgecat/openai_skills_slides/README.md
+++ b/profiles/openai/skills/openai_skills_slides/for-claude/.forgecat/profiles/@forgecat/openai_skills_slides/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_slides/for-codex/.forgecat/profiles/@forgecat/openai_skills_slides/README.md
+++ b/profiles/openai/skills/openai_skills_slides/for-codex/.forgecat/profiles/@forgecat/openai_skills_slides/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_slides/for-cursor/.forgecat/profiles/@forgecat/openai_skills_slides/README.md
+++ b/profiles/openai/skills/openai_skills_slides/for-cursor/.forgecat/profiles/@forgecat/openai_skills_slides/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_sora/for-claude/.forgecat/profiles/@forgecat/openai_skills_sora/README.md
+++ b/profiles/openai/skills/openai_skills_sora/for-claude/.forgecat/profiles/@forgecat/openai_skills_sora/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_sora/for-codex/.forgecat/profiles/@forgecat/openai_skills_sora/README.md
+++ b/profiles/openai/skills/openai_skills_sora/for-codex/.forgecat/profiles/@forgecat/openai_skills_sora/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_sora/for-cursor/.forgecat/profiles/@forgecat/openai_skills_sora/README.md
+++ b/profiles/openai/skills/openai_skills_sora/for-cursor/.forgecat/profiles/@forgecat/openai_skills_sora/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_speech/for-claude/.forgecat/profiles/@forgecat/openai_skills_speech/README.md
+++ b/profiles/openai/skills/openai_skills_speech/for-claude/.forgecat/profiles/@forgecat/openai_skills_speech/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_speech/for-codex/.forgecat/profiles/@forgecat/openai_skills_speech/README.md
+++ b/profiles/openai/skills/openai_skills_speech/for-codex/.forgecat/profiles/@forgecat/openai_skills_speech/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_speech/for-cursor/.forgecat/profiles/@forgecat/openai_skills_speech/README.md
+++ b/profiles/openai/skills/openai_skills_speech/for-cursor/.forgecat/profiles/@forgecat/openai_skills_speech/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_spreadsheet/for-claude/.forgecat/profiles/@forgecat/openai_skills_spreadsheet/README.md
+++ b/profiles/openai/skills/openai_skills_spreadsheet/for-claude/.forgecat/profiles/@forgecat/openai_skills_spreadsheet/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_spreadsheet/for-codex/.forgecat/profiles/@forgecat/openai_skills_spreadsheet/README.md
+++ b/profiles/openai/skills/openai_skills_spreadsheet/for-codex/.forgecat/profiles/@forgecat/openai_skills_spreadsheet/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_spreadsheet/for-cursor/.forgecat/profiles/@forgecat/openai_skills_spreadsheet/README.md
+++ b/profiles/openai/skills/openai_skills_spreadsheet/for-cursor/.forgecat/profiles/@forgecat/openai_skills_spreadsheet/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_system-openai-docs/for-claude/.forgecat/profiles/@forgecat/openai_skills_system-openai-docs/README.md
+++ b/profiles/openai/skills/openai_skills_system-openai-docs/for-claude/.forgecat/profiles/@forgecat/openai_skills_system-openai-docs/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_system-openai-docs/for-codex/.forgecat/profiles/@forgecat/openai_skills_system-openai-docs/README.md
+++ b/profiles/openai/skills/openai_skills_system-openai-docs/for-codex/.forgecat/profiles/@forgecat/openai_skills_system-openai-docs/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_system-openai-docs/for-cursor/.forgecat/profiles/@forgecat/openai_skills_system-openai-docs/README.md
+++ b/profiles/openai/skills/openai_skills_system-openai-docs/for-cursor/.forgecat/profiles/@forgecat/openai_skills_system-openai-docs/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_system-skill-creator/for-claude/.forgecat/profiles/@forgecat/openai_skills_system-skill-creator/README.md
+++ b/profiles/openai/skills/openai_skills_system-skill-creator/for-claude/.forgecat/profiles/@forgecat/openai_skills_system-skill-creator/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_system-skill-creator/for-codex/.forgecat/profiles/@forgecat/openai_skills_system-skill-creator/README.md
+++ b/profiles/openai/skills/openai_skills_system-skill-creator/for-codex/.forgecat/profiles/@forgecat/openai_skills_system-skill-creator/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_system-skill-creator/for-cursor/.forgecat/profiles/@forgecat/openai_skills_system-skill-creator/README.md
+++ b/profiles/openai/skills/openai_skills_system-skill-creator/for-cursor/.forgecat/profiles/@forgecat/openai_skills_system-skill-creator/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_system-skill-installer/for-claude/.forgecat/profiles/@forgecat/openai_skills_system-skill-installer/README.md
+++ b/profiles/openai/skills/openai_skills_system-skill-installer/for-claude/.forgecat/profiles/@forgecat/openai_skills_system-skill-installer/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_system-skill-installer/for-codex/.forgecat/profiles/@forgecat/openai_skills_system-skill-installer/README.md
+++ b/profiles/openai/skills/openai_skills_system-skill-installer/for-codex/.forgecat/profiles/@forgecat/openai_skills_system-skill-installer/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_system-skill-installer/for-cursor/.forgecat/profiles/@forgecat/openai_skills_system-skill-installer/README.md
+++ b/profiles/openai/skills/openai_skills_system-skill-installer/for-cursor/.forgecat/profiles/@forgecat/openai_skills_system-skill-installer/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_transcribe/for-claude/.forgecat/profiles/@forgecat/openai_skills_transcribe/README.md
+++ b/profiles/openai/skills/openai_skills_transcribe/for-claude/.forgecat/profiles/@forgecat/openai_skills_transcribe/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_transcribe/for-codex/.forgecat/profiles/@forgecat/openai_skills_transcribe/README.md
+++ b/profiles/openai/skills/openai_skills_transcribe/for-codex/.forgecat/profiles/@forgecat/openai_skills_transcribe/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_transcribe/for-cursor/.forgecat/profiles/@forgecat/openai_skills_transcribe/README.md
+++ b/profiles/openai/skills/openai_skills_transcribe/for-cursor/.forgecat/profiles/@forgecat/openai_skills_transcribe/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_vercel-deploy/for-claude/.forgecat/profiles/@forgecat/openai_skills_vercel-deploy/README.md
+++ b/profiles/openai/skills/openai_skills_vercel-deploy/for-claude/.forgecat/profiles/@forgecat/openai_skills_vercel-deploy/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_vercel-deploy/for-codex/.forgecat/profiles/@forgecat/openai_skills_vercel-deploy/README.md
+++ b/profiles/openai/skills/openai_skills_vercel-deploy/for-codex/.forgecat/profiles/@forgecat/openai_skills_vercel-deploy/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_vercel-deploy/for-cursor/.forgecat/profiles/@forgecat/openai_skills_vercel-deploy/README.md
+++ b/profiles/openai/skills/openai_skills_vercel-deploy/for-cursor/.forgecat/profiles/@forgecat/openai_skills_vercel-deploy/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_winui-app/for-claude/.forgecat/profiles/@forgecat/openai_skills_winui-app/README.md
+++ b/profiles/openai/skills/openai_skills_winui-app/for-claude/.forgecat/profiles/@forgecat/openai_skills_winui-app/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_winui-app/for-codex/.forgecat/profiles/@forgecat/openai_skills_winui-app/README.md
+++ b/profiles/openai/skills/openai_skills_winui-app/for-codex/.forgecat/profiles/@forgecat/openai_skills_winui-app/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_winui-app/for-cursor/.forgecat/profiles/@forgecat/openai_skills_winui-app/README.md
+++ b/profiles/openai/skills/openai_skills_winui-app/for-cursor/.forgecat/profiles/@forgecat/openai_skills_winui-app/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_yeet/for-claude/.forgecat/profiles/@forgecat/openai_skills_yeet/README.md
+++ b/profiles/openai/skills/openai_skills_yeet/for-claude/.forgecat/profiles/@forgecat/openai_skills_yeet/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_yeet/for-codex/.forgecat/profiles/@forgecat/openai_skills_yeet/README.md
+++ b/profiles/openai/skills/openai_skills_yeet/for-codex/.forgecat/profiles/@forgecat/openai_skills_yeet/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/openai/skills/openai_skills_yeet/for-cursor/.forgecat/profiles/@forgecat/openai_skills_yeet/README.md
+++ b/profiles/openai/skills/openai_skills_yeet/for-cursor/.forgecat/profiles/@forgecat/openai_skills_yeet/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/orchestra-research/ai-research-skills/for-claude/.forgecat/profiles/@forgecat/orchestra-research_ai-research-skills/README.md
+++ b/profiles/orchestra-research/ai-research-skills/for-claude/.forgecat/profiles/@forgecat/orchestra-research_ai-research-skills/README.md
@@ -1,4 +1,4 @@
-*written by forgecat*
+*written by ForgeCat*
 
 ![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/orchestra-research/ai-research-skills/for-codex/.forgecat/profiles/@forgecat/orchestra-research_ai-research-skills/README.md
+++ b/profiles/orchestra-research/ai-research-skills/for-codex/.forgecat/profiles/@forgecat/orchestra-research_ai-research-skills/README.md
@@ -1,4 +1,4 @@
-*written by forgecat*
+*written by ForgeCat*
 
 ![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/orchestra-research/ai-research-skills/for-forgecat/README.md
+++ b/profiles/orchestra-research/ai-research-skills/for-forgecat/README.md
@@ -1,4 +1,4 @@
-*written by forgecat*
+*written by ForgeCat*
 
 ![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/remotion-dev/skills/remotion-dev_skills_remotion/for-forgecat/README.md
+++ b/profiles/remotion-dev/skills/remotion-dev_skills_remotion/for-forgecat/README.md
@@ -1,4 +1,4 @@
-*written by forgecat*
+*written by ForgeCat*
 
 ![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/tldraw/tldraw/for-claude/.forgecat/profiles/@forgecat/tldraw_tldraw/README.md
+++ b/profiles/tldraw/tldraw/for-claude/.forgecat/profiles/@forgecat/tldraw_tldraw/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/tldraw/tldraw/for-codex/.forgecat/profiles/@forgecat/tldraw_tldraw/README.md
+++ b/profiles/tldraw/tldraw/for-codex/.forgecat/profiles/@forgecat/tldraw_tldraw/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/tldraw/tldraw/for-cursor/.forgecat/profiles/@forgecat/tldraw_tldraw/README.md
+++ b/profiles/tldraw/tldraw/for-cursor/.forgecat/profiles/@forgecat/tldraw_tldraw/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/tldraw/tldraw/for-forgecat/profile.yml
+++ b/profiles/tldraw/tldraw/for-forgecat/profile.yml
@@ -4,6 +4,7 @@ description: Draw and visually collaborate with your agents inside Cursor.
 repository: https://github.com/tldraw/tldraw
 license: '-'
 visibility: public
+sourcePlatform: cursor
 compatibility:
   platforms:
     tested:

--- a/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_composition-patterns/for-claude/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_composition-patterns/README.md
+++ b/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_composition-patterns/for-claude/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_composition-patterns/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_composition-patterns/for-codex/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_composition-patterns/README.md
+++ b/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_composition-patterns/for-codex/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_composition-patterns/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_composition-patterns/for-cursor/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_composition-patterns/README.md
+++ b/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_composition-patterns/for-cursor/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_composition-patterns/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_composition-patterns/for-forgecat/profile.yml
+++ b/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_composition-patterns/for-forgecat/profile.yml
@@ -7,6 +7,7 @@ description: React composition patterns that scale. Use when refactoring compone
 repository: https://github.com/vercel-labs/agent-skills
 license: MIT
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_deploy-to-vercel/for-codex/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_deploy-to-vercel/README.md
+++ b/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_deploy-to-vercel/for-codex/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_deploy-to-vercel/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_deploy-to-vercel/for-forgecat/profile.yml
+++ b/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_deploy-to-vercel/for-forgecat/profile.yml
@@ -6,6 +6,7 @@ description: Deploy applications and websites to Vercel. Use when the user reque
 repository: https://github.com/vercel-labs/agent-skills
 license: MIT
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-best-practices/for-claude/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_react-best-practices/README.md
+++ b/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-best-practices/for-claude/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_react-best-practices/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-best-practices/for-codex/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_react-best-practices/README.md
+++ b/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-best-practices/for-codex/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_react-best-practices/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-best-practices/for-cursor/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_react-best-practices/README.md
+++ b/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-best-practices/for-cursor/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_react-best-practices/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-best-practices/for-forgecat/profile.yml
+++ b/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-best-practices/for-forgecat/profile.yml
@@ -7,6 +7,7 @@ description: React and Next.js performance optimization guidelines from Vercel E
 repository: https://github.com/vercel-labs/agent-skills
 license: MIT
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-native-skills/for-claude/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_react-native-skills/README.md
+++ b/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-native-skills/for-claude/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_react-native-skills/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-native-skills/for-codex/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_react-native-skills/README.md
+++ b/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-native-skills/for-codex/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_react-native-skills/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-native-skills/for-cursor/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_react-native-skills/README.md
+++ b/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-native-skills/for-cursor/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_react-native-skills/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-native-skills/for-forgecat/profile.yml
+++ b/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-native-skills/for-forgecat/profile.yml
@@ -7,6 +7,7 @@ description: React Native and Expo best practices for building performant mobile
 repository: https://github.com/vercel-labs/agent-skills
 license: MIT
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-view-transitions/for-codex/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_react-view-transitions/README.md
+++ b/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-view-transitions/for-codex/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_react-view-transitions/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-view-transitions/for-forgecat/profile.yml
+++ b/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-view-transitions/for-forgecat/profile.yml
@@ -12,6 +12,7 @@ description: Guide for implementing smooth, native-feeling animations using Reac
 repository: https://github.com/vercel-labs/agent-skills
 license: MIT
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_vercel-cli-with-tokens/for-codex/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_vercel-cli-with-tokens/README.md
+++ b/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_vercel-cli-with-tokens/for-codex/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_vercel-cli-with-tokens/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_vercel-cli-with-tokens/for-forgecat/profile.yml
+++ b/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_vercel-cli-with-tokens/for-forgecat/profile.yml
@@ -6,6 +6,7 @@ description: Deploy and manage projects on Vercel using token-based authenticati
 repository: https://github.com/vercel-labs/agent-skills
 license: MIT
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_web-design-guidelines/for-codex/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_web-design-guidelines/README.md
+++ b/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_web-design-guidelines/for-codex/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_web-design-guidelines/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_web-design-guidelines/for-forgecat/profile.yml
+++ b/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_web-design-guidelines/for-forgecat/profile.yml
@@ -6,6 +6,7 @@ description: Review UI code for Web Interface Guidelines compliance. Use when as
 repository: https://github.com/vercel-labs/agent-skills
 license: MIT
 visibility: public
+sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_business-product/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_business-product/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_business-product/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_business-product/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_business-product/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_business-product/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_business-product/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_business-product/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_business-product/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_business-product/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_business-product/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_business-product/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_core-development/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_core-development/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_core-development/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_core-development/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_core-development/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_core-development/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_core-development/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_core-development/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_core-development/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_core-development/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_core-development/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_core-development/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_data-ai/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_data-ai/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_data-ai/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_data-ai/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_data-ai/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_data-ai/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_data-ai/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_data-ai/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_data-ai/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_data-ai/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_data-ai/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_data-ai/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_developer-experience/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_developer-experience/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_developer-experience/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_developer-experience/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_developer-experience/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_developer-experience/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_developer-experience/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_developer-experience/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_developer-experience/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_developer-experience/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_developer-experience/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_developer-experience/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_infrastructure/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_infrastructure/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_infrastructure/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_infrastructure/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_infrastructure/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_infrastructure/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_infrastructure/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_infrastructure/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_infrastructure/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_infrastructure/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_infrastructure/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_infrastructure/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_language-specialists/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_language-specialists/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_language-specialists/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_language-specialists/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_language-specialists/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_language-specialists/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_language-specialists/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_language-specialists/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_language-specialists/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_language-specialists/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_language-specialists/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_language-specialists/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_meta-orchestration/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_meta-orchestration/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_meta-orchestration/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_meta-orchestration/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_meta-orchestration/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_meta-orchestration/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_meta-orchestration/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_meta-orchestration/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_meta-orchestration/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_meta-orchestration/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_meta-orchestration/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_meta-orchestration/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_quality-security/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_quality-security/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_quality-security/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_quality-security/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_quality-security/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_quality-security/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_quality-security/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_quality-security/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_quality-security/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_quality-security/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_quality-security/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_quality-security/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_research-analysis/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_research-analysis/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_research-analysis/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_research-analysis/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_research-analysis/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_research-analysis/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_research-analysis/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_research-analysis/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_research-analysis/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_research-analysis/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_research-analysis/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_research-analysis/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_specialized-domains/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_specialized-domains/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_specialized-domains/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_specialized-domains/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_specialized-domains/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_specialized-domains/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_specialized-domains/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_specialized-domains/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_specialized-domains/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_specialized-domains/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_specialized-domains/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_specialized-domains/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 ![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 

--- a/profiles/xixu-me/skills/for-claude/.forgecat/profiles/@forgecat/xixu-me_skills/README.md
+++ b/profiles/xixu-me/skills/for-claude/.forgecat/profiles/@forgecat/xixu-me_skills/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 # Xi Xu Skills
 

--- a/profiles/xixu-me/skills/for-codex/.forgecat/profiles/@forgecat/xixu-me_skills/README.md
+++ b/profiles/xixu-me/skills/for-codex/.forgecat/profiles/@forgecat/xixu-me_skills/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 # Xi Xu Skills
 

--- a/profiles/xixu-me/skills/for-forgecat/README.md
+++ b/profiles/xixu-me/skills/for-forgecat/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 # Xi Xu Skills
 

--- a/profiles/yeachan-heo/oh-my-claudecode_agents/for-claude/.forgecat/profiles/@forgecat/yeachan-heo_oh-my-claudecode_agents/README.md
+++ b/profiles/yeachan-heo/oh-my-claudecode_agents/for-claude/.forgecat/profiles/@forgecat/yeachan-heo_oh-my-claudecode_agents/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 # oh-my-claudecode Agents
 

--- a/profiles/yeachan-heo/oh-my-claudecode_agents/for-codex/.forgecat/profiles/@forgecat/yeachan-heo_oh-my-claudecode_agents/README.md
+++ b/profiles/yeachan-heo/oh-my-claudecode_agents/for-codex/.forgecat/profiles/@forgecat/yeachan-heo_oh-my-claudecode_agents/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 # oh-my-claudecode Agents
 

--- a/profiles/yeachan-heo/oh-my-claudecode_agents/for-cursor/.forgecat/profiles/@forgecat/yeachan-heo_oh-my-claudecode_agents/README.md
+++ b/profiles/yeachan-heo/oh-my-claudecode_agents/for-cursor/.forgecat/profiles/@forgecat/yeachan-heo_oh-my-claudecode_agents/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 # oh-my-claudecode Agents
 

--- a/profiles/yeachan-heo/oh-my-claudecode_agents/for-forgecat/README.md
+++ b/profiles/yeachan-heo/oh-my-claudecode_agents/for-forgecat/README.md
@@ -1,4 +1,4 @@
-*written by Forgecat*
+*written by ForgeCat*
 
 # oh-my-claudecode Agents
 


### PR DESCRIPTION
## Summary

Repo-wide metadata normalization so all 166 profiles validate clean. No functional content changes.

**1. README label casing** — normalize every `*written by Forgecat*` / `*written by ForgeCat*` label line to the canonical brand casing `*written by ForgeCat*` (621 files). The workspace validator (check 16) and conversion skill enforce this exact casing.

**2. `sourcePlatform` backfill** — add the optional `sourcePlatform` manifest field (specs/profiles.md §2.2) to the 80 `for-forgecat/profile.yml` manifests that were missing it (86 already had it). Values derived from each profile's README `Source platform` row. Validator check 28 now requires the field.

**3. yeachan README Version label** — rename the `Registry version` Details row to the canonical `Version` field (root + for-forgecat README) so check 24 and the registry/repo sync gate (both require a `| Version |` row) can read it. Value unchanged.

## Validation

- `validate-profile.sh` (28 checks) against all 166 profiles: **166 pass, 0 fail.**
- The previously-failing `anthropics_knowledge-work-plugins_small-business` was a validator false positive (a `.codex` manifest under the spec-native `platforms/codex/` `mode: override` subtree is legitimate per specs/profiles.md §2.7); fixed in the workspace validator (check 15 now ignores the `platforms/<id>/` override subtree). No profile change needed.
- `forgecat validate --json`: ok on sampled profiles.
- All edited `profile.yml` files re-parse as valid YAML.

Registry tarballs pick up the README/manifest changes on each profile's next publish; no republish here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)