### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #152)

### DIFF
--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_agent-sdk-dev/for-forgecat/commands/new-sdk-app.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_agent-sdk-dev/for-forgecat/commands/new-sdk-app.md
@@ -1,6 +1,6 @@
 ---
 description: Create and setup a new Claude Agent SDK application
-argument-hint: [project-name]
+argument-hint: "[project-name]"
 ---
 
 You are tasked with helping the user create a new Claude Agent SDK application. Follow these steps carefully:

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-claude/.claude/skills/command-development/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-claude/.claude/skills/command-development/README.md
@@ -117,7 +117,7 @@ Claude loads references and examples as needed based on task.
 ```markdown
 ---
 description: Brief description
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 allowed-tools: Read, Bash(git:*)
 ---
 
@@ -172,7 +172,7 @@ Review this code for quality and potential bugs.
 ```markdown
 ---
 description: Deploy to environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Deploy to $1 environment using version $2
@@ -183,7 +183,7 @@ Deploy to $1 environment using version $2
 ```markdown
 ---
 description: Document file
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Generate documentation for @$1

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-claude/.claude/skills/command-development/SKILL.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-claude/.claude/skills/command-development/SKILL.md
@@ -189,7 +189,7 @@ model: haiku
 
 ```yaml
 ---
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 ---
 ```
 
@@ -222,7 +222,7 @@ Capture all arguments as single string:
 ```markdown
 ---
 description: Fix issue by number
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Fix issue #$ARGUMENTS following our coding standards and best practices.
@@ -249,7 +249,7 @@ Capture individual arguments with `$1`, `$2`, `$3`, etc.:
 ```markdown
 ---
 description: Review PR with priority and assignee
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 ---
 
 Review pull request #$1 with priority level $2.
@@ -298,7 +298,7 @@ Include file contents in command:
 ```markdown
 ---
 description: Review specific file
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Review @$1 for:
@@ -419,7 +419,7 @@ Organize commands in subdirectories:
 
 ```markdown
 ---
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ---
 
 $IF($1,
@@ -452,7 +452,7 @@ Please provide a PR number. Usage: /review-pr [number]
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 <!--
@@ -491,7 +491,7 @@ Provide specific feedback for each file.
 ```markdown
 ---
 description: Run tests for specific file
-argument-hint: [test-file]
+argument-hint: "[test-file]"
 allowed-tools: Bash(npm:*)
 ---
 
@@ -505,7 +505,7 @@ Analyze results and suggest fixes for failures.
 ```markdown
 ---
 description: Generate documentation for file
-argument-hint: [source-file]
+argument-hint: "[source-file]"
 ---
 
 Generate comprehensive documentation for @$1 including:
@@ -522,7 +522,7 @@ Generate comprehensive documentation for @$1 including:
 ```markdown
 ---
 description: Complete PR workflow
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 allowed-tools: Bash(gh:*), Read
 ---
 
@@ -651,7 +651,7 @@ plugin-name/
 ```markdown
 ---
 description: Deploy using plugin configuration
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Read, Bash(*)
 ---
 
@@ -666,7 +666,7 @@ Monitor deployment and report status.
 ```markdown
 ---
 description: Generate docs from template
-argument-hint: [component]
+argument-hint: "[component]"
 ---
 
 Template: @${CLAUDE_PLUGIN_ROOT}/templates/docs.md
@@ -702,7 +702,7 @@ Launch plugin agents for complex tasks:
 ```markdown
 ---
 description: Deep code review
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Initiate comprehensive review of @$1 using the code-reviewer agent.
@@ -734,7 +734,7 @@ Leverage plugin skills for specialized knowledge:
 ```markdown
 ---
 description: Document API with standards
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Document API in @$1 following plugin standards.
@@ -774,7 +774,7 @@ Combine agents, skills, and scripts:
 ```markdown
 ---
 description: Comprehensive review workflow
-argument-hint: [file]
+argument-hint: "[file]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -811,7 +811,7 @@ Commands should validate inputs and resources before processing.
 ```markdown
 ---
 description: Deploy with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Validate environment: !`echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
@@ -828,7 +828,7 @@ Show usage: /deploy [environment]
 ```markdown
 ---
 description: Process configuration
-argument-hint: [config-file]
+argument-hint: "[config-file]"
 ---
 
 Check file exists: !`test -f $1 && echo "EXISTS" || echo "MISSING"`

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-claude/.claude/skills/command-development/examples/plugin-commands.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-claude/.claude/skills/command-development/examples/plugin-commands.md
@@ -26,7 +26,7 @@ Practical examples of commands designed for Claude Code plugins, demonstrating p
 ```markdown
 ---
 description: Analyze code quality using plugin tools
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -57,7 +57,7 @@ Review the analysis output and provide:
 ```markdown
 ---
 description: Complete code audit using plugin suite
-argument-hint: [directory]
+argument-hint: "[directory]"
 allowed-tools: Bash(*)
 model: sonnet
 ---
@@ -97,7 +97,7 @@ Analyze all results and create comprehensive report including:
 ```markdown
 ---
 description: Generate API documentation from template
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Template structure: @${CLAUDE_PLUGIN_ROOT}/templates/api-documentation.md
@@ -134,7 +134,7 @@ Format output as markdown suitable for README or docs site.
 ```markdown
 ---
 description: Execute complete release workflow
-argument-hint: [version]
+argument-hint: "[version]"
 allowed-tools: Bash(*), Read
 ---
 
@@ -177,7 +177,7 @@ Review all step outputs and report:
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Read, Bash(*)
 ---
 
@@ -218,7 +218,7 @@ Report deployment status and any issues encountered.
 ```markdown
 ---
 description: Deep code review using plugin agent
-argument-hint: [file-or-directory]
+argument-hint: "[file-or-directory]"
 ---
 
 Initiate comprehensive code review of @$1 using the code-reviewer agent.
@@ -255,7 +255,7 @@ Note: This uses the Task tool to launch the plugin's code-reviewer agent for tho
 ```markdown
 ---
 description: Document API following plugin standards
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 API source code: @$1
@@ -295,7 +295,7 @@ Generate production-ready API documentation.
 ```markdown
 ---
 description: Comprehensive review using all plugin components
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -352,7 +352,7 @@ Include specific file locations and suggested changes for each item.
 ```markdown
 ---
 description: Build for specific environment with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(*)
 ---
 
@@ -397,7 +397,7 @@ If validations fail:
 ```markdown
 ---
 description: Run environment-appropriate checks
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(*), Read
 ---
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-claude/.claude/skills/command-development/examples/simple-commands.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-claude/.claude/skills/command-development/examples/simple-commands.md
@@ -91,7 +91,7 @@ Prioritize issues by severity.
 ```markdown
 ---
 description: Run tests for specific file
-argument-hint: [test-file]
+argument-hint: "[test-file]"
 allowed-tools: Bash(npm:*), Bash(jest:*)
 ---
 
@@ -122,7 +122,7 @@ If failures found, suggest fixes based on error messages.
 ```markdown
 ---
 description: Generate documentation for file
-argument-hint: [source-file]
+argument-hint: "[source-file]"
 ---
 
 Generate comprehensive documentation for @$1
@@ -200,7 +200,7 @@ Provide:
 ```markdown
 ---
 description: Deploy to specified environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 allowed-tools: Bash(kubectl:*), Read
 ---
 
@@ -238,7 +238,7 @@ Proceed with deployment? (yes/no)
 ```markdown
 ---
 description: Compare two files
-argument-hint: [file1] [file2]
+argument-hint: "[file1] [file2]"
 ---
 
 Compare @$1 with @$2
@@ -283,7 +283,7 @@ Present as structured comparison report.
 ```markdown
 ---
 description: Quick fix for common issues
-argument-hint: [issue-description]
+argument-hint: "[issue-description]"
 model: haiku
 ---
 
@@ -319,7 +319,7 @@ Provide code changes with file paths and line numbers.
 ```markdown
 ---
 description: Research best practices for topic
-argument-hint: [topic]
+argument-hint: "[topic]"
 model: sonnet
 ---
 
@@ -364,7 +364,7 @@ Provide actionable guidance based on research.
 ```markdown
 ---
 description: Explain how code works
