### PR TITLE
chore: sync geo seo release metadata

### DIFF
--- a/profiles/zubair-trabzada/geo-seo-claude/README.md
+++ b/profiles/zubair-trabzada/geo-seo-claude/README.md
@@ -41,7 +41,7 @@ npx forgecat install @forgecat/zubair-trabzada_geo-seo-claude
 |---|---|
 | Author | Zubair Trabzada |
 | Original repository | https://github.com/zubair-trabzada/geo-seo-claude |
-| Version | `0.0.0` |
+| Version | `0.1.0` |
 | Original commit | `9eec32f5f700a1e6c3cb1cb735a56ee5ec49a964` |
 | License | MIT |
 | Source platform | Claude Code skills (non-plugin) |


### PR DESCRIPTION
## Summary
- sync geo-seo-claude profile README to registry-assigned version 0.1.0

## Verification
- ruby scripts/check-readme-catalog.rb
- BASE_DIR=/tmp/forgecat-repo-geo-seo-claude/profiles bash /Users/openclawuser/.openclaw/workspace-forgecat/scripts/validate-profile.sh zubair-trabzada geo-seo-claude
- bash /Users/openclawuser/.openclaw/workspace-forgecat/scripts/check-registry-repo-sync-gate.sh --profile geo-seo-claude

## Registry
- published @forgecat/zubair-trabzada_geo-seo-claude@0.1.0
