### PR TITLE
Strengthen profile catalog governance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: Bug report
+description: Report a broken profile install, runtime failure, or metadata problem.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: input
+    id: profile
+    attributes:
+      label: Profile
+      description: The full ForgeCat profile name.
+      placeholder: "@forgecat/openai_skills_frontend-skill"
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - claude-code
+        - cursor
+        - codex
+        - registry or metadata
+        - other
+    validations:
+      required: true
+  - type: input
+    id: forgecat-version
+    attributes:
+      label: ForgeCat CLI version
+      placeholder: "forgecat --version"
+  - type: textarea
+    id: command
+    attributes:
+      label: Command
+      description: Paste the exact command that failed.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Paste the error or describe the incorrect installed files/runtime behavior.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Include logs, installed file paths, runtime prompts, screenshots, or source links.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues for the same profile and failure.
+          required: true
+        - label: I included the exact profile name, platform, command, and error/result.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: ForgeCat docs
+    url: https://forgecat.ai/docs
+    about: Read the ForgeCat documentation.

--- a/.github/ISSUE_TEMPLATE/platform_support.yml
+++ b/.github/ISSUE_TEMPLATE/platform_support.yml
@@ -1,0 +1,49 @@
+name: Platform support
+description: Request testing, native artifacts, or compatibility fixes for a profile platform.
+title: "[Platform]: "
+labels:
+  - platform-support
+body:
+  - type: input
+    id: profile
+    attributes:
+      label: Profile
+      placeholder: "@forgecat/obra_superpowers"
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - claude-code
+        - cursor
+        - codex
+    validations:
+      required: true
+  - type: textarea
+    id: request
+    attributes:
+      label: What support is needed?
+      description: Describe whether this is a missing tested artifact, partial support, install failure, or runtime issue.
+    validations:
+      required: true
+  - type: textarea
+    id: current-result
+    attributes:
+      label: Current result
+      description: Include install commands, runtime prompts, errors, or observed missing files.
+      render: text
+  - type: textarea
+    id: expected-result
+    attributes:
+      label: Expected result
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I included the exact profile and platform.
+          required: true
+        - label: I checked whether the profile already has a matching `for-<platform>` directory.
+          required: true

--- a/.github/ISSUE_TEMPLATE/profile_request.yml
+++ b/.github/ISSUE_TEMPLATE/profile_request.yml
@@ -1,0 +1,54 @@
+name: Profile request
+description: Request a new public source repository to be converted into a ForgeCat profile.
+title: "[Profile request]: "
+labels:
+  - profile-request
+body:
+  - type: input
+    id: source-repo
+    attributes:
+      label: Source repository
+      description: Link to the upstream GitHub repository.
+      placeholder: "https://github.com/owner/repo"
+    validations:
+      required: true
+  - type: textarea
+    id: value
+    attributes:
+      label: Why this should be a ForgeCat profile
+      description: Who would use it, and what workflow would it improve?
+    validations:
+      required: true
+  - type: dropdown
+    id: target-platform
+    attributes:
+      label: Target platform
+      options:
+        - all supported platforms
+        - claude-code
+        - cursor
+        - codex
+        - not sure
+    validations:
+      required: true
+  - type: textarea
+    id: surfaces
+    attributes:
+      label: Agent surfaces
+      description: List any skills, agents, rules, commands, hooks, MCP servers, or config files you noticed.
+      placeholder: "skills/, agents/, .mcp.json, hooks/, rules, commands..."
+  - type: input
+    id: license
+    attributes:
+      label: License
+      description: Link to the upstream license, or say if you could not find one.
+      placeholder: "MIT, Apache-2.0, unknown, https://github.com/owner/repo/blob/main/LICENSE"
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: The source repository is public.
+          required: true
+        - label: I checked whether the repository has an explicit license.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,75 @@
+## Summary
+
+<!-- What changed, and why? Keep this short and concrete. -->
+
+## Scope
+
+- [ ] New profile
+- [ ] Existing profile fix
+- [ ] Platform artifact or compatibility update
+- [ ] README, metadata, or license correction
+- [ ] Repo maintenance
+
+## Source and License
+
+- Source repository:
+- Source path or subdirectory:
+- License evidence:
+
+Checklist:
+
+- [ ] I inspected the upstream source repository directly.
+- [ ] I preserved source attribution in the profile README or metadata.
+- [ ] I confirmed the license and reflected it in `for-forgecat/profile.yml`.
+- [ ] I did not add files that are unrelated to the profile runtime.
+
+## Validation
+
+Commands run:
+
+```text
+
+```
+
+Results:
+
+```text
+
+```
+
+Checklist:
+
+- [ ] `forgecat validate` passes from the profile's `for-forgecat/` directory.
+- [ ] README install commands and profile metadata agree.
+- [ ] No secrets, local state, logs, or generated tool cache files are included.
+
+## Profile Conversion Review Checklist
+
+Complete this table for new profiles, profile fixes, and platform compatibility updates.
+
+| Review item | Required detail |
+|---|---|
+| Internal file edits | List any edits made inside copied upstream files. Write `None` if upstream files were preserved without internal edits. |
+| Behavior parity risk | Explain whether the conversion could change upstream behavior. Include the reason and mitigation for any non-low risk. |
+| Platform install/runtime | For each tested platform, include the install command, installed skill/agent/hook/command/MCP surface exercised, and exact result. |
+| Notes / special cases | Record partial support, auth requirements, MCP prompts, unsupported files, source limitations, or other reviewer context. |
+
+## Platform Evidence
+
+Complete this section when `compatibility.platforms` changes.
+
+| Platform | Status | Install command | Runtime surface tested | Result |
+|---|---|---|---|---|
+| Claude Code | not tested |  |  |  |
+| Cursor | not tested |  |  |  |
+| Codex | not tested |  |  |  |
+
+Checklist:
+
+- [ ] Tested platforms have matching native `for-<platform>` directories.
+- [ ] Partial platforms list known limitations.
+- [ ] Runtime testing exercised the installed skill, agent, hook, command, or MCP surface, not only a generic prompt.
+
+## Notes
+
+<!-- Known limitations, intentional source differences, reviewer context. -->