-argument-hint: [file-or-function]
+argument-hint: "[file-or-function]"
 ---
 
 Explain @$1 in detail
@@ -438,7 +438,7 @@ Analyze and suggest...
 
 ```markdown
 ---
-argument-hint: [target]
+argument-hint: "[target]"
 ---
 
 Process $1...
@@ -450,7 +450,7 @@ Process $1...
 
 ```markdown
 ---
-argument-hint: [source] [target] [options]
+argument-hint: "[source] [target] [options]"
 ---
 
 Process $1 to $2 with $3...

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-claude/.claude/skills/command-development/references/advanced-workflows.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-claude/.claude/skills/command-development/references/advanced-workflows.md
@@ -15,7 +15,7 @@ Commands that guide users through multi-step processes:
 ```markdown
 ---
 description: Complete PR review workflow
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 allowed-tools: Bash(gh:*), Read, Grep
 ---
 
@@ -132,7 +132,7 @@ Commands that adapt based on conditions:
 ```markdown
 ---
 description: Smart deployment workflow
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(git:*), Bash(npm:*), Read
 ---
 
@@ -454,7 +454,7 @@ Ready for next deployment.
 ```markdown
 ---
 description: Deploy with optional version
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Environment: ${1:-staging}
@@ -472,7 +472,7 @@ Note: Using defaults for missing arguments:
 ```markdown
 ---
 description: Deploy to validated environment
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Environment: $1
@@ -494,7 +494,7 @@ Environment validated. Proceeding...
 ```markdown
 ---
 description: Deploy with shorthand
-argument-hint: [env-shorthand]
+argument-hint: "[env-shorthand]"
 ---
 
 Input: $1
@@ -641,7 +641,7 @@ If any step fails, resume with:
 ```markdown
 ---
 description: Initialize deployment
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Write, Bash(git:*)
 ---
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-claude/.claude/skills/command-development/references/documentation-patterns.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-claude/.claude/skills/command-development/references/documentation-patterns.md
@@ -13,7 +13,7 @@ Well-documented commands are easier to use, maintain, and distribute. Documentat
 ```markdown
 ---
 description: Clear, actionable description under 60 chars
-argument-hint: [arg1] [arg2] [optional-arg]
+argument-hint: "[arg1] [arg2] [optional-arg]"
 allowed-tools: Read, Bash(git:*)
 model: sonnet
 ---
@@ -233,7 +233,7 @@ Create a help subcommand for complex commands:
 ```markdown
 ---
 description: Main command with help
-argument-hint: [subcommand] [args]
+argument-hint: "[subcommand] [args]"
 ---
 
 # Command Processor
@@ -273,7 +273,7 @@ Provide help based on context:
 ```markdown
 ---
 description: Context-aware command
-argument-hint: [operation] [target]
+argument-hint: "[operation] [target]"
 ---
 
 # Context-Aware Operation

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-claude/.claude/skills/command-development/references/frontmatter-reference.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-claude/.claude/skills/command-development/references/frontmatter-reference.md
@@ -11,7 +11,7 @@ YAML frontmatter is optional metadata at the start of command files:
 description: Brief description
 allowed-tools: Read, Write
 model: sonnet
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 ---
 
 Command prompt content here...
@@ -203,29 +203,29 @@ model: opus
 
 **Format:**
 ```yaml
-argument-hint: [arg1] [arg2] [optional-arg]
+argument-hint: "[arg1] [arg2] [optional-arg]"
 ```
 
 **Examples:**
 
 **Single argument:**
 ```yaml
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ```
 
 **Multiple required arguments:**
 ```yaml
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ```
 
 **Optional arguments:**
 ```yaml
-argument-hint: [file-path] [options]
+argument-hint: "[file-path] [options]"
 ```
 
 **Descriptive names:**
 ```yaml
-argument-hint: [source-branch] [target-branch] [commit-message]
+argument-hint: "[source-branch] [target-branch] [commit-message]"
 ```
 
 **Best practices:**
@@ -241,7 +241,7 @@ argument-hint: [source-branch] [target-branch] [commit-message]
 ```yaml
 ---
 description: Fix issue by number
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Fix issue #$1...
@@ -251,7 +251,7 @@ Fix issue #$1...
 ```yaml
 ---
 description: Deploy to environment
-argument-hint: [app-name] [environment] [version]
+argument-hint: "[app-name] [environment] [version]"
 ---
 
 Deploy $1 to $2 using version $3...
@@ -261,7 +261,7 @@ Deploy $1 to $2 using version $3...
 ```yaml
 ---
 description: Run tests with options
-argument-hint: [test-pattern] [options]
+argument-hint: "[test-pattern] [options]"
 ---
 
 Run tests matching $1 with options: $2
@@ -368,7 +368,7 @@ All common fields:
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [app-name] [environment] [version]
+argument-hint: "[app-name] [environment] [version]"
 allowed-tools: Bash(kubectl:*), Bash(helm:*), Read
 model: sonnet
 ---
@@ -390,7 +390,7 @@ Restricted invocation:
 ```markdown
 ---
 description: Approve production deployment
-argument-hint: [deployment-id]
+argument-hint: "[deployment-id]"
 disable-model-invocation: true
 allowed-tools: Bash(gh:*)
 ---

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-claude/.claude/skills/command-development/references/interactive-commands.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-claude/.claude/skills/command-development/references/interactive-commands.md
@@ -875,7 +875,7 @@ Options:
 **Arguments for known values:**
 ```markdown
 ---
-argument-hint: [project-name]
+argument-hint: "[project-name]"
 allowed-tools: AskUserQuestion, Write
 ---
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-claude/.claude/skills/command-development/references/plugin-features-reference.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-claude/.claude/skills/command-development/references/plugin-features-reference.md
@@ -249,7 +249,7 @@ Commands that use plugin templates:
 ```markdown
 ---
 description: Generate documentation from template
-argument-hint: [component-name]
+argument-hint: "[component-name]"
 ---
 
 Template: @${CLAUDE_PLUGIN_ROOT}/templates/component-docs.md
@@ -294,7 +294,7 @@ Commands that adapt to environment:
 ```markdown
 ---
 description: Deploy based on environment
-argument-hint: [dev|staging|prod]
+argument-hint: "[dev|staging|prod]"
 ---
 
 Environment config: @${CLAUDE_PLUGIN_ROOT}/config/$1.json
@@ -336,7 +336,7 @@ Commands can trigger plugin agents using the Task tool:
 ```markdown
 ---
 description: Deep analysis using plugin agent
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Initiate deep code analysis of @$1 using the code-analyzer agent.
@@ -362,7 +362,7 @@ Commands can reference plugin skills for specialized knowledge:
 ```markdown
 ---
 description: API documentation with best practices
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Document the API in @$1 following our API documentation standards.
@@ -412,7 +412,7 @@ Commands that coordinate multiple plugin components:
 ```markdown
 ---
 description: Comprehensive code review workflow
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 File to review: @$1
@@ -445,7 +445,7 @@ Commands should validate inputs before processing:
 ```markdown
 ---
 description: Deploy to environment with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Validate environment: !`echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
@@ -468,7 +468,7 @@ Verify required files exist:
 ```markdown
 ---
 description: Process configuration file
-argument-hint: [config-file]
+argument-hint: "[config-file]"
 ---
 
 Check file: !`test -f $1 && echo "EXISTS" || echo "MISSING"`
@@ -488,7 +488,7 @@ Validate required arguments provided:
 ```markdown
 ---
 description: Create deployment with version
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Validate inputs: !`test -n "$1" -a -n "$2" && echo "OK" || echo "MISSING"`
@@ -545,7 +545,7 @@ Handle errors gracefully with helpful messages:
 ```markdown
 ---
 description: Process file with error handling
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Try processing: !`node ${CLAUDE_PLUGIN_ROOT}/scripts/process.js $1 2>&1 || echo "ERROR: $?"`

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-codex/.agents/skills/command-development/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-codex/.agents/skills/command-development/README.md
@@ -117,7 +117,7 @@ Claude loads references and examples as needed based on task.
 ```markdown
 ---
 description: Brief description
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 allowed-tools: Read, Bash(git:*)
 ---
 
@@ -172,7 +172,7 @@ Review this code for quality and potential bugs.
 ```markdown
 ---
 description: Deploy to environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Deploy to $1 environment using version $2
