### PR TITLE
Remove README top title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# ForgeCat Agent Profiles
-
 <div align="center">
   <a href="https://github.com/nota-america/forgecat-agent-profiles">
     <img width="1500" alt="ForgeCat Agent Profiles" src="./assets/forgecat_banner.png" />


### PR DESCRIPTION
## Summary

Remove the top-level `# ForgeCat Agent Profiles` heading so the README starts directly with the centered banner section.

## Scope

- [ ] New profile
- [ ] Existing profile fix
- [ ] Platform artifact or compatibility update
- [x] README, metadata, or license correction
- [ ] Repo maintenance

## Source and License

- Source repository: N/A
- Source path or subdirectory: N/A
- License evidence: N/A

Checklist:

- [x] I inspected the upstream source repository directly. N/A for README-only formatting update.
- [x] I preserved source attribution in the profile README or metadata. N/A for README-only formatting update.
- [x] I confirmed the license and reflected it in `for-forgecat/profile.yml`. N/A for README-only formatting update.
- [x] I did not add files that are unrelated to the profile runtime.

## Validation

Commands run:

```text
ruby scripts/check-readme-catalog.rb
git diff --check
```

Results:

```text
README catalog check passed
profiles=173
collections=34
git diff --check passed
```

Checklist:

- [x] `forgecat validate` passes from the profile's `for-forgecat/` directory. N/A for README-only formatting update.
- [x] README install commands and profile metadata agree. README catalog check passed.
- [x] No secrets, local state, logs, or generated tool cache files are included.

## Profile Conversion Review Checklist

| Review item | Required detail |
|---|---|
| Internal file edits | None. Only root README heading was removed. |
| Behavior parity risk | None. No profile package files or install behavior changed. |
| Platform install/runtime | N/A. No profile compatibility changed. |
| Notes / special cases | README now starts directly with the centered banner block. |

## Platform Evidence

N/A. No `compatibility.platforms` changes.