--- a/.github/workflows/catalog-check.yml
+++ b/.github/workflows/catalog-check.yml
@@ -1,0 +1,33 @@
+name: Catalog check
+
+on:
+  pull_request:
+    paths:
+      - README.md
+      - profiles/**
+      - scripts/check-readme-catalog.rb
+      - .github/workflows/catalog-check.yml
+  push:
+    branches:
+      - main
+    paths:
+      - README.md
+      - profiles/**
+      - scripts/check-readme-catalog.rb
+      - .github/workflows/catalog-check.yml
+
+jobs:
+  readme-catalog:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+
+      - name: Check README catalog
+        run: ruby scripts/check-readme-catalog.rb

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,133 @@
+# Contributing to ForgeCat Agent Profiles
+
+Thanks for helping improve the ForgeCat profile catalog. This repository exists to make useful agent workflows easy to find, inspect, install, and improve across Claude Code, Cursor, and Codex.
+
+## What to Contribute
+
+Good contributions include:
+
+- New profiles converted from public source repositories
+- Fixes for profiles that install incorrectly
+- Missing `for-<platform>` artifacts after real platform testing
+- README improvements that make profiles easier to understand and install
+- License, source attribution, and metadata corrections
+- Issue reports with exact install/runtime failures
+
+Please keep changes focused. A PR should usually touch one profile, one collection, or one repo-level maintenance concern.
+
+## Profile Requirements
+
+Every profile must have a canonical ForgeCat source directory:
+
+```text
+profiles/<source-owner>/<source-repository-or-collection>/<profile-name>/for-forgecat/
+```
+
+Small single-profile repositories may use:
+
+```text
+profiles/<source-owner>/<source-repository>/for-forgecat/
+```
+
+The canonical package must include:
+
+- `for-forgecat/profile.yml`
+- A useful README for the profile or collection
+- Source attribution back to the original repository
+- License metadata when the original source provides it
+- Only files needed for the profile to work
+
+## Source Fidelity
+
+Profiles should preserve the behavior and intent of the original source repository.
+
+Before converting or changing a profile:
+
+1. Inspect the upstream repository directly.
+2. Check the actual files being packaged, not only README prose.
+3. Do not invent commands, skills, agents, hooks, or MCP servers that are not present in the source unless the PR clearly explains the compatibility shim.
+4. Preserve relative file references used by skills, scripts, hooks, and MCP configuration.
+5. Keep original wording where it affects tool behavior.
+
+If a profile intentionally differs from upstream behavior, call that out in the PR.
+
+## License and Attribution
+
+Each profile can carry content from a different upstream project, so license review is required.
+
+Before opening a PR:
+
+1. Check the upstream repository for `LICENSE`, `LICENSE.md`, `LICENSE.txt`, package metadata, and README license notes.
+2. Use an SPDX identifier in `for-forgecat/profile.yml` when the license is clear.
+3. Include the upstream repository URL in `repository`.
+4. Keep license files from the upstream source when they are part of the package.
+5. Do not mark an unknown license as permissive.
+
+If the license is missing or ambiguous, open an issue before publishing the profile publicly.
+
+## Platform Compatibility
+
+ForgeCat supports:
+
+| Platform | Profile id |
+|---|---|
+| Claude Code | `claude-code` |
+| Cursor | `cursor` |
+| Codex | `codex` |
+
+Use `compatibility.platforms.tested` only after a real install/runtime check in that platform.
+
+When a platform is marked tested:
+
+- The matching native artifact should exist in the profile directory:
+  - `for-claude/` for Claude Code
+  - `for-cursor/` for Cursor
+  - `for-codex/` for Codex
+- The PR should describe the install command, runtime surface, and result.
+- README platform tables and `for-forgecat/profile.yml` should agree.
+
+Use `compatibility.platforms.partial` for profiles that install but have known limitations.
+
+## Validation
+
+Run validation from the canonical package directory:
+
+```bash
+cd profiles/<source-owner>/<source-repository-or-collection>/<profile-name>/for-forgecat
+forgecat validate
+```
+
+For stricter local checks, also run:
+
+```bash
+forgecat validate --strict
+```
+
+Before submitting a repo-level documentation change, run:
+
+```bash
+ruby scripts/check-readme-catalog.rb
+```
+
+## Pull Requests
+
+Open a PR with:
+
+- The source repository URL
+- A short summary of what changed
+- License evidence
+- Validation results
+- Platform install/runtime evidence when compatibility metadata changed
+- Notes for known limitations or intentional behavior changes
+
+Keep generated files, local tool state, and unrelated profile changes out of the PR.
+
+## Issues and Profile Requests
+
+Use the issue templates for:
+
+- Broken installs or runtime failures
+- New profile requests
+- Requests to test or add support for another platform
+
+Include exact commands, error output, profile name, ForgeCat CLI version, platform, and workspace details when reporting a failure.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!) The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,104 +1,180 @@
-# 🐾 ForgeCat Agent Profiles
+# ForgeCat Agent Profiles
 
-Curated collection of AI Agent Profiles — ready to install and use across platforms.
+Install production-ready agent profiles for Claude Code, Cursor, and Codex with one command.
 
-**Forge your agents. Stamp your mark.**
+[![Profiles](https://img.shields.io/badge/profiles-171-blue)](#browse-profiles)
+[![Collections](https://img.shields.io/badge/collections-32-blue)](#browse-profiles)
+[![Platforms](https://img.shields.io/badge/platforms-Claude%20Code%20%7C%20Cursor%20%7C%20Codex-green)](#supported-platforms)
 
----
+![ForgeCat Agent Profiles](./assets/forgecat_banner.png)
 
-## What is this?
+ForgeCat profiles package the files that make coding agents useful: skills, agents, rules, commands, hooks, and MCP settings. This repository curates open agent profiles from public projects and turns them into installable packages that work across supported tools.
 
-This repository hosts a curated set of **AI Agent Profiles** for [ForgeCat](https://forgecat.ai). An Agent Profile is a portable bundle of configuration files — agents, skills, rules, commands, and MCP settings — packaged together so you can supercharge your AI environment with a single command.
+## Install a Profile
 
----
+Install the ForgeCat CLI:
 
-## Collections
+```bash
+npm install -g forgecat
+```
+
+Search for profiles:
+
+```bash
+forgecat search frontend
+forgecat search mcp
+forgecat search review
+```
+
+Install a profile:
+
+```bash
+forgecat install @forgecat/openai_skills_frontend-skill -p codex
+forgecat install @forgecat/everyinc_compound-engineering-plugin -p claude-code
+forgecat install @forgecat/obra_superpowers -p cursor
+```
+
+Use `forgecat install <profile> -p <platform>` with one of the supported platform ids below.
+
+## Why Star This Repo
+
+This repository is the public catalog of ForgeCat-compatible agent profiles. Starring it helps developers discover reusable agent workflows instead of rebuilding the same skills, rules, and MCP setup in each tool.
+
+You should watch or star this repo if you want:
+
+- New agent profiles as they are converted and tested
+- Cross-platform ports of useful Claude Code, Cursor, and Codex workflows
+- Practical examples of profile packaging, attribution, licensing, and platform compatibility
+- A place to request profiles from public agent-skill repositories
+
+## Supported Platforms
+
+| Platform | ForgeCat id | What gets installed |
+|---|---|---|
+| Claude Code | `claude-code` | Claude-native skills, agents, commands, MCP, hooks, and project settings where supported |
+| Cursor | `cursor` | Cursor rules, agents, MCP configuration, and compatible profile resources |
+| Codex | `codex` | Codex skills, instructions, MCP configuration, hooks, and compatible profile resources |
+
+Each profile declares its tested and partial platforms in `for-forgecat/profile.yml`. When a profile is marked tested, the matching native `for-<platform>` artifact should also exist in the profile directory.
+
+## Featured Profiles
+
+| Profile | Install | Good for |
+|---|---|---|
+| [OpenAI frontend skill](./profiles/openai/skills/openai_skills_frontend-skill) | `forgecat install @forgecat/openai_skills_frontend-skill -p codex` | Visually strong web apps, landing pages, prototypes, and UI polish |
+| [Compound Engineering](./profiles/everyinc/compound-engineering-plugin) | `forgecat install @forgecat/everyinc_compound-engineering-plugin -p claude-code` | Code review, research, planning, design review, and engineering workflows |
+| [Superpowers](./profiles/obra/superpowers) | `forgecat install @forgecat/obra_superpowers -p cursor` | Planning, TDD, debugging, review, subagents, and session-start workflow guidance |
+| [tldraw](./profiles/tldraw/tldraw) | `forgecat install @forgecat/tldraw_tldraw -p cursor` | Visual collaboration with agent workflows |
+| [Azure skills](./profiles/microsoft/azure-skills) | `forgecat search azure` | Azure deployment, observability, compliance, RBAC, storage, and AI workflows |
+
+## Browse Profiles
+
+Profiles are grouped by their original source owner and repository:
+
+```text
+profiles/<source-owner>/<source-repository-or-collection>/
+```
+
+<details>
+<summary>Show all collections</summary>
 
 | Collection | Profiles | Description |
-|---|---|---|
+|---|---:|---|
 | [addyosmani/agent-skills](./profiles/addyosmani/agent-skills) | 1 | Production-grade engineering skills pack by Addy Osmani |
 | [anthropics/claude-code](./profiles/anthropics/claude-code) | 1 | Claude Code profile conversion |
-| [anthropics/claude-plugins-official](./profiles/anthropics/claude-plugins-official) | 16 | Hook-free official Anthropic Claude plugin conversions (skills, agents, commands, MCP) |
-| [anthropics/knowledge-work-plugins](./profiles/anthropics/knowledge-work-plugins) | 15 | Knowledge work plugins — legal, finance, HR, marketing, operations, and more |
-| [anthropics/skills](./profiles/anthropics/skills) | 17 | Anthropic skills collection converted from `anthropics/skills` subpaths (docx, pdf, pptx, xlsx, mcp-builder, and more) |
-| [awslabs/aidlc-workflows](./profiles/awslabs/aidlc-workflows) | 1 | AWS AI-DLC workflow rules profile for planning, construction, and governance workflows |
-| [coreyhaines31/marketingskills](./profiles/coreyhaines31/marketingskills) | 1 | Marketing agent skills for conversion optimization, copywriting, SEO, paid ads, analytics, growth, and go-to-market workflows |
-| [cursor/plugins](./profiles/cursor/plugins) | 3 | Plugins for Cursor — team workflows, continual learning, and iterative agent loops |
-| [everyinc/compound-engineering-plugin](./profiles/everyinc/compound-engineering-plugin) | 1 | AI-powered development profile with deep workflows for review, research, and design |
-| [fivetaku/fablize](./profiles/fivetaku/fablize) | 1 | Claude Code harness for grounded multi-step work, verification, discipline packs, and early-stop guard support |
-| [forgecat/forgecat-agent-profiles](./profiles/forgecat/forgecat-agent-profiles) | 1 | ForgeCat-authored orchestration profiles built from existing profile packages |
-| [garrytan/gstack](./profiles/garrytan/gstack) | 1 | Garry's Stack — 35+ AI engineering workflow skills for planning, QA, review, and deployment |
-| [google-gemini/gemini-skills](./profiles/google-gemini/gemini-skills) | 3 | Google Gemini skills set converted into installable ForgeCat profiles (API dev, interactions API, live API) |
-| [googleworkspace/cli](./profiles/googleworkspace/cli) | 1 | Google Workspace CLI agent skills for Drive, Gmail, Calendar, Docs, Sheets, Slides, Chat, Apps Script, personas, and recipes |
-| [juliusbrussee/caveman](./profiles/juliusbrussee/caveman) | 1 | Julius Brussee's caveman communication mode with compressed skills, commands, agents, and hooks |
-| [kepano/obsidian-skills](./profiles/kepano/obsidian-skills) | 1 | Agent skills for creating and editing Obsidian vault files, Markdown notes, Bases, Canvas files, and Obsidian CLI workflows |
-| [leonxlnx/taste-skill](./profiles/leonxlnx/taste-skill) | 1 | Skill-only Taste Skill package for premium frontend design, redesign, image-to-code, and image-generation workflows |
-| [mattpocock/skills](./profiles/mattpocock/skills) | 1 | TypeScript skills by Matt Pocock converted into an installable ForgeCat profile |
-| [microsoft/azure-skills](./profiles/microsoft/azure-skills) | 20 | Microsoft Azure skills converted from `microsoft/azure-skills`, including the full Azure plugin profile plus split legacy skill profiles |
-| [msitarzewski/agency-agents](./profiles/msitarzewski/agency-agents) | 13 | Team role agents for agencies — academic, design, engineering, marketing, sales, and more |
+| [anthropics/claude-plugins-official](./profiles/anthropics/claude-plugins-official) | 16 | Official Anthropic Claude plugin conversions for skills, agents, commands, and MCP |
+| [anthropics/knowledge-work-plugins](./profiles/anthropics/knowledge-work-plugins) | 15 | Knowledge-work plugins for legal, finance, HR, marketing, operations, sales, and more |
+| [anthropics/skills](./profiles/anthropics/skills) | 17 | Anthropic skill profiles for documents, spreadsheets, slides, web apps, themes, and more |
+| [awslabs/aidlc-workflows](./profiles/awslabs/aidlc-workflows) | 1 | AWS AI-DLC workflow rules for planning, construction, and governance |
+| [coreyhaines31/marketingskills](./profiles/coreyhaines31/marketingskills) | 1 | Marketing skills for conversion, copywriting, SEO, paid ads, analytics, and GTM work |
+| [cursor/plugins](./profiles/cursor/plugins) | 3 | Cursor plugins for team workflows, continual learning, and iterative agent loops |
+| [dietrichgebert/ponytail](./profiles/dietrichgebert/ponytail) | 1 | Ponytail mode hooks and workflow support |
+| [everyinc/compound-engineering-plugin](./profiles/everyinc/compound-engineering-plugin) | 1 | AI-powered development workflows for review, research, design, and delivery |
+| [fivetaku/fablize](./profiles/fivetaku/fablize) | 1 | Claude Code harness for grounded multi-step work and verification discipline |
+| [forgecat/forgecat-agent-profiles](./profiles/forgecat/forgecat-agent-profiles) | 1 | ForgeCat-authored orchestration profile built from existing profile packages |
+| [garrytan/gstack](./profiles/garrytan/gstack) | 1 | Garry's Stack engineering workflow skills for planning, QA, review, and deployment |
+| [google-gemini/gemini-skills](./profiles/google-gemini/gemini-skills) | 3 | Gemini API, interactions API, and live API development skills |
+| [googleworkspace/cli](./profiles/googleworkspace/cli) | 1 | Google Workspace CLI skills for Drive, Gmail, Calendar, Docs, Sheets, Slides, Chat, and Apps Script |
+| [juliusbrussee/caveman](./profiles/juliusbrussee/caveman) | 1 | Caveman communication mode with compressed skills, commands, agents, and hooks |
+| [kepano/obsidian-skills](./profiles/kepano/obsidian-skills) | 1 | Obsidian vault, Markdown, Bases, Canvas, and CLI workflows |
+| [leonxlnx/taste-skill](./profiles/leonxlnx/taste-skill) | 1 | Taste Skill package for premium frontend design and image-to-code workflows |
+| [mattpocock/skills](./profiles/mattpocock/skills) | 1 | TypeScript skills by Matt Pocock |
+| [microsoft/azure-skills](./profiles/microsoft/azure-skills) | 20 | Microsoft Azure skills for deployment, observability, compliance, storage, AI, and more |
+| [msitarzewski/agency-agents](./profiles/msitarzewski/agency-agents) | 13 | Agency role agents for academic, design, engineering, marketing, sales, and operations teams |
 | [multica-ai/andrej-karpathy-skills](./profiles/multica-ai/andrej-karpathy-skills) | 1 | Andrej Karpathy coding guidelines for focused, verifiable agent work |
-| [obra/superpowers](./profiles/obra/superpowers) | 1 | Superpowers profile with hook-backed startup context |
-| [openai/skills](./profiles/openai/skills) | 45 | Skills for OpenAI platforms — ASP.NET Core, Figma, Playwright, and more |
-| [orchestra-research/ai-research-skills](./profiles/orchestra-research/ai-research-skills) | 1 | AI research skills library for autonomous research, training, evaluation, inference, MLOps, RAG, multimodal systems, and paper writing |
+| [obra/superpowers](./profiles/obra/superpowers) | 1 | Superpowers software-development methodology with hook-backed startup context |
+| [openai/skills](./profiles/openai/skills) | 45 | OpenAI skills for frontend, Figma, Playwright, deployment, documents, security, and more |
+| [orchestra-research/ai-research-skills](./profiles/orchestra-research/ai-research-skills) | 1 | AI research skills for training, evaluation, inference, MLOps, RAG, multimodal systems, and papers |
 | [remotion-dev/skills](./profiles/remotion-dev/skills) | 1 | Remotion best-practices skill for video creation in React |
 | [tldraw/tldraw](./profiles/tldraw/tldraw) | 1 | Visual collaboration profile powered by the tldraw MCP server |
 | [upstash/context7](./profiles/upstash/context7) | 1 | Context7 MCP integration for up-to-date documentation lookup |
-| [vercel-labs/agent-skills](./profiles/vercel-labs/agent-skills) | 7 | Vercel agent skill collection split into installable profiles (deploy, React, UI audit, and workflow skills) |
-| [voltagent/awesome-codex-subagents](./profiles/voltagent/awesome-codex-subagents) | 10 | Subagents for OpenAI Codex — development, infrastructure, security, research |
-| [xixu-me/skills](./profiles/xixu-me/skills) | 1 | Xi Xu Agent Skills collection for userscripts, GitHub Actions docs, secure hosting, browser workflows, and Xdrop/Xget/tzst tooling |
+| [vercel-labs/agent-skills](./profiles/vercel-labs/agent-skills) | 7 | Vercel agent skills for deployment, React, UI audits, and workflow patterns |
+| [voltagent/awesome-codex-subagents](./profiles/voltagent/awesome-codex-subagents) | 10 | Codex subagents for development, infrastructure, security, and research |
+| [xixu-me/skills](./profiles/xixu-me/skills) | 1 | Xi Xu skills for userscripts, GitHub Actions docs, secure hosting, browser workflows, and tooling |
 | [yeachan-heo/oh-my-claudecode_agents](./profiles/yeachan-heo/oh-my-claudecode_agents) | 1 | Agents-only Claude Code orchestration profile from oh-my-claudecode |
 
-Total profiles: **170** across **31** collections.
+</details>
 
-### Profile Directory Layout
+Total: 171 profiles across 32 collections.
 
-Profiles are grouped by the original GitHub source owner:
+## Profile Layout
+
+A complete profile directory usually contains:
 
 ```text
-profiles/<source-owner>/<source-repository-or-collection>/...
+profiles/<source-owner>/<source-repository>/
+├── README.md
+├── for-forgecat/
+│   ├── profile.yml
+│   └── ...
+├── for-claude/
+├── for-cursor/
+└── for-codex/
 ```
 
-Use lowercase owner and collection directory names. For example, profiles from `https://github.com/anthropics/skills` live under `profiles/anthropics/skills`, and profiles from `https://github.com/anthropics/claude-plugins-official` live under `profiles/anthropics/claude-plugins-official`.
-
----
-
-## Quick Start
-
-```bash
-# Install the CLI
-npm install -g forgecat
-
-# Browse profiles
-forgecat search <keyword>
-
-# Install a profile
-forgecat install <@scope/profile>
-```
-
-Visit [forgecat.ai/docs](https://forgecat.ai/docs) for full documentation.
-
----
-
-## Links
-
-- **Website**: [forgecat.ai](https://forgecat.ai)
-- **Docs**: [forgecat.ai/docs](https://forgecat.ai/docs)
-- **CLI**: `npm install -g forgecat`
-
----
+`for-forgecat/` is the canonical ForgeCat package source. Native `for-claude`, `for-cursor`, and `for-codex` directories are added when the profile has been tested and materialized for those platforms.
 
 ## Contributing
 
-Run the layout check before adding or moving profiles:
+Contributions are welcome when they improve installability, source fidelity, documentation, or platform support.
 
-```bash
-ruby scripts/check-profile-layout.rb
-```
+Read [CONTRIBUTING.md](./CONTRIBUTING.md) before opening a PR.
 
----
+Good contributions include:
+
+- Adding a new profile from a public source repository
+- Fixing profile packaging when installed files do not match the original source behavior
+- Adding missing native platform artifacts after a real platform test
+- Improving README clarity, installation examples, attribution, or license metadata
+- Reporting a profile that installs incorrectly or no longer matches its upstream source
+
+Before opening a PR:
+
+1. Keep the profile under `profiles/<source-owner>/<source-repository-or-collection>/`.
+2. Verify the upstream source repository directly. Do not rely only on copied metadata.
+3. Confirm the original license and preserve source attribution.
+4. Run `forgecat validate` from the profile's `for-forgecat/` directory.
+5. If you mark a platform as tested, include the matching native `for-<platform>` artifact and note the install/runtime evidence in the PR.
+
+## Request a Profile
+
+Open an issue with:
+
+- Source repository URL
+- Why the profile would be useful
+- Target platform: `claude-code`, `cursor`, `codex`, or all supported platforms
+- Any license or setup requirements you already know about
+
+Profiles with clear agent surfaces, permissive licensing, active usage, and strong developer value are the best candidates.
+
+## Links
+
+- Website: [forgecat.ai](https://forgecat.ai)
+- Docs: [forgecat.ai/docs](https://forgecat.ai/docs)
+- CLI: `npm install -g forgecat`
 
 ## License
 
-This repository is licensed under Apache License 2.0.
+This repository is distributed under the Apache License 2.0. See [LICENSE](./LICENSE).
 
-Individual profiles may carry their own licenses. See each profile directory for details.
+Individual profiles may include content from their original source repositories and can carry their own license terms. Check each profile's `for-forgecat/profile.yml`, README, and included license files before redistributing or modifying profile content.

--- a/scripts/check-readme-catalog.rb
+++ b/scripts/check-readme-catalog.rb
@@ -1,0 +1,87 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "set"
+
+ROOT = File.expand_path("..", __dir__)
+README = File.join(ROOT, "README.md")
+
+def fail_with(errors)
+  return if errors.empty?
+
+  warn "README catalog check failed:"
+  errors.each { |error| warn "- #{error}" }
+  exit 1
+end
+
+def read(path)
+  File.read(path)
+rescue Errno::ENOENT
+  abort "Missing required file: #{path}"
+end
+
+manifest_paths = Dir.glob(File.join(ROOT, "profiles/**/for-forgecat/profile.yml")).sort
+profile_count = manifest_paths.length
+
+collection_counts = Hash.new(0)
+manifest_paths.each do |path|
+  relative = path.delete_prefix("#{ROOT}/")
+  segments = relative.split("/")
+  next unless segments[0] == "profiles" && segments.length >= 4
+
+  collection = "#{segments[1]}/#{segments[2]}"
+  collection_counts[collection] += 1
+end
+
+readme = read(README)
+errors = []
+
+expected_summary = "Total: #{profile_count} profiles across #{collection_counts.length} collections."
+errors << "expected README summary #{expected_summary.inspect}" unless readme.include?(expected_summary)
+
+expected_profile_badge = "profiles-#{profile_count}-blue"
+errors << "expected profile badge to include #{expected_profile_badge.inspect}" unless readme.include?(expected_profile_badge)
+
+expected_collection_badge = "collections-#{collection_counts.length}-blue"
+errors << "expected collection badge to include #{expected_collection_badge.inspect}" unless readme.include?(expected_collection_badge)
+
+rows = {}
+readme.each_line do |line|
+  match = line.match(%r{\|\s*\[([^\]]+)\]\(\./profiles/([^)]+)\)\s*\|\s*(\d+)\s*\|})
+  next unless match
+
+  label = match[1]
+  path = match[2]
+  count = match[3].to_i
+  errors << "collection row label #{label.inspect} does not match path #{path.inspect}" unless label == path
+  rows[path] = count
+end
+
+expected_collections = collection_counts.keys.to_set
+actual_collections = rows.keys.to_set
+
+(expected_collections - actual_collections).sort.each do |collection|
+  errors << "missing README collection row for #{collection}"
+end
+
+(actual_collections - expected_collections).sort.each do |collection|
+  errors << "README has stale collection row for #{collection}"
+end
+
+collection_counts.sort.each do |collection, expected_count|
+  actual_count = rows[collection]
+  next if actual_count == expected_count
+
+  errors << "README collection #{collection} count is #{actual_count.inspect}, expected #{expected_count}"
+end
+
+readme.scan(/\]\((\.\/[^)#]+)(?:#[^)]+)?\)/).flatten.uniq.sort.each do |relative_link|
+  path = File.join(ROOT, relative_link.delete_prefix("./"))
+  errors << "README local link target does not exist: #{relative_link}" unless File.exist?(path)
+end
+
+fail_with(errors)
+
+puts "README catalog check passed"
+puts "profiles=#{profile_count}"
+puts "collections=#{collection_counts.length}"


### PR DESCRIPTION
## Summary

This PR turns the profile repository into a more complete open-source catalog surface for ForgeCat profiles.

It updates the root README so visitors can quickly understand what the repo is, install profiles, browse supported platforms, and find contribution paths. It also adds repo-level governance files and a catalog drift check so profile counts, collection rows, and README links stay aligned with the repository tree.

## Changes

- Reworked the root README around install/search/star/contribute flows
- Added an Apache-2.0 `LICENSE`
- Added `CONTRIBUTING.md` with source fidelity, license, validation, and platform evidence rules
- Added bug report, profile request, and platform support issue templates
- Added a PR template with source/license/validation sections
- Added a `Converter Agent Checklist` section to the PR template, including an at-a-glance summary and review rows for internal edits, behavior parity risk, install/runtime evidence, special cases, and operator next action
- Added `scripts/check-readme-catalog.rb` to verify README profile counts, collection rows, and local links
- Added a GitHub Actions workflow to run the catalog check on README/profile/catalog changes

## Validation

```text
ruby scripts/check-readme-catalog.rb
README catalog check passed
profiles=171
collections=32
```

```text
ruby -c scripts/check-readme-catalog.rb
Syntax OK
```

```text
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/catalog-check.yml"); Dir[".github/ISSUE_TEMPLATE/*.yml"].each { |f| YAML.load_file(f) }; puts "yaml ok"'
yaml ok
```

```text
README local link check
local_links=40
missing=0
```

## Notes

- This PR intentionally does not add `SECURITY.md`.
- The README counts are based on current `main` before the pending `paramchoudhary/resumeskills` branch lands.