@@ -183,7 +183,7 @@ Deploy to $1 environment using version $2
 ```markdown
 ---
 description: Document file
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Generate documentation for @$1

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-codex/.agents/skills/command-development/SKILL.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-codex/.agents/skills/command-development/SKILL.md
@@ -189,7 +189,7 @@ model: haiku
 
 ```yaml
 ---
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 ---
 ```
 
@@ -222,7 +222,7 @@ Capture all arguments as single string:
 ```markdown
 ---
 description: Fix issue by number
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Fix issue #$ARGUMENTS following our coding standards and best practices.
@@ -249,7 +249,7 @@ Capture individual arguments with `$1`, `$2`, `$3`, etc.:
 ```markdown
 ---
 description: Review PR with priority and assignee
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 ---
 
 Review pull request #$1 with priority level $2.
@@ -298,7 +298,7 @@ Include file contents in command:
 ```markdown
 ---
 description: Review specific file
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Review @$1 for:
@@ -419,7 +419,7 @@ Organize commands in subdirectories:
 
 ```markdown
 ---
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ---
 
 $IF($1,
@@ -452,7 +452,7 @@ Please provide a PR number. Usage: /review-pr [number]
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 <!--
@@ -491,7 +491,7 @@ Provide specific feedback for each file.
 ```markdown
 ---
 description: Run tests for specific file
-argument-hint: [test-file]
+argument-hint: "[test-file]"
 allowed-tools: Bash(npm:*)
 ---
 
@@ -505,7 +505,7 @@ Analyze results and suggest fixes for failures.
 ```markdown
 ---
 description: Generate documentation for file
-argument-hint: [source-file]
+argument-hint: "[source-file]"
 ---
 
 Generate comprehensive documentation for @$1 including:
@@ -522,7 +522,7 @@ Generate comprehensive documentation for @$1 including:
 ```markdown
 ---
 description: Complete PR workflow
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 allowed-tools: Bash(gh:*), Read
 ---
 
@@ -651,7 +651,7 @@ plugin-name/
 ```markdown
 ---
 description: Deploy using plugin configuration
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Read, Bash(*)
 ---
 
@@ -666,7 +666,7 @@ Monitor deployment and report status.
 ```markdown
 ---
 description: Generate docs from template
-argument-hint: [component]
+argument-hint: "[component]"
 ---
 
 Template: @${CLAUDE_PLUGIN_ROOT}/templates/docs.md
@@ -702,7 +702,7 @@ Launch plugin agents for complex tasks:
 ```markdown
 ---
 description: Deep code review
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Initiate comprehensive review of @$1 using the code-reviewer agent.
@@ -734,7 +734,7 @@ Leverage plugin skills for specialized knowledge:
 ```markdown
 ---
 description: Document API with standards
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Document API in @$1 following plugin standards.
@@ -774,7 +774,7 @@ Combine agents, skills, and scripts:
 ```markdown
 ---
 description: Comprehensive review workflow
-argument-hint: [file]
+argument-hint: "[file]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -811,7 +811,7 @@ Commands should validate inputs and resources before processing.
 ```markdown
 ---
 description: Deploy with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Validate environment: !`echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
@@ -828,7 +828,7 @@ Show usage: /deploy [environment]
 ```markdown
 ---
 description: Process configuration
-argument-hint: [config-file]
+argument-hint: "[config-file]"
 ---
 
 Check file exists: !`test -f $1 && echo "EXISTS" || echo "MISSING"`

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-codex/.agents/skills/command-development/examples/plugin-commands.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-codex/.agents/skills/command-development/examples/plugin-commands.md
@@ -26,7 +26,7 @@ Practical examples of commands designed for Claude Code plugins, demonstrating p
 ```markdown
 ---
 description: Analyze code quality using plugin tools
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -57,7 +57,7 @@ Review the analysis output and provide:
 ```markdown
 ---
 description: Complete code audit using plugin suite
-argument-hint: [directory]
+argument-hint: "[directory]"
 allowed-tools: Bash(*)
 model: sonnet
 ---
@@ -97,7 +97,7 @@ Analyze all results and create comprehensive report including:
 ```markdown
 ---
 description: Generate API documentation from template
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Template structure: @${CLAUDE_PLUGIN_ROOT}/templates/api-documentation.md
@@ -134,7 +134,7 @@ Format output as markdown suitable for README or docs site.
 ```markdown
 ---
 description: Execute complete release workflow
-argument-hint: [version]
+argument-hint: "[version]"
 allowed-tools: Bash(*), Read
 ---
 
@@ -177,7 +177,7 @@ Review all step outputs and report:
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Read, Bash(*)
 ---
 
@@ -218,7 +218,7 @@ Report deployment status and any issues encountered.
 ```markdown
 ---
 description: Deep code review using plugin agent
-argument-hint: [file-or-directory]
+argument-hint: "[file-or-directory]"
 ---
 
 Initiate comprehensive code review of @$1 using the code-reviewer agent.
@@ -255,7 +255,7 @@ Note: This uses the Task tool to launch the plugin's code-reviewer agent for tho
 ```markdown
 ---
 description: Document API following plugin standards
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 API source code: @$1
@@ -295,7 +295,7 @@ Generate production-ready API documentation.
 ```markdown
 ---
 description: Comprehensive review using all plugin components
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -352,7 +352,7 @@ Include specific file locations and suggested changes for each item.
 ```markdown
 ---
 description: Build for specific environment with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(*)
 ---
 
@@ -397,7 +397,7 @@ If validations fail:
 ```markdown
 ---
 description: Run environment-appropriate checks
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(*), Read
 ---
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-codex/.agents/skills/command-development/examples/simple-commands.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-codex/.agents/skills/command-development/examples/simple-commands.md
@@ -91,7 +91,7 @@ Prioritize issues by severity.
 ```markdown
 ---
 description: Run tests for specific file
-argument-hint: [test-file]
+argument-hint: "[test-file]"
 allowed-tools: Bash(npm:*), Bash(jest:*)
 ---
 
@@ -122,7 +122,7 @@ If failures found, suggest fixes based on error messages.
 ```markdown
 ---
 description: Generate documentation for file
-argument-hint: [source-file]
+argument-hint: "[source-file]"
 ---
 
 Generate comprehensive documentation for @$1
@@ -200,7 +200,7 @@ Provide:
 ```markdown
 ---
 description: Deploy to specified environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 allowed-tools: Bash(kubectl:*), Read
 ---
 
@@ -238,7 +238,7 @@ Proceed with deployment? (yes/no)
 ```markdown
 ---
 description: Compare two files
-argument-hint: [file1] [file2]
+argument-hint: "[file1] [file2]"
 ---
 
 Compare @$1 with @$2
@@ -283,7 +283,7 @@ Present as structured comparison report.
 ```markdown
 ---
 description: Quick fix for common issues
-argument-hint: [issue-description]
+argument-hint: "[issue-description]"
 model: haiku
 ---
 
@@ -319,7 +319,7 @@ Provide code changes with file paths and line numbers.
 ```markdown
 ---
 description: Research best practices for topic
-argument-hint: [topic]
+argument-hint: "[topic]"
 model: sonnet
 ---
 
@@ -364,7 +364,7 @@ Provide actionable guidance based on research.
 ```markdown
 ---
 description: Explain how code works
-argument-hint: [file-or-function]
+argument-hint: "[file-or-function]"
 ---
 
 Explain @$1 in detail
@@ -438,7 +438,7 @@ Analyze and suggest...
 
 ```markdown
 ---
-argument-hint: [target]
+argument-hint: "[target]"
 ---
 
 Process $1...
@@ -450,7 +450,7 @@ Process $1...
 
 ```markdown
 ---
