### PR TITLE
Sync paramchoudhary resumeskills version

### DIFF
--- a/profiles/paramchoudhary/resumeskills/README.md
+++ b/profiles/paramchoudhary/resumeskills/README.md
@@ -49,7 +49,7 @@ npx forgecat install @forgecat/paramchoudhary_resumeskills
 |---|---|
 | Author | Param Choudhary |
 | Original repository | https://github.com/Paramchoudhary/ResumeSkills/tree/main/skills |
-| Version | `0.0.0` |
+| Version | `0.1.0` |
 | Original commit | `24c6edc8942edceba609e897ee8ec24f09d7581f` (2026-05-20) |
 | License | MIT |
 | Source platform | Agent Skills |

--- a/profiles/paramchoudhary/resumeskills/for-forgecat/README.md
+++ b/profiles/paramchoudhary/resumeskills/for-forgecat/README.md
@@ -51,7 +51,7 @@ npx forgecat install @forgecat/paramchoudhary_resumeskills
 |---|---|
 | Author | Param Choudhary |
 | Original repository | https://github.com/Paramchoudhary/ResumeSkills/tree/main/skills |
-| Version | `0.0.0` |
+| Version | `0.1.0` |
 | Original commit | `24c6edc8942edceba609e897ee8ec24f09d7581f` (2026-05-20) |
 | License | MIT |
 | Source platform | Agent Skills |


### PR DESCRIPTION
## Summary

Syncs the ResumeSkills profile README metadata to the registry-assigned version after publishing `@forgecat/paramchoudhary_resumeskills@0.1.0`.

## Evidence

- Published package: `@forgecat/paramchoudhary_resumeskills@0.1.0`
- Publish integrity: `sha256-a8a73167b6153fbb2acc42e8a7bface58b6281d68398d7f9499fced0f53d4a26`
- `BASE_DIR=/tmp/forgecat-resumeskills-publish/profiles bash scripts/validate-profile.sh paramchoudhary resumeskills` -> passed
- `bash scripts/check-registry-repo-sync-gate.sh --repo-profiles-dir /tmp/forgecat-resumeskills-publish/profiles --profile @forgecat/paramchoudhary_resumeskills` -> `SYNC_GATE_PASS`

## Scope

Only updates the `Version` row from `0.0.0` to `0.1.0` in:

- `profiles/paramchoudhary/resumeskills/README.md`
- `profiles/paramchoudhary/resumeskills/for-forgecat/README.md`