### PR TITLE
Profile: ip-as-logo-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 
 <div align="center">
 
-[![Profiles](https://img.shields.io/badge/profiles-187-blue)](#browse-profiles)
-[![Collections](https://img.shields.io/badge/collections-38-blue)](#browse-profiles)
+[![Profiles](https://img.shields.io/badge/profiles-188-blue)](#browse-profiles)
+[![Collections](https://img.shields.io/badge/collections-39-blue)](#browse-profiles)
 [![Platforms](https://img.shields.io/badge/platforms-Claude%20Code%20%7C%20Cursor%20%7C%20Codex%20%7C%20OpenClaw%20%7C%20Hermes-green)](#supported-platforms)
 [![GitHub issues](https://img.shields.io/github/issues/nota-america/forgecat-agent-profiles)](https://github.com/nota-america/forgecat-agent-profiles/issues)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/nota-america/forgecat-agent-profiles)](https://github.com/nota-america/forgecat-agent-profiles/pulls)
@@ -142,6 +142,7 @@ profiles/<source-owner>/<source-repository-or-collection>/
 | [orchestra-research/ai-research-skills](./profiles/orchestra-research/ai-research-skills) | 1 | AI research skills for training, evaluation, inference, MLOps, RAG, multimodal systems, and papers |
 | [paramchoudhary/resumeskills](./profiles/paramchoudhary/resumeskills) | 1 | Resume and career-development skills for ATS optimization, resume writing, interview prep, and offer decisions |
 | [remotion-dev/skills](./profiles/remotion-dev/skills) | 1 | Remotion best-practices skill for video creation in React |
+| [s1dashu/ip-as-logo-skill](./profiles/s1dashu/ip-as-logo-skill) | 1 | Agent Skill for generating simple, rounded IP mascot images with constrained colors and lower-corner compositions |
 | [upstash/context7](./profiles/upstash/context7) | 1 | Context7 MCP integration for up-to-date documentation lookup |
 | [vercel-labs/agent-skills](./profiles/vercel-labs/agent-skills) | 7 | Vercel agent skills for deployment, React, UI audits, and workflow patterns |
 | [voltagent/awesome-codex-subagents](./profiles/voltagent/awesome-codex-subagents) | 10 | Codex subagents for development, infrastructure, security, and research |
@@ -149,7 +150,7 @@ profiles/<source-owner>/<source-repository-or-collection>/
 | [yeachan-heo/oh-my-claudecode_agents](./profiles/yeachan-heo/oh-my-claudecode_agents) | 1 | Agents-only Claude Code orchestration profile from oh-my-claudecode |
 | [zubair-trabzada/geo-seo-claude](./profiles/zubair-trabzada/geo-seo-claude) | 1 | GEO-first SEO skills and agents for AI-search visibility audits, reports, schema, crawlers, and client workflows |
 
-Total: 187 profiles across 38 collections.
+Total: 188 profiles across 39 collections.
 
 ## Profile Layout
 

--- a/profiles/s1dashu/ip-as-logo-skill/README.md
+++ b/profiles/s1dashu/ip-as-logo-skill/README.md
@@ -1,0 +1,51 @@
+*written by ForgeCat*
+
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+
+# IP as Logo
+
+Generate extremely simple, cute IP mascot images with rounded silhouettes, a constrained three-color palette, and lower-corner compositions.
+
+## Tags
+
+- agent-skill
+- image-generation
+- logo-design
+- mascot
+
+## Installation
+
+```bash
+npx forgecat install @forgecat/s1dashu_ip-as-logo-skill
+```
+
+## Skills
+
+- **ip-as-logo:** Generate extremely simple, cute, personified square character images with rounded heavy forms, two purposeful character colors, one solid background color, and a dominant lower-corner composition. Use when creating an animal, creature, robot, ghost, plant, object, or other character image, including when the agent should infer three product-relevant directions and propose six independent candidates for approval.
+
+## Details
+
+| Field | Value |
+|---|---|
+| Author | s1dashu |
+| Original repository | https://github.com/s1dashu/ip-as-logo-skill |
+| Version | `pending-registry-publish` |
+| Original commit | b1bf517c54a407452cfaca98a54668cd052f8e63 |
+| License | MIT |
+| Source platform | agent-skills |
+
+## Compatibility
+
+### Platforms
+
+| Platform | Status |
+|---|---|
+| Claude Code | Partial |
+| Cursor | Partial |
+| Codex | Partial |
+| OpenClaw | Partial |
+| Hermes | Partial |
+
+## Dependencies
+
+- A configured image-generation capability that can return generated images as assets

--- a/profiles/s1dashu/ip-as-logo-skill/for-forgecat/LICENSE
+++ b/profiles/s1dashu/ip-as-logo-skill/for-forgecat/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 s1dashu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/profiles/s1dashu/ip-as-logo-skill/for-forgecat/README.md
+++ b/profiles/s1dashu/ip-as-logo-skill/for-forgecat/README.md
@@ -1,0 +1,146 @@
+*written by ForgeCat*
+
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+
+# IP as Logo
+
+Generate extremely simple, cute IP mascot images with rounded silhouettes, a constrained three-color palette, and lower-corner compositions.
+
+## Tags
+
+- agent-skill
+- image-generation
+- logo-design
+- mascot
+
+## Installation
+
+```bash
+npx forgecat install @forgecat/s1dashu_ip-as-logo-skill
+```
+
+## Skills
+
+- **ip-as-logo:** Generate extremely simple, cute, personified square character images with rounded heavy forms, two purposeful character colors, one solid background color, and a dominant lower-corner composition. Use when creating an animal, creature, robot, ghost, plant, object, or other character image, including when the agent should infer three product-relevant directions and propose six independent candidates for approval.
+
+## Details
+
+| Field | Value |
+|---|---|
+| Author | s1dashu |
+| Original repository | https://github.com/s1dashu/ip-as-logo-skill |
+| Version | `pending-registry-publish` |
+| Original commit | b1bf517c54a407452cfaca98a54668cd052f8e63 |
+| License | MIT |
+| Source platform | agent-skills |
+
+## Compatibility
+
+### Platforms
+
+| Platform | Status |
+|---|---|
+| Claude Code | Partial |
+| Cursor | Partial |
+| Codex | Partial |
+| OpenClaw | Partial |
+| Hermes | Partial |
+
+## Dependencies
+
+- A configured image-generation capability that can return generated images as assets
+
+---
+*written by original source*
+
+# IP as Logo
+
+`ip-as-logo` is a compact Agent Skill for generating extremely simple, cute, company-ready IP mascots. It prioritizes lovable character appeal, bold rounded silhouettes, strict complexity limits, a dominant lower-corner composition, and a solid named background color.
+
+It follows the open Agent Skills format and is designed to work with any compatible AI agent, rather than being tied to a specific agent product.
+
+You can also browse the free [IP as Logo Skill website](https://ipaslogo.com), a searchable library backed by Cloudflare R2 and Supabase.
+
+![IP as Logo showcase](https://raw.githubusercontent.com/s1dashu/ip-as-logo-skill/b1bf517c54a407452cfaca98a54668cd052f8e63/assets/ip-as-logo-wall.webp)
+
+**Don't have Codex, Doubao, Coze, or Workbuddy?** [Visit our website](https://ipaslogo.com) to download ready-made logos for free. Every logo is free for commercial use.
+
+## What it guides
+
+- One dominant silhouette built from roughly 4–7 large basic shapes
+- Three semantic colors by default: two IP base colors plus one background color
+- Three proposed directions followed by six independently generated candidates after user approval
+- Familiar, broadly appealing animals as the default open-ended subject; objects, machines, fantasy artifacts, and obscure creatures require a clear product reason
+- Context-aware, clearly separated subject colors and gently muted, slightly lower-saturation backgrounds with barely-there neo-skeuomorphic depth, described without percentages or prescribed gradient and shading formulas
+- Thick, rounded forms without sharp or fragile details
+- A large, visually dominant IP emerging flexibly from the lower-left or lower-right, without prescribing a fixed crop
+- A balanced default six-image split: three lower-left and three lower-right
+- Extreme simplification, cute baby-like appeal, and removal of nonessential lines and details
+- One named solid background color filling the square, without image-mode language in the generation prompt
+- Image-only generation prompts that never reveal logo, brand-mark, app-icon, or icon-asset use
+- One-pass batch generation that preserves and delivers every returned image without filtering or automatic retries
+
+## Install
+
+Install the complete skill with the Agent Skills CLI:
+
+```bash
+npx skills@latest add s1dashu/ip-as-logo-skill
+```
+
+The installer detects the repository's root `SKILL.md`, lets you choose a supported coding agent, and installs the complete `ip-as-logo` directory, including its supporting assets. Use `--global` for a personal installation available across projects:
+
+```bash
+npx skills@latest add s1dashu/ip-as-logo-skill --global
+```
+
+## Agent compatibility
+
+Supported agents include **Codex, Coze, Doubao, YouMind, Manus, Gemini Apps, and Replit Agent**. This skill only supports agents with built-in image-generation capabilities that can return generated images as assets.
+
+## Use
+
+Ask your AI agent for an IP mascot image, for example:
+
+```text
+Create a very simple, cute rounded ghost IP character on a solid deep navy background.
+```
+
+The skill does not ask for a color-mode choice by default. Every default candidate uses three semantic colors: two IP base colors plus one background color. It no longer reserves any fraction of the candidate set for two-color images. A two-color image is generated only when the user explicitly requests it, and then uses background-colored negative space for facial marks rather than introducing a third color.
+
+When the user already names an IP subject, the skill proposes three controlled design treatments of that subject. When the subject is open, it proposes familiar animal mascots first and ties each to a product attribute or brand promise. In open-ended batches, 95–100% of candidates should be familiar animals; non-animal subjects are limited to a small minority with a direct product connection, never used merely to manufacture novelty.
+
+Large batches create variety within commercially plausible animal mascots through species or breed, ear and muzzle proportions, expression, lower-left versus lower-right emergence, crop, silhouette, and secondary color organization. Clocks, locks, industrial tools, measuring instruments, vehicles, abstract machines, fantasy artifacts, and obscure creatures are not default company mascots.
+
+If the skill runs inside a product repository, it inspects relevant read-only context before asking questions. If product context is insufficient, it asks one consolidated round of background questions. Once context is sufficient, it always presents three concise directions and proposes generating six independent images. It proceeds after the user agrees, or immediately when the user has already explicitly authorized six outputs.
+
+When the user accepts all three directions, the default batch contains two variants per direction: `A1`, `A2`, `B1`, `B2`, `C1`, and `C2`. The first variant of each direction emerges from the lower-left and the second from the lower-right. When the user selects one direction, odd-numbered variants use the lower-left and even-numbered variants use the lower-right. This guarantees a three-left, three-right default split. If the user rejects the proposed quantity or distribution, their replacement instructions take precedence.
+
+Every default candidate emerges from the lower-left or lower-right rather than the center or bottom-center and fills roughly 85–95% of the square so the IP remains visually dominant. Bottom or side cropping may strengthen the corner emergence, but the Skill does not prescribe exact edge contact or a fixed crop.
+
+Compatible agents may generate the six candidates in parallel with subagents up to the runtime's available concurrency, using additional waves when needed. Codex can use ImageGen when available; other agent environments may use any configured image generator. If no generator is available, the skill asks the user to provide or enable one instead of pretending that an image was generated. Every result is a separate full-resolution square asset, never a six-image contact sheet.
+
+When the user does not supply a palette, the skill gently lowers background saturation so the result feels a little more muted and controlled while remaining clearly chromatic, clean, and intentional rather than vivid, gray, or muddy. It keeps the normal design to exactly three semantic colors: two IP base colors plus the background. The generation prompt names the intended solid background color directly and avoids terms such as `opaque`, `alpha`, or `transparency` that may distract the image model from the desired visual result.
+
+Although the project is named `ip-as-logo`, the prompt sent to the image generator describes only the requested square character image. It never calls the result a logo, brand mark, app icon, or icon asset, and it does not prepend use-case metadata that reveals those purposes.
+
+Generation is intentionally treated as a creative draw. Each requested candidate is generated once and delivered as returned. The skill does not inspect transparency, block outputs, classify candidates as compliant or non-compliant, or automatically retry results because of their background, colors, composition, gradients, shading, or dimensionality. Users can explicitly request another draw or a refinement after reviewing the batch.
+
+## Repository structure
+
+```text
+SKILL.md
+assets/ip-as-logo-wall.webp
+README.md
+LICENSE
+```
+
+The skill itself intentionally consists of a single instruction document. The repository also includes the showcase image above, but no scripts, style references, or generation dependencies.
+
+## Model behavior
+
+Image-generation models are stochastic and may interpret individual constraints differently. The skill preserves and returns every result without validation gates, transparency checks, automatic rejection, automatic retry, or silent repair.
+
+## License
+
+MIT

--- a/profiles/s1dashu/ip-as-logo-skill/for-forgecat/profile.yml
+++ b/profiles/s1dashu/ip-as-logo-skill/for-forgecat/profile.yml
@@ -1,0 +1,26 @@
+name: '@forgecat/s1dashu_ip-as-logo-skill'
+description: Generate extremely simple, cute IP mascot images with rounded silhouettes, a constrained three-color palette, and lower-corner compositions.
+visibility: public
+repository: https://github.com/s1dashu/ip-as-logo-skill
+license: MIT
+sourcePlatform: agent-skills
+compatibility:
+  platforms:
+    tested: []
+    partial:
+    - claude-code
+    - cursor
+    - codex
+    - openclaw
+    - hermes
+  models:
+    recommended: []
+    minimum: []
+skills:
+- name: ip-as-logo
+  path: skills/ip-as-logo/SKILL.md
+  description: Generate extremely simple, cute, personified square character images with rounded heavy
+    forms, two purposeful character colors, one solid background color, and a dominant lower-corner composition.
+    Use when creating an animal, creature, robot, ghost, plant, object, or other character image, including
+    when the agent should infer three product-relevant directions and propose six independent candidates
+    for approval.

--- a/profiles/s1dashu/ip-as-logo-skill/for-forgecat/skills/ip-as-logo/SKILL.md
+++ b/profiles/s1dashu/ip-as-logo-skill/for-forgecat/skills/ip-as-logo/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: ip-as-logo
+description: Generate extremely simple, cute, personified square character images with rounded heavy forms, two purposeful character colors, one solid background color, and a dominant lower-corner composition. Use when creating an animal, creature, robot, ghost, plant, object, or other character image, including when the agent should infer three product-relevant directions and propose six independent candidates for approval.
+---
+
+# IP as Logo
+
+Create the simplest possible cute IP character: a compact, lovable symbol that remains recognizable at `32 × 32`, not a detailed character illustration.
+
+## Workflow
+
+1. Parse the request for an explicit IP subject and available product context. Do not ask the user to choose a color mode unless they explicitly want to control it.
+2. When the user has not specified an IP subject and the current workspace is a product repository, inspect relevant read-only context before asking questions. Prefer the README, product docs, package or app metadata, landing-page copy, manifests, and design tokens. Treat context as sufficient when the product purpose, primary audience, and intended personality can be inferred with reasonable confidence.
+3. When product context is insufficient, ask one consolidated round of background questions covering what the product does, who it serves, and how it should feel. Do not start a second background questionnaire. Continue with the best supported interpretation after the answer.
+4. Once context is sufficient, always present three concise directions before generation and explicitly propose generating six independent candidates in one batch. Do not generate until the user agrees, unless the current request already explicitly authorizes six outputs or asks the agent to proceed without another confirmation.
+5. Choose the three proposed directions deliberately:
+   - When the user explicitly specifies an IP subject, keep that subject and propose three distinct design treatments based on silhouette treatment, secondary color region, defining feature, or personality emphasis.
+   - When the user does not specify an IP subject, propose three genuinely different IP subjects or metaphors. Tie each one to a different product attribute or brand promise; do not return three arbitrary animals with no rationale.
+6. Interpret the user's response exactly:
+   - If the user accepts all three directions and the six-image proposal, generate two independent variants per direction and label them `A1`, `A2`, `B1`, `B2`, `C1`, and `C2`. Assign `A1`, `B1`, and `C1` to the lower-left and `A2`, `B2`, and `C2` to the lower-right so every direction is tested once from each side.
+   - If the user selects one direction but accepts six images, generate six controlled variants of that direction and label them `A1` through `A6`. Assign odd-numbered variants to the lower-left and even-numbered variants to the lower-right.
+   - If the user rejects the proposed quantity, directions, or distribution, follow the user's replacement instructions without arguing for the default.
+   - For any other even default batch size, split candidates equally between lower-left and lower-right. For an odd batch, assign the extra candidate to either side deliberately and record the imbalance. Do not use bottom-center unless the user explicitly requests it.
+7. Default every candidate to exactly three semantic colors in the complete image: exactly two IP base colors plus exactly one background color. Reuse the two IP colors for facial marks rather than introducing additional semantic colors. Follow an explicit user request for another color count. Keep required product cues, identifying features, complexity limits, and any supplied palette consistent enough for useful comparison.
+8. Determine the available image-generation path before promising output. In Codex, use ImageGen when it is available. In any other agent environment, use an available configured image generator; if none is available, ask the user whether they can provide or enable one. Do not fabricate generated results.
+9. If the runtime supports subagents, parallelize the six independent candidates up to the available concurrency. Give every subagent the same product brief, shared constraints, and one assigned direction or variant; run remaining candidates in subsequent waves when capacity is limited. If subagents are unavailable, generate the candidates through separate image-generation calls or jobs.
+10. If the user supplies a background palette, reserve every supplied color for backgrounds unless they explicitly say otherwise. Choose exactly two IP base colors independently for the subject and context unless the user also assigns subject colors. Do not treat any historical or example palette as a closed list of allowed backgrounds.
+11. Abstract each subject using the complexity budget below. Generate every candidate as a separate full-resolution square asset; never ask an image model to compose a contact sheet, grid, or multi-image sheet. Do not use previous candidates as image references when testing prompt-only reproducibility.
+12. Treat each batch as a one-pass creative draw. Generate every requested candidate once, then preserve and deliver every returned result as-is. Do not inspect outputs to block delivery, classify them as recommended or non-recommended, retry them automatically, or repair them with post-processing.
+13. Preserve and label every generated result. Report every label, IP direction and rationale, assigned corner, saved path, prompt/color mapping, and dimensions. Present all results together; generate refinements or replacements only when the user explicitly asks for another draw.
+
+When proposing directions before generation, describe each in one compact line: `<IP subject> — <product connection> — <defining silhouette>`. End with a direct proposal to generate six images using the distribution above. Do not turn the discovery phase into a long branding workshop unless the user asks for one.
+
+## Complexity budget
+
+- Build one dominant continuous outer silhouette from roughly `4–7` large basic geometric shapes. Merge or delete any shape that does not carry identity, expression, or recognition.
+- Use at most one species-defining feature: for example, one large pouch beak, one pair of curled horns, or one broad visor.
+- Use at most two broad internal color regions corresponding to the two IP base colors. Keep the face to two eyes and, only when needed for the expression, one tiny mouth. Omit eyebrows, highlights, nostrils, texture, outlines, and decorative marks unless essential for recognition.
+- Remove repeated feathers, scales, fur tufts, armor plates, buttons, screws, numbers, labels, and other illustrative detail.
+- Make simplification, cuteness, and an endearing baby-like personality the decisive qualities. Favor a large head, compact proportions, soft cheeks, widely spaced simple eyes, and a calm friendly expression when appropriate to the subject.
+- Require a readable black silhouette and recognizability at `32 × 32`. If a feature disappears or becomes noise at that size, enlarge, merge, or remove it.
+
+## Shape language and composition
+
+- Use thick, rounded, weighty contours and broad color masses.
+- Forbid sharp corners, pointed ears or beaks, needle-like tails, thin antennae, thin smiles, narrow gaps, and acute flame or feather tips. Replace every necessary tip with a visibly blunt rounded end.
+- Show both members of paired identifying features, such as ears, horns, wings, gills, or bells.
+- Show the character upright and emerging from the assigned lower-left or lower-right corner, filling about `85–95%` of the canvas so the IP remains visually dominant.
+- Cropping at the bottom or assigned side is welcome when it strengthens the sense of emerging from that corner, but do not prescribe exact edge contact or a fixed crop.
+- Never center or bottom-center the character unless the user explicitly requests it.
+- Preserve both members of paired identifying features within the visible composition.
+- Keep the artwork upright; never rotate the canvas or tilt the main mark without an explicit request.
+
+## Simplicity and visual treatment
+
+- Start from large, clean semantic shapes and the strongest possible simple silhouette. The character should be understood immediately, before any internal feature is noticed.
+- Prefer fewer, larger, softer forms over extra definition. Do not add a feature merely to explain anatomy or material.
+- Keep facial marks tiny, simple, and subordinate. Do not add glossy hotspots or detailed cavity rendering to eyes, mouths, noses, or other small features.
+- Keep the named background color visually solid and uniform, without scenery, texture, halo, vignette, or lighting variation.
+- Ask for the subtle dimensional effect only with the single sentence used in the Prompt skeleton. Do not expand it into numerical strength or instructions for gradients, highlights, or shadows. Incidental gradients, shading, or mild dimensionality returned by the generator are acceptable and must not trigger filtering or retrying.
+- Keep the requested visual direction graphic and simple rather than asking for clay, inflatable, plastic, plush, toy-like, or photorealistic rendering.
+
+## Color and canvas
+
+- Default to exactly three semantic colors in the complete image: exactly two IP base colors plus exactly one background color.
+- Choose the two IP colors from the product context, subject identity, intended personality, and user request. Organize both into broad purposeful masses; reuse one for facial marks and keep the other in one continuous defining region rather than scattering decorative fragments.
+- Choose both subject colors independently from the background. Favor clear, lively subject colors when appropriate, but do not impose global saturation, OKLCH, hue-shift, or chroma bands on the IP.
+- Choose the background freely for the context or from a user-supplied palette. Unless the user asks for vivid color, gently mute the background by lowering its saturation a little; keep it clearly chromatic and intentional rather than vivid, gray, or muddy. Historical palettes and examples are suggestions only, never an allowlist or mandatory default palette.
+- Preserve clear visual separation between the dominant IP silhouette, its facial marks, and the background. If a user-supplied background causes weak separation, adjust the subject colors first rather than replacing the requested background.
+- Across a batch, vary the two-IP-color strategies deliberately instead of repeating the same neutral-heavy combination.
+- Treat the two character colors as semantic color families. Incidental tonal variation within either family does not invalidate an output.
+- Name the intended solid background color directly. Ask for it to fill every open area and the unoccupied corners while the assigned emergence corner is occupied by the character. Do not use image-mode terms such as `opaque`, `alpha`, or `transparency` in the generation prompt.
+- Generate a direct `1:1` square with square outer corners. Request approximately `1536 × 1536`; accept and preserve a native `1254 × 1254` result when that is the service output limit. Never resample merely to reach the requested number.
+
+## Prompt skeleton
+
+### Route constraints by generator capability
+
+Determine the available image model and its actual tool schema from runtime metadata, configured provider documentation, or an explicit user statement. Do not guess a model or invent unsupported parameters.
+
+Describe the requested visual as an image only. Never tell the image generator that the image is a `logo`, `brand mark`, `app icon`, `icon asset`, or intended for any of those uses. Do not prepend use-case or asset-type scaffolding that reveals such a use. This rule applies only to the generation prompt; the surrounding user conversation and Skill name may still describe the broader project.
+
+- For modern instruction-following image models such as GPT Image 2, Nano Banana Pro, and Seedream 5.0 Pro, keep the complete positive prompt and express the minimal exclusions as the natural-language `Constraints:` line inside the main prompt. Do not create a separate negative-prompt payload for these models.
+- For an older model or runtime that explicitly exposes a dedicated parameter such as `negative_prompt`, keep every positive prompt line unchanged and deliver the minimal exclusions through that dedicated parameter in the syntax required by the available adapter. Omit the natural-language `Constraints:` line from the main prompt to avoid duplicating the same exclusions in both channels.
+- For an older model without a dedicated negative-prompt parameter, follow its documented prompt format. When only one prompt string is available, retain the concise natural-language `Constraints:` line.
+- Record the model or provider, the detected constraint-delivery mode (`main-prompt constraints` or `dedicated negative parameter`), and the exact constraint text or payload in the generation report.
+
+When a dedicated legacy negative-prompt parameter is available, adapt this minimal payload to its required syntax:
+
+```text
+text, watermark, borders, frames, cards, presentation masks, extra subjects, scenery, thin fragile lines, sharp tips, photorealistic materials, strong three-dimensional rendering, external cast shadows
+```
+
+For modern instruction-following models and single-prompt interfaces, use the following complete prompt:
+
+```text
+Create one complete full-bleed 1:1 square image.
+Background: fill the entire square with solid <background>. Keep <background> visible in every open area and in the corners not occupied by the character; the assigned emergence corner must be occupied by the character.
+Subject: place one extremely simplified, cute, endearing <subject> IP character on the background, reduced to one soft rounded continuous silhouette and one defining feature.
+Complexity: use only 4–7 large basic shapes and at most two broad internal color regions. Use two simple eyes and add one tiny mouth only when it helps the expression. Remove every nonessential line, outline, anatomical detail, texture, and decoration. Keep the character readable at 32 × 32.
+Color behavior: use exactly three semantic colors in the complete image: exactly two IP base colors plus the background color. Choose the two IP colors from the subject and context, organize both into broad purposeful masses, and reuse them for facial marks. Choose the background independently or follow the user's supplied background. Unless the user asks for vivid color, lower the background saturation slightly so it feels gently muted and restrained while remaining clearly chromatic, clean, and intentional rather than gray or muddy. Keep the IP, facial marks, and background clearly separated. Treat any example palette as optional inspiration, never as an allowlist.
+Composition: keep the character upright and emerging from the assigned <lower-left or lower-right>, filling about 85–95% of the square so it remains visually dominant. Cropping at the bottom or assigned side is welcome when it strengthens the corner emergence. Preserve both paired identifying features. Never center or bottom-center the character.
+Style: make simplification, cuteness, and lovable baby-like appeal the strongest qualities. Use large soft forms, compact proportions, thick rounded contours, and an ultra-clean graphic treatment. Prefer one clear shape over several explanatory details. Add an extremely, extremely subtle, almost imperceptible sense of depth through a barely-there neo-skeuomorphic treatment.
+Finish: show only the character on the full-canvas background, with clean surfaces and normal square outer corners.
+Constraints: Use no text or watermark. Add no borders, frames, cards, or presentation masks. Include one character only, with no extra subjects or scenery. Use no fragile lines, sharp tips, unnecessary outlines, tiny details, or decorative marks. Add no photorealistic material, dramatic bevel, glossy hotspot, deep occlusion, extrusion, strong three-dimensional rendering, or external cast shadow. Keep the background solid and uniform, with no texture, vignette, or lighting variation.
+```
+
+## Delivery behavior
+
+- Treat generation as a stochastic draw, not a conformance test.
+- Generate the requested number of independent candidates once and deliver every returned image.
+- Do not inspect or report alpha, transparency, or background mode by default.
+- Do not block delivery, rank candidates as compliant or non-compliant, mark them as recommended or non-recommended, or automatically retry any result because of its background, colors, detail, composition, gradient, shading, or dimensionality.
+- Do not post-process a result to make it appear more compliant. If the user later requests another direction or replacement, generate a new independent candidate in response to that explicit request.

--- a/scripts/check-profile-artifacts.rb
+++ b/scripts/check-profile-artifacts.rb
@@ -8,11 +8,12 @@ require "English"
 ROOT = File.expand_path("..", __dir__)
 PROFILE_GLOB = File.join(ROOT, "profiles/**/for-forgecat/profile.yml")
 
-PLATFORM_ARTIFACTS = {
+KNOWN_PLATFORMS = Set.new(%w[claude-code cursor codex openclaw hermes]).freeze
+
+PROJECT_PLATFORM_ARTIFACTS = {
   "claude-code" => "for-claude",
   "cursor" => "for-cursor",
-  "codex" => "for-codex",
-  "openclaw" => "for-openclaw"
+  "codex" => "for-codex"
 }.freeze
 
 def fail_with(errors)
@@ -82,7 +83,7 @@ manifest_paths.each do |manifest_path|
   partial = Array(platforms["partial"])
   root = profile_root(manifest_path)
 
-  unknown = (tested + partial).uniq - PLATFORM_ARTIFACTS.keys
+  unknown = (tested + partial).uniq - KNOWN_PLATFORMS.to_a
   unknown.each do |platform|
     errors << "#{relative(manifest_path)} uses unknown platform #{platform.inspect}"
   end
@@ -93,7 +94,7 @@ manifest_paths.each do |manifest_path|
   end
 
   tested.each do |platform|
-    artifact_dir = PLATFORM_ARTIFACTS[platform]
+    artifact_dir = PROJECT_PLATFORM_ARTIFACTS[platform]
     next unless artifact_dir
 
     artifact_path = File.join(root, artifact_dir)


### PR DESCRIPTION
## IP as Logo

**Source:** https://github.com/s1dashu/ip-as-logo-skill @ `b1bf517c54a407452cfaca98a54668cd052f8e63`
**Path:** `profiles/s1dashu/ip-as-logo-skill`

### Conversion notes

- Converted as one profile containing one Agent Skill.
- `SKILL.md` and `LICENSE` are byte-preserved and relocated into `for-forgecat/`.
- The source README is preserved in the ForgeCat README sandwich. Its presentation-only showcase image was excluded from the shipping tree, and the relative image link was changed to a commit-pinned upstream URL.
- `.gitignore` was excluded as repository development metadata.
- Runtime output requires an image-generation capability. No platform is marked `tested` before exact-version install and component-aware runtime verification.
- The first live run exposed a README dependency-schema mismatch and two PR-stage gaps. Local converter commits `fabdc9e`, `f7bbfd4`, and `db6b720` fix dependency rendering, catalog synchronization, and pre-push repository checks; the full test suite passes.
- The repository catalog is now synced to 188 profiles and 39 collections. The artifact checker recognizes both home targets without requiring project-native artifact directories.
- Conversion history: https://github.com/nota-america/forgecat-profile-converter-history/pull/1

## Converter Agent Checklist

### At a glance

| Field | Value |
|---|---|
| Profile | `@forgecat/s1dashu_ip-as-logo-skill` |
| Source repo | https://github.com/s1dashu/ip-as-logo-skill @ `b1bf517c54a407452cfaca98a54668cd052f8e63` |
| Profile PR | https://github.com/nota-america/forgecat-agent-profiles/pull/166 |
| Registry version | Pending |
| Overall status | Partial |
| Main caveat | The skill can produce assets only where a configured image generator is available. |
| Operator next action | Review both PRs, then approve pushing converter commits through `db6b720` and running the registry release if publication should continue. |

### Review checklist

| Area | Human review question | Status | Evidence | Risk / next action | Notes / special cases |
|---|---|---|---|---|---|
| PR scope | Does the PR contain only profile artifacts, the required root README catalog update, and any explicitly justified validation compatibility fix, with no source snapshots, history docs, scratch reports, or generated CSVs? | Pass | https://github.com/nota-america/forgecat-agent-profiles/pull/166; profile path, repository `README.md`, and `scripts/check-profile-artifacts.rb` | None. | The script change adds Hermes to the known five-platform set and limits native-artifact requirements to project targets. |
| Profile identity | Do `profile.yml` name, profile folder, source owner, collection, source URL, and source commit line up? | Pass | `@forgecat/s1dashu_ip-as-logo-skill`; source commit `b1bf517c54a407452cfaca98a54668cd052f8e63` | None. | Source platform is `agent-skills`, matching the upstream open Agent Skills format. |
| Source inventory | Were all source runtime surfaces inventoried: skills, agents, commands, hooks, MCP, rules/instructions, docs, runtime helpers, assets/templates, and platform-native files? | Pass | 5 files inventoried: one skill, README, license, showcase asset, `.gitignore`; 0 medium/low-confidence rows. | None. | No agents, commands, hooks, MCP, rules, scripts, or platform-native manifests exist upstream. |
| Converted components | Are required source surfaces present in the forgecat profile, or explicitly classified as intentional exclusion / unsupported limitation? | Pass | 1 skill; 2 relocated source files; 1 modified README; 2 explicit exclusions; missing 0. | None. | Showcase image is presentation-only; `.gitignore` is development metadata. |
| Internal file edits | Were any file contents changed beyond relocation, such as hook/script path rewrites, wrapper changes, config rewrites, or internal file-reference updates caused by forgecat install paths? | Pass | `SKILL.md` and `LICENSE` byte-identical; README showcase link is commit-pinned; artifact checker has a 6-line/5-line compatibility correction. | Review the README link and validator diff. | No runtime instruction content changed. |
| Behavior parity risk | Is there any known chance that the converted profile behaves differently from the original repo because of runtime support gaps, path rewrites, platform conversion, missing host features, or intentional exclusions? | Partial | The skill explicitly checks for an available image generator and asks the user to enable one if absent. | Verify generation separately per platform during release. | Install/load can pass even when image generation is unavailable. |
| Manifest/schema | Does `for-forgecat/profile.yml` pass current forgecat schema rules, including visibility, compatibility, models.minimum, no comments, and no source-derived version for new profiles? | Pass | `bin/convert validate`; `forgecat validate --strict --json`: 0 errors, 0 warnings. | None. | `tested: []`; all five supported platforms remain `partial`. |
| README/docs | Do root and `for-forgecat/README.md` follow the current README rules and preserve source docs or path rewrites needed by installed skills? | Pass | Root ForgeCat README plus labeled original-source README; commit-pinned showcase URL. | None. | Version is `pending-registry-publish`. |
| QA findings | Did an independent QA pass run, and are all blocker / fix-before-merge findings fixed or explicitly classified? | Pass | Independent QA: blocker 0, profile-content fix 0, follow-up 0; the stale-checklist finding is resolved. | None before release review. | The later repository-only fixes are covered by their own catalog/artifact checks. |
| Validation gates | Did post-conversion validation, forgecat validate/scan, and dry-run publish pass before review? | Pass | Converter validate pass; ForgeCat strict validate pass; five-platform plan pass; scan untracked 0; public dry-run pass; GitHub `readme-catalog` check pass. | Real publish still requires explicit approval. | The read-only QA reviewer unexpectedly ran the authenticated dry-run; it did not publish or change registry state. |
| Registry/version | If published, is the registry-assigned version synced back to profile metadata and does the targeted registry/repo sync gate pass? | Pending | No registry push performed. | Continue with `profile-release` only after approval. | `profile.yml` is versionless. |
| Platform install/runtime | Are install and component-aware runtime results recorded separately for all five ForgeCat platforms, with unsupported home-target surfaces explicit and every unverified platform kept out of `tested`? | Pending | claude-code: pending; cursor: pending; codex: pending; openclaw: pending; hermes: pending. | Exact-version install and skill-triggered generation probes belong to the release lane. | All five are conservatively `partial`. |
| Native artifacts | Do `for-claude/`, `for-codex/`, `for-cursor/`, or other native artifacts exist only when intentionally generated and component-runtime-tested? | N/A | Upstream ships no native platform artifact; profile uses canonical `for-forgecat/` skill only. | None. | ForgeCat plan maps the skill to all five targets. |
| License/security | Are upstream license/notices preserved, and does the forgecat CLI's built-in secret/content scan (`forgecat validate` / publish gate) pass for the shipping file set? | Pass | MIT license preserved at `for-forgecat/LICENSE`; strict validate and public dry-run pass with 0 warnings. | Real publish security evaluation remains release-lane evidence. | No scripts, hooks, MCP, or credentials ship. |
| Archive/history | Is post-merge archive/history sync complete, or clearly pending until the human merge gate is cleared? | Partial | https://github.com/nota-america/forgecat-profile-converter-history/pull/1; source commit and exact personal-repo source snapshot recorded. | Update the same history PR after publish/install/runtime. | Publish/install/runtime fields are explicitly pending. |
| Operator decision | Based on the rows above, should the operator merge, request fixes, reject/close, or provide a missing decision? | Partial | Conversion, static validation, QA, profile PR, and history PR are complete. | Explicitly approve pushing converter commits through `db6b720` and running `profile-release`, or leave both PRs open. | Real registry publication remains a separate irreversible-boundary approval. |