-argument-hint: [source] [target] [options]
+argument-hint: "[source] [target] [options]"
 ---
 
 Process $1 to $2 with $3...

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-codex/.agents/skills/command-development/references/advanced-workflows.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-codex/.agents/skills/command-development/references/advanced-workflows.md
@@ -15,7 +15,7 @@ Commands that guide users through multi-step processes:
 ```markdown
 ---
 description: Complete PR review workflow
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 allowed-tools: Bash(gh:*), Read, Grep
 ---
 
@@ -132,7 +132,7 @@ Commands that adapt based on conditions:
 ```markdown
 ---
 description: Smart deployment workflow
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(git:*), Bash(npm:*), Read
 ---
 
@@ -454,7 +454,7 @@ Ready for next deployment.
 ```markdown
 ---
 description: Deploy with optional version
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Environment: ${1:-staging}
@@ -472,7 +472,7 @@ Note: Using defaults for missing arguments:
 ```markdown
 ---
 description: Deploy to validated environment
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Environment: $1
@@ -494,7 +494,7 @@ Environment validated. Proceeding...
 ```markdown
 ---
 description: Deploy with shorthand
-argument-hint: [env-shorthand]
+argument-hint: "[env-shorthand]"
 ---
 
 Input: $1
@@ -641,7 +641,7 @@ If any step fails, resume with:
 ```markdown
 ---
 description: Initialize deployment
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Write, Bash(git:*)
 ---
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-codex/.agents/skills/command-development/references/documentation-patterns.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-codex/.agents/skills/command-development/references/documentation-patterns.md
@@ -13,7 +13,7 @@ Well-documented commands are easier to use, maintain, and distribute. Documentat
 ```markdown
 ---
 description: Clear, actionable description under 60 chars
-argument-hint: [arg1] [arg2] [optional-arg]
+argument-hint: "[arg1] [arg2] [optional-arg]"
 allowed-tools: Read, Bash(git:*)
 model: sonnet
 ---
@@ -233,7 +233,7 @@ Create a help subcommand for complex commands:
 ```markdown
 ---
 description: Main command with help
-argument-hint: [subcommand] [args]
+argument-hint: "[subcommand] [args]"
 ---
 
 # Command Processor
@@ -273,7 +273,7 @@ Provide help based on context:
 ```markdown
 ---
 description: Context-aware command
-argument-hint: [operation] [target]
+argument-hint: "[operation] [target]"
 ---
 
 # Context-Aware Operation

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-codex/.agents/skills/command-development/references/frontmatter-reference.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-codex/.agents/skills/command-development/references/frontmatter-reference.md
@@ -11,7 +11,7 @@ YAML frontmatter is optional metadata at the start of command files:
 description: Brief description
 allowed-tools: Read, Write
 model: sonnet
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 ---
 
 Command prompt content here...
@@ -203,29 +203,29 @@ model: opus
 
 **Format:**
 ```yaml
-argument-hint: [arg1] [arg2] [optional-arg]
+argument-hint: "[arg1] [arg2] [optional-arg]"
 ```
 
 **Examples:**
 
 **Single argument:**
 ```yaml
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ```
 
 **Multiple required arguments:**
 ```yaml
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ```
 
 **Optional arguments:**
 ```yaml
-argument-hint: [file-path] [options]
+argument-hint: "[file-path] [options]"
 ```
 
 **Descriptive names:**
 ```yaml
-argument-hint: [source-branch] [target-branch] [commit-message]
+argument-hint: "[source-branch] [target-branch] [commit-message]"
 ```
 
 **Best practices:**
@@ -241,7 +241,7 @@ argument-hint: [source-branch] [target-branch] [commit-message]
 ```yaml
 ---
 description: Fix issue by number
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Fix issue #$1...
@@ -251,7 +251,7 @@ Fix issue #$1...
 ```yaml
 ---
 description: Deploy to environment
-argument-hint: [app-name] [environment] [version]
+argument-hint: "[app-name] [environment] [version]"
 ---
 
 Deploy $1 to $2 using version $3...
@@ -261,7 +261,7 @@ Deploy $1 to $2 using version $3...
 ```yaml
 ---
 description: Run tests with options
-argument-hint: [test-pattern] [options]
+argument-hint: "[test-pattern] [options]"
 ---
 
 Run tests matching $1 with options: $2
@@ -368,7 +368,7 @@ All common fields:
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [app-name] [environment] [version]
+argument-hint: "[app-name] [environment] [version]"
 allowed-tools: Bash(kubectl:*), Bash(helm:*), Read
 model: sonnet
 ---
@@ -390,7 +390,7 @@ Restricted invocation:
 ```markdown
 ---
 description: Approve production deployment
-argument-hint: [deployment-id]
+argument-hint: "[deployment-id]"
 disable-model-invocation: true
 allowed-tools: Bash(gh:*)
 ---

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-codex/.agents/skills/command-development/references/interactive-commands.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-codex/.agents/skills/command-development/references/interactive-commands.md
@@ -875,7 +875,7 @@ Options:
 **Arguments for known values:**
 ```markdown
 ---
-argument-hint: [project-name]
+argument-hint: "[project-name]"
 allowed-tools: AskUserQuestion, Write
 ---
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-codex/.agents/skills/command-development/references/plugin-features-reference.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-codex/.agents/skills/command-development/references/plugin-features-reference.md
@@ -249,7 +249,7 @@ Commands that use plugin templates:
 ```markdown
 ---
 description: Generate documentation from template
-argument-hint: [component-name]
+argument-hint: "[component-name]"
 ---
 
 Template: @${CLAUDE_PLUGIN_ROOT}/templates/component-docs.md
@@ -294,7 +294,7 @@ Commands that adapt to environment:
 ```markdown
 ---
 description: Deploy based on environment
-argument-hint: [dev|staging|prod]
+argument-hint: "[dev|staging|prod]"
 ---
 
 Environment config: @${CLAUDE_PLUGIN_ROOT}/config/$1.json
@@ -336,7 +336,7 @@ Commands can trigger plugin agents using the Task tool:
 ```markdown
 ---
 description: Deep analysis using plugin agent
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Initiate deep code analysis of @$1 using the code-analyzer agent.
@@ -362,7 +362,7 @@ Commands can reference plugin skills for specialized knowledge:
 ```markdown
 ---
 description: API documentation with best practices
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Document the API in @$1 following our API documentation standards.
@@ -412,7 +412,7 @@ Commands that coordinate multiple plugin components:
 ```markdown
 ---
 description: Comprehensive code review workflow
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 File to review: @$1
@@ -445,7 +445,7 @@ Commands should validate inputs before processing:
 ```markdown
 ---
 description: Deploy to environment with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Validate environment: !`echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
@@ -468,7 +468,7 @@ Verify required files exist:
 ```markdown
 ---
 description: Process configuration file
-argument-hint: [config-file]
+argument-hint: "[config-file]"
 ---
 
 Check file: !`test -f $1 && echo "EXISTS" || echo "MISSING"`
@@ -488,7 +488,7 @@ Validate required arguments provided:
 ```markdown
 ---
 description: Create deployment with version
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Validate inputs: !`test -n "$1" -a -n "$2" && echo "OK" || echo "MISSING"`
@@ -545,7 +545,7 @@ Handle errors gracefully with helpful messages:
 ```markdown
 ---
 description: Process file with error handling
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Try processing: !`node ${CLAUDE_PLUGIN_ROOT}/scripts/process.js $1 2>&1 || echo "ERROR: $?"`

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-cursor/.cursor/skills/command-development/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-cursor/.cursor/skills/command-development/README.md
@@ -117,7 +117,7 @@ Claude loads references and examples as needed based on task.
 ```markdown
 ---
 description: Brief description
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 allowed-tools: Read, Bash(git:*)
 ---
 
@@ -172,7 +172,7 @@ Review this code for quality and potential bugs.
 ```markdown
 ---
 description: Deploy to environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Deploy to $1 environment using version $2
