### PR TITLE
docs: refresh Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/nota-america/forgecat-agent-profiles)](https://github.com/nota-america/forgecat-agent-profiles/pulls)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-yellow.svg)](./LICENSE)
 [![npm version](https://img.shields.io/npm/v/forgecat.svg)](https://www.npmjs.com/package/forgecat)
-[![Discord](https://img.shields.io/badge/Discord-Join%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/re3w8WGnb)
+[![Discord](https://img.shields.io/badge/Discord-Join%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/8XYVQdg4wb)
 [![Reddit](https://img.shields.io/badge/Reddit-r%2FForgeCat-FF4500?logo=reddit&logoColor=white)](https://www.reddit.com/r/ForgeCat/)
 
 </div>


### PR DESCRIPTION
Replaces the README Discord badge target with the current community invite after the previous update was merged.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 via [Codex](https://openai.com/codex/)