@@ -183,7 +183,7 @@ Deploy to $1 environment using version $2
 ```markdown
 ---
 description: Document file
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Generate documentation for @$1

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-cursor/.cursor/skills/command-development/SKILL.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-cursor/.cursor/skills/command-development/SKILL.md
@@ -189,7 +189,7 @@ model: haiku
 
 ```yaml
 ---
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 ---
 ```
 
@@ -222,7 +222,7 @@ Capture all arguments as single string:
 ```markdown
 ---
 description: Fix issue by number
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Fix issue #$ARGUMENTS following our coding standards and best practices.
@@ -249,7 +249,7 @@ Capture individual arguments with `$1`, `$2`, `$3`, etc.:
 ```markdown
 ---
 description: Review PR with priority and assignee
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 ---
 
 Review pull request #$1 with priority level $2.
@@ -298,7 +298,7 @@ Include file contents in command:
 ```markdown
 ---
 description: Review specific file
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Review @$1 for:
@@ -419,7 +419,7 @@ Organize commands in subdirectories:
 
 ```markdown
 ---
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ---
 
 $IF($1,
@@ -452,7 +452,7 @@ Please provide a PR number. Usage: /review-pr [number]
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 <!--
@@ -491,7 +491,7 @@ Provide specific feedback for each file.
 ```markdown
 ---
 description: Run tests for specific file
-argument-hint: [test-file]
+argument-hint: "[test-file]"
 allowed-tools: Bash(npm:*)
 ---
 
@@ -505,7 +505,7 @@ Analyze results and suggest fixes for failures.
 ```markdown
 ---
 description: Generate documentation for file
-argument-hint: [source-file]
+argument-hint: "[source-file]"
 ---
 
 Generate comprehensive documentation for @$1 including:
@@ -522,7 +522,7 @@ Generate comprehensive documentation for @$1 including:
 ```markdown
 ---
 description: Complete PR workflow
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 allowed-tools: Bash(gh:*), Read
 ---
 
@@ -651,7 +651,7 @@ plugin-name/
 ```markdown
 ---
 description: Deploy using plugin configuration
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Read, Bash(*)
 ---
 
@@ -666,7 +666,7 @@ Monitor deployment and report status.
 ```markdown
 ---
 description: Generate docs from template
-argument-hint: [component]
+argument-hint: "[component]"
 ---
 
 Template: @${CLAUDE_PLUGIN_ROOT}/templates/docs.md
@@ -702,7 +702,7 @@ Launch plugin agents for complex tasks:
 ```markdown
 ---
 description: Deep code review
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Initiate comprehensive review of @$1 using the code-reviewer agent.
@@ -734,7 +734,7 @@ Leverage plugin skills for specialized knowledge:
 ```markdown
 ---
 description: Document API with standards
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Document API in @$1 following plugin standards.
@@ -774,7 +774,7 @@ Combine agents, skills, and scripts:
 ```markdown
 ---
 description: Comprehensive review workflow
-argument-hint: [file]
+argument-hint: "[file]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -811,7 +811,7 @@ Commands should validate inputs and resources before processing.
 ```markdown
 ---
 description: Deploy with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Validate environment: !`echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
@@ -828,7 +828,7 @@ Show usage: /deploy [environment]
 ```markdown
 ---
 description: Process configuration
-argument-hint: [config-file]
+argument-hint: "[config-file]"
 ---
 
 Check file exists: !`test -f $1 && echo "EXISTS" || echo "MISSING"`

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-cursor/.cursor/skills/command-development/examples/plugin-commands.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-cursor/.cursor/skills/command-development/examples/plugin-commands.md
@@ -26,7 +26,7 @@ Practical examples of commands designed for Claude Code plugins, demonstrating p
 ```markdown
 ---
 description: Analyze code quality using plugin tools
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -57,7 +57,7 @@ Review the analysis output and provide:
 ```markdown
 ---
 description: Complete code audit using plugin suite
-argument-hint: [directory]
+argument-hint: "[directory]"
 allowed-tools: Bash(*)
 model: sonnet
 ---
@@ -97,7 +97,7 @@ Analyze all results and create comprehensive report including:
 ```markdown
 ---
 description: Generate API documentation from template
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Template structure: @${CLAUDE_PLUGIN_ROOT}/templates/api-documentation.md
@@ -134,7 +134,7 @@ Format output as markdown suitable for README or docs site.
 ```markdown
 ---
 description: Execute complete release workflow
-argument-hint: [version]
+argument-hint: "[version]"
 allowed-tools: Bash(*), Read
 ---
 
@@ -177,7 +177,7 @@ Review all step outputs and report:
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Read, Bash(*)
 ---
 
@@ -218,7 +218,7 @@ Report deployment status and any issues encountered.
 ```markdown
 ---
 description: Deep code review using plugin agent
-argument-hint: [file-or-directory]
+argument-hint: "[file-or-directory]"
 ---
 
 Initiate comprehensive code review of @$1 using the code-reviewer agent.
@@ -255,7 +255,7 @@ Note: This uses the Task tool to launch the plugin's code-reviewer agent for tho
 ```markdown
 ---
 description: Document API following plugin standards
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 API source code: @$1
@@ -295,7 +295,7 @@ Generate production-ready API documentation.
 ```markdown
 ---
 description: Comprehensive review using all plugin components
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -352,7 +352,7 @@ Include specific file locations and suggested changes for each item.
 ```markdown
 ---
 description: Build for specific environment with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(*)
 ---
 
@@ -397,7 +397,7 @@ If validations fail:
 ```markdown
 ---
 description: Run environment-appropriate checks
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(*), Read
 ---
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-cursor/.cursor/skills/command-development/examples/simple-commands.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-cursor/.cursor/skills/command-development/examples/simple-commands.md
@@ -91,7 +91,7 @@ Prioritize issues by severity.
 ```markdown
 ---
 description: Run tests for specific file
-argument-hint: [test-file]
+argument-hint: "[test-file]"
 allowed-tools: Bash(npm:*), Bash(jest:*)
 ---
 
@@ -122,7 +122,7 @@ If failures found, suggest fixes based on error messages.
 ```markdown
 ---
 description: Generate documentation for file
-argument-hint: [source-file]
+argument-hint: "[source-file]"
 ---
 
 Generate comprehensive documentation for @$1
@@ -200,7 +200,7 @@ Provide:
 ```markdown
 ---
 description: Deploy to specified environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 allowed-tools: Bash(kubectl:*), Read
 ---
 
@@ -238,7 +238,7 @@ Proceed with deployment? (yes/no)
 ```markdown
 ---
 description: Compare two files
-argument-hint: [file1] [file2]
+argument-hint: "[file1] [file2]"
 ---
 
 Compare @$1 with @$2
@@ -283,7 +283,7 @@ Present as structured comparison report.
 ```markdown
 ---
 description: Quick fix for common issues
-argument-hint: [issue-description]
+argument-hint: "[issue-description]"
 model: haiku
 ---
 
@@ -319,7 +319,7 @@ Provide code changes with file paths and line numbers.
 ```markdown
 ---
 description: Research best practices for topic
-argument-hint: [topic]
+argument-hint: "[topic]"
 model: sonnet
 ---
 
@@ -364,7 +364,7 @@ Provide actionable guidance based on research.
 ```markdown
 ---
 description: Explain how code works
-argument-hint: [file-or-function]
+argument-hint: "[file-or-function]"
 ---
 
 Explain @$1 in detail
@@ -438,7 +438,7 @@ Analyze and suggest...
 
 ```markdown
 ---
-argument-hint: [target]
+argument-hint: "[target]"
 ---
 
 Process $1...
@@ -450,7 +450,7 @@ Process $1...
 
 ```markdown
 ---
-argument-hint: [source] [target] [options]
+argument-hint: "[source] [target] [options]"
 ---
 
 Process $1 to $2 with $3...

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-cursor/.cursor/skills/command-development/references/advanced-workflows.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-cursor/.cursor/skills/command-development/references/advanced-workflows.md
@@ -15,7 +15,7 @@ Commands that guide users through multi-step processes:
 ```markdown
 ---
 description: Complete PR review workflow
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 allowed-tools: Bash(gh:*), Read, Grep
 ---
 
@@ -132,7 +132,7 @@ Commands that adapt based on conditions:
 ```markdown
 ---
 description: Smart deployment workflow
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(git:*), Bash(npm:*), Read
 ---
 
@@ -454,7 +454,7 @@ Ready for next deployment.
 ```markdown
 ---
 description: Deploy with optional version
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Environment: ${1:-staging}
@@ -472,7 +472,7 @@ Note: Using defaults for missing arguments:
 ```markdown
 ---
 description: Deploy to validated environment
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Environment: $1
@@ -494,7 +494,7 @@ Environment validated. Proceeding...
 ```markdown
 ---
 description: Deploy with shorthand
-argument-hint: [env-shorthand]
+argument-hint: "[env-shorthand]"
 ---
 
 Input: $1
@@ -641,7 +641,7 @@ If any step fails, resume with:
 ```markdown
 ---
 description: Initialize deployment
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Write, Bash(git:*)
 ---
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-cursor/.cursor/skills/command-development/references/documentation-patterns.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-cursor/.cursor/skills/command-development/references/documentation-patterns.md
@@ -13,7 +13,7 @@ Well-documented commands are easier to use, maintain, and distribute. Documentat
 ```markdown
 ---
 description: Clear, actionable description under 60 chars
-argument-hint: [arg1] [arg2] [optional-arg]
+argument-hint: "[arg1] [arg2] [optional-arg]"
 allowed-tools: Read, Bash(git:*)
 model: sonnet
 ---
@@ -233,7 +233,7 @@ Create a help subcommand for complex commands:
 ```markdown
 ---
 description: Main command with help
-argument-hint: [subcommand] [args]
+argument-hint: "[subcommand] [args]"
 ---
 
 # Command Processor
@@ -273,7 +273,7 @@ Provide help based on context:
 ```markdown
 ---
 description: Context-aware command
-argument-hint: [operation] [target]
+argument-hint: "[operation] [target]"
 ---
 
 # Context-Aware Operation

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-cursor/.cursor/skills/command-development/references/frontmatter-reference.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-cursor/.cursor/skills/command-development/references/frontmatter-reference.md
@@ -11,7 +11,7 @@ YAML frontmatter is optional metadata at the start of command files:
 description: Brief description
 allowed-tools: Read, Write
 model: sonnet
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 ---
 
 Command prompt content here...
@@ -203,29 +203,29 @@ model: opus
 
 **Format:**
 ```yaml
-argument-hint: [arg1] [arg2] [optional-arg]
+argument-hint: "[arg1] [arg2] [optional-arg]"
 ```
 
 **Examples:**
 
 **Single argument:**
 ```yaml
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ```
 
 **Multiple required arguments:**
 ```yaml
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ```
 
 **Optional arguments:**
 ```yaml
-argument-hint: [file-path] [options]
+argument-hint: "[file-path] [options]"
 ```
 
 **Descriptive names:**
 ```yaml
-argument-hint: [source-branch] [target-branch] [commit-message]
+argument-hint: "[source-branch] [target-branch] [commit-message]"
 ```
 
 **Best practices:**
@@ -241,7 +241,7 @@ argument-hint: [source-branch] [target-branch] [commit-message]
 ```yaml
 ---
 description: Fix issue by number
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Fix issue #$1...
@@ -251,7 +251,7 @@ Fix issue #$1...
 ```yaml
 ---
 description: Deploy to environment
-argument-hint: [app-name] [environment] [version]
+argument-hint: "[app-name] [environment] [version]"
 ---
 
 Deploy $1 to $2 using version $3...
@@ -261,7 +261,7 @@ Deploy $1 to $2 using version $3...
 ```yaml
 ---
 description: Run tests with options
-argument-hint: [test-pattern] [options]
+argument-hint: "[test-pattern] [options]"
 ---
 
 Run tests matching $1 with options: $2
@@ -368,7 +368,7 @@ All common fields:
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [app-name] [environment] [version]
+argument-hint: "[app-name] [environment] [version]"
 allowed-tools: Bash(kubectl:*), Bash(helm:*), Read
 model: sonnet
 ---
@@ -390,7 +390,7 @@ Restricted invocation:
 ```markdown
 ---
 description: Approve production deployment
-argument-hint: [deployment-id]
+argument-hint: "[deployment-id]"
 disable-model-invocation: true
 allowed-tools: Bash(gh:*)
 ---

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-cursor/.cursor/skills/command-development/references/interactive-commands.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-cursor/.cursor/skills/command-development/references/interactive-commands.md
@@ -875,7 +875,7 @@ Options:
 **Arguments for known values:**
 ```markdown
 ---
-argument-hint: [project-name]
+argument-hint: "[project-name]"
 allowed-tools: AskUserQuestion, Write
 ---
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-cursor/.cursor/skills/command-development/references/plugin-features-reference.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-cursor/.cursor/skills/command-development/references/plugin-features-reference.md
@@ -249,7 +249,7 @@ Commands that use plugin templates:
 ```markdown
 ---
 description: Generate documentation from template
-argument-hint: [component-name]
+argument-hint: "[component-name]"
 ---
 
 Template: @${CLAUDE_PLUGIN_ROOT}/templates/component-docs.md
@@ -294,7 +294,7 @@ Commands that adapt to environment:
 ```markdown
 ---
 description: Deploy based on environment
-argument-hint: [dev|staging|prod]
+argument-hint: "[dev|staging|prod]"
 ---
 
 Environment config: @${CLAUDE_PLUGIN_ROOT}/config/$1.json
@@ -336,7 +336,7 @@ Commands can trigger plugin agents using the Task tool:
 ```markdown
 ---
 description: Deep analysis using plugin agent
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Initiate deep code analysis of @$1 using the code-analyzer agent.
@@ -362,7 +362,7 @@ Commands can reference plugin skills for specialized knowledge:
 ```markdown
 ---
 description: API documentation with best practices
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Document the API in @$1 following our API documentation standards.
@@ -412,7 +412,7 @@ Commands that coordinate multiple plugin components:
 ```markdown
 ---
 description: Comprehensive code review workflow
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 File to review: @$1
@@ -445,7 +445,7 @@ Commands should validate inputs before processing:
 ```markdown
 ---
 description: Deploy to environment with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Validate environment: !`echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
@@ -468,7 +468,7 @@ Verify required files exist:
 ```markdown
 ---
 description: Process configuration file
-argument-hint: [config-file]
+argument-hint: "[config-file]"
 ---
 
 Check file: !`test -f $1 && echo "EXISTS" || echo "MISSING"`
@@ -488,7 +488,7 @@ Validate required arguments provided:
 ```markdown
 ---
 description: Create deployment with version
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Validate inputs: !`test -n "$1" -a -n "$2" && echo "OK" || echo "MISSING"`
@@ -545,7 +545,7 @@ Handle errors gracefully with helpful messages:
 ```markdown
 ---
 description: Process file with error handling
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Try processing: !`node ${CLAUDE_PLUGIN_ROOT}/scripts/process.js $1 2>&1 || echo "ERROR: $?"`

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-forgecat/skills/command-development/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-forgecat/skills/command-development/README.md
@@ -117,7 +117,7 @@ Claude loads references and examples as needed based on task.
 ```markdown
 ---
 description: Brief description
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 allowed-tools: Read, Bash(git:*)
 ---
 
@@ -172,7 +172,7 @@ Review this code for quality and potential bugs.
 ```markdown
 ---
 description: Deploy to environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Deploy to $1 environment using version $2
@@ -183,7 +183,7 @@ Deploy to $1 environment using version $2
 ```markdown
 ---
 description: Document file
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Generate documentation for @$1

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-forgecat/skills/command-development/SKILL.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-forgecat/skills/command-development/SKILL.md
@@ -183,7 +183,7 @@ model: haiku
 
 ```yaml
 ---
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 ---
 ```
 
@@ -216,7 +216,7 @@ Capture all arguments as single string:
 ```markdown
 ---
 description: Fix issue by number
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Fix issue #$ARGUMENTS following our coding standards and best practices.
@@ -243,7 +243,7 @@ Capture individual arguments with `$1`, `$2`, `$3`, etc.:
 ```markdown
 ---
 description: Review PR with priority and assignee
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 ---
 
 Review pull request #$1 with priority level $2.
@@ -292,7 +292,7 @@ Include file contents in command:
 ```markdown
 ---
 description: Review specific file
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Review @$1 for:
@@ -413,7 +413,7 @@ Organize commands in subdirectories:
 
 ```markdown
 ---
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ---
 
 $IF($1,
@@ -446,7 +446,7 @@ Please provide a PR number. Usage: /review-pr [number]
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 <!--
@@ -485,7 +485,7 @@ Provide specific feedback for each file.
 ```markdown
 ---
 description: Run tests for specific file
-argument-hint: [test-file]
+argument-hint: "[test-file]"
 allowed-tools: Bash(npm:*)
 ---
 
@@ -499,7 +499,7 @@ Analyze results and suggest fixes for failures.
 ```markdown
 ---
 description: Generate documentation for file
-argument-hint: [source-file]
+argument-hint: "[source-file]"
 ---
 
 Generate comprehensive documentation for @$1 including:
@@ -516,7 +516,7 @@ Generate comprehensive documentation for @$1 including:
 ```markdown
 ---
 description: Complete PR workflow
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 allowed-tools: Bash(gh:*), Read
 ---
 
@@ -645,7 +645,7 @@ plugin-name/
 ```markdown
 ---
 description: Deploy using plugin configuration
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Read, Bash(*)
 ---
 
@@ -660,7 +660,7 @@ Monitor deployment and report status.
 ```markdown
 ---
 description: Generate docs from template
-argument-hint: [component]
+argument-hint: "[component]"
 ---
 
 Template: @${CLAUDE_PLUGIN_ROOT}/templates/docs.md
@@ -696,7 +696,7 @@ Launch plugin agents for complex tasks:
 ```markdown
 ---
 description: Deep code review
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Initiate comprehensive review of @$1 using the code-reviewer agent.
@@ -728,7 +728,7 @@ Leverage plugin skills for specialized knowledge:
 ```markdown
 ---
 description: Document API with standards
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Document API in @$1 following plugin standards.
@@ -768,7 +768,7 @@ Combine agents, skills, and scripts:
 ```markdown
 ---
 description: Comprehensive review workflow
-argument-hint: [file]
+argument-hint: "[file]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -805,7 +805,7 @@ Commands should validate inputs and resources before processing.
 ```markdown
 ---
 description: Deploy with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Validate environment: !`echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
@@ -822,7 +822,7 @@ Show usage: /deploy [environment]
 ```markdown
 ---
 description: Process configuration
-argument-hint: [config-file]
+argument-hint: "[config-file]"
 ---
 
 Check file exists: !`test -f $1 && echo "EXISTS" || echo "MISSING"`

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-forgecat/skills/command-development/examples/plugin-commands.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-forgecat/skills/command-development/examples/plugin-commands.md
@@ -26,7 +26,7 @@ Practical examples of commands designed for Claude Code plugins, demonstrating p
 ```markdown
 ---
 description: Analyze code quality using plugin tools
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -57,7 +57,7 @@ Review the analysis output and provide:
 ```markdown
 ---
 description: Complete code audit using plugin suite
-argument-hint: [directory]
+argument-hint: "[directory]"
 allowed-tools: Bash(*)
 model: sonnet
 ---
@@ -97,7 +97,7 @@ Analyze all results and create comprehensive report including:
 ```markdown
 ---
 description: Generate API documentation from template
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Template structure: @${CLAUDE_PLUGIN_ROOT}/templates/api-documentation.md
@@ -134,7 +134,7 @@ Format output as markdown suitable for README or docs site.
 ```markdown
 ---
 description: Execute complete release workflow
-argument-hint: [version]
+argument-hint: "[version]"
 allowed-tools: Bash(*), Read
 ---
 
@@ -177,7 +177,7 @@ Review all step outputs and report:
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Read, Bash(*)
 ---
 
@@ -218,7 +218,7 @@ Report deployment status and any issues encountered.
 ```markdown
 ---
 description: Deep code review using plugin agent
-argument-hint: [file-or-directory]
+argument-hint: "[file-or-directory]"
 ---
 
 Initiate comprehensive code review of @$1 using the code-reviewer agent.
@@ -255,7 +255,7 @@ Note: This uses the Task tool to launch the plugin's code-reviewer agent for tho
 ```markdown
 ---
 description: Document API following plugin standards
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 API source code: @$1
@@ -295,7 +295,7 @@ Generate production-ready API documentation.
 ```markdown
 ---
 description: Comprehensive review using all plugin components
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -352,7 +352,7 @@ Include specific file locations and suggested changes for each item.
 ```markdown
 ---
 description: Build for specific environment with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(*)
 ---
 
@@ -397,7 +397,7 @@ If validations fail:
 ```markdown
 ---
 description: Run environment-appropriate checks
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(*), Read
 ---
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-forgecat/skills/command-development/examples/simple-commands.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-forgecat/skills/command-development/examples/simple-commands.md
@@ -91,7 +91,7 @@ Prioritize issues by severity.
 ```markdown
 ---
 description: Run tests for specific file
-argument-hint: [test-file]
+argument-hint: "[test-file]"
 allowed-tools: Bash(npm:*), Bash(jest:*)
 ---
 
@@ -122,7 +122,7 @@ If failures found, suggest fixes based on error messages.
 ```markdown
 ---
 description: Generate documentation for file
-argument-hint: [source-file]
+argument-hint: "[source-file]"
 ---
 
 Generate comprehensive documentation for @$1
@@ -200,7 +200,7 @@ Provide:
 ```markdown
 ---
 description: Deploy to specified environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 allowed-tools: Bash(kubectl:*), Read
 ---
 
@@ -238,7 +238,7 @@ Proceed with deployment? (yes/no)
 ```markdown
 ---
 description: Compare two files
-argument-hint: [file1] [file2]
+argument-hint: "[file1] [file2]"
 ---
 
 Compare @$1 with @$2
@@ -283,7 +283,7 @@ Present as structured comparison report.
 ```markdown
 ---
 description: Quick fix for common issues
-argument-hint: [issue-description]
+argument-hint: "[issue-description]"
 model: haiku
 ---
 
@@ -319,7 +319,7 @@ Provide code changes with file paths and line numbers.
 ```markdown
 ---
 description: Research best practices for topic
-argument-hint: [topic]
+argument-hint: "[topic]"
 model: sonnet
 ---
 
@@ -364,7 +364,7 @@ Provide actionable guidance based on research.
 ```markdown
 ---
 description: Explain how code works
-argument-hint: [file-or-function]
+argument-hint: "[file-or-function]"
 ---
 
 Explain @$1 in detail
@@ -438,7 +438,7 @@ Analyze and suggest...
 
 ```markdown
 ---
-argument-hint: [target]
+argument-hint: "[target]"
 ---
 
 Process $1...
@@ -450,7 +450,7 @@ Process $1...
 
 ```markdown
 ---
-argument-hint: [source] [target] [options]
+argument-hint: "[source] [target] [options]"
 ---
 
 Process $1 to $2 with $3...

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-forgecat/skills/command-development/references/advanced-workflows.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-forgecat/skills/command-development/references/advanced-workflows.md
@@ -15,7 +15,7 @@ Commands that guide users through multi-step processes:
 ```markdown
 ---
 description: Complete PR review workflow
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 allowed-tools: Bash(gh:*), Read, Grep
 ---
 
@@ -132,7 +132,7 @@ Commands that adapt based on conditions:
 ```markdown
 ---
 description: Smart deployment workflow
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(git:*), Bash(npm:*), Read
 ---
 
@@ -454,7 +454,7 @@ Ready for next deployment.
 ```markdown
 ---
 description: Deploy with optional version
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Environment: ${1:-staging}
@@ -472,7 +472,7 @@ Note: Using defaults for missing arguments:
 ```markdown
 ---
 description: Deploy to validated environment
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Environment: $1
@@ -494,7 +494,7 @@ Environment validated. Proceeding...
 ```markdown
 ---
 description: Deploy with shorthand
-argument-hint: [env-shorthand]
+argument-hint: "[env-shorthand]"
 ---
 
 Input: $1
@@ -641,7 +641,7 @@ If any step fails, resume with:
 ```markdown
 ---
 description: Initialize deployment
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Write, Bash(git:*)
 ---
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-forgecat/skills/command-development/references/documentation-patterns.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-forgecat/skills/command-development/references/documentation-patterns.md
@@ -13,7 +13,7 @@ Well-documented commands are easier to use, maintain, and distribute. Documentat
 ```markdown
 ---
 description: Clear, actionable description under 60 chars
-argument-hint: [arg1] [arg2] [optional-arg]
+argument-hint: "[arg1] [arg2] [optional-arg]"
 allowed-tools: Read, Bash(git:*)
 model: sonnet
 ---
@@ -233,7 +233,7 @@ Create a help subcommand for complex commands:
 ```markdown
 ---
 description: Main command with help
-argument-hint: [subcommand] [args]
+argument-hint: "[subcommand] [args]"
 ---
 
 # Command Processor
@@ -273,7 +273,7 @@ Provide help based on context:
 ```markdown
 ---
 description: Context-aware command
-argument-hint: [operation] [target]
+argument-hint: "[operation] [target]"
 ---
 
 # Context-Aware Operation

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-forgecat/skills/command-development/references/frontmatter-reference.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-forgecat/skills/command-development/references/frontmatter-reference.md
@@ -11,7 +11,7 @@ YAML frontmatter is optional metadata at the start of command files:
 description: Brief description
 allowed-tools: Read, Write
 model: sonnet
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 ---
 
 Command prompt content here...
@@ -203,29 +203,29 @@ model: opus
 
 **Format:**
 ```yaml
-argument-hint: [arg1] [arg2] [optional-arg]
+argument-hint: "[arg1] [arg2] [optional-arg]"
 ```
 
 **Examples:**
 
 **Single argument:**
 ```yaml
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ```
 
 **Multiple required arguments:**
 ```yaml
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ```
 
 **Optional arguments:**
 ```yaml
-argument-hint: [file-path] [options]
+argument-hint: "[file-path] [options]"
 ```
 
 **Descriptive names:**
 ```yaml
-argument-hint: [source-branch] [target-branch] [commit-message]
+argument-hint: "[source-branch] [target-branch] [commit-message]"
 ```
 
 **Best practices:**
@@ -241,7 +241,7 @@ argument-hint: [source-branch] [target-branch] [commit-message]
 ```yaml
 ---
 description: Fix issue by number
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Fix issue #$1...
@@ -251,7 +251,7 @@ Fix issue #$1...
 ```yaml
 ---
 description: Deploy to environment
-argument-hint: [app-name] [environment] [version]
+argument-hint: "[app-name] [environment] [version]"
 ---
 
 Deploy $1 to $2 using version $3...
@@ -261,7 +261,7 @@ Deploy $1 to $2 using version $3...
 ```yaml
 ---
 description: Run tests with options
-argument-hint: [test-pattern] [options]
+argument-hint: "[test-pattern] [options]"
 ---
 
 Run tests matching $1 with options: $2
@@ -368,7 +368,7 @@ All common fields:
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [app-name] [environment] [version]
+argument-hint: "[app-name] [environment] [version]"
 allowed-tools: Bash(kubectl:*), Bash(helm:*), Read
 model: sonnet
 ---
@@ -390,7 +390,7 @@ Restricted invocation:
 ```markdown
 ---
 description: Approve production deployment
-argument-hint: [deployment-id]
+argument-hint: "[deployment-id]"
 disable-model-invocation: true
 allowed-tools: Bash(gh:*)
 ---

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-forgecat/skills/command-development/references/interactive-commands.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-forgecat/skills/command-development/references/interactive-commands.md
@@ -875,7 +875,7 @@ Options:
 **Arguments for known values:**
 ```markdown
 ---
-argument-hint: [project-name]
+argument-hint: "[project-name]"
 allowed-tools: AskUserQuestion, Write
 ---
 

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-forgecat/skills/command-development/references/plugin-features-reference.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-forgecat/skills/command-development/references/plugin-features-reference.md
@@ -249,7 +249,7 @@ Commands that use plugin templates:
 ```markdown
 ---
 description: Generate documentation from template
-argument-hint: [component-name]
+argument-hint: "[component-name]"
 ---
 
 Template: @${CLAUDE_PLUGIN_ROOT}/templates/component-docs.md
@@ -294,7 +294,7 @@ Commands that adapt to environment:
 ```markdown
 ---
 description: Deploy based on environment
-argument-hint: [dev|staging|prod]
+argument-hint: "[dev|staging|prod]"
 ---
 
 Environment config: @${CLAUDE_PLUGIN_ROOT}/config/$1.json
@@ -336,7 +336,7 @@ Commands can trigger plugin agents using the Task tool:
 ```markdown
 ---
 description: Deep analysis using plugin agent
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Initiate deep code analysis of @$1 using the code-analyzer agent.
@@ -362,7 +362,7 @@ Commands can reference plugin skills for specialized knowledge:
 ```markdown
 ---
 description: API documentation with best practices
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Document the API in @$1 following our API documentation standards.
@@ -412,7 +412,7 @@ Commands that coordinate multiple plugin components:
 ```markdown
 ---
 description: Comprehensive code review workflow
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 File to review: @$1
@@ -445,7 +445,7 @@ Commands should validate inputs before processing:
 ```markdown
 ---
 description: Deploy to environment with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Validate environment: !`echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
@@ -468,7 +468,7 @@ Verify required files exist:
 ```markdown
 ---
 description: Process configuration file
-argument-hint: [config-file]
+argument-hint: "[config-file]"
 ---
 
 Check file: !`test -f $1 && echo "EXISTS" || echo "MISSING"`
@@ -488,7 +488,7 @@ Validate required arguments provided:
 ```markdown
 ---
 description: Create deployment with version
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Validate inputs: !`test -n "$1" -a -n "$2" && echo "OK" || echo "MISSING"`
@@ -545,7 +545,7 @@ Handle errors gracefully with helpful messages:
 ```markdown
 ---
 description: Process file with error handling
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Try processing: !`node ${CLAUDE_PLUGIN_ROOT}/scripts/process.js $1 2>&1 || echo "ERROR: $?"`


### PR DESCRIPTION
Closes #152.

## Summary

Quotes `argument-hint` values that were written with bare brackets so YAML parses them as strings instead of flow-sequence arrays.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax, so strict loaders receive a list instead of a string and may reject the skill or command. The quoted form preserves the documented string shape used by Claude Code slash commands and VS Code Agent Skills.

## Scope

This PR now applies only to the remaining `anthropics/claude-plugins-official` profiles:

- `profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_agent-sdk-dev`
- `profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev`

The previously listed `egonex-ai/understand-anything` paths are no longer part of the repository and are not included in the current diff.

## Files

37 files changed:

- 1 loadable command frontmatter file in `anthropics_claude-plugins-official_agent-sdk-dev`
- 36 vendored command-development skill/docs/example files across `for-forgecat`, `for-claude`, `for-codex`, and `for-cursor` in `anthropics_claude-plugins-official_plugin-dev`

## Verification

- `git diff --check origin/main...HEAD`
- YAML parse check on changed top-level frontmatter: changed `argument-hint` values parse as `String`
- YAML parse check on changed fenced frontmatter snippets: 252 parseable snippets with `argument-hint` parse as `String`
- Bare-bracket scan: no changed file retains `argument-hint: [...]`
- `ruby scripts/check-profile-artifacts.rb --changed-only origin/main...HEAD`
- `ruby scripts/check-readme-catalog.rb`
- `forgecat validate --cwd profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_agent-sdk-dev/for-forgecat --json`
- `forgecat validate --cwd profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_plugin-dev/for-forgecat --json`

## Notes

The branch has been updated with current `main` so the README catalog state is current.
