### PR TITLE
fix(slides-grab): sync README to 0.1.3

### DIFF
--- a/profiles/nomadamas/slides-grab/README.md
+++ b/profiles/nomadamas/slides-grab/README.md
@@ -62,7 +62,7 @@ A fresh `slides-grab@1.5.1` install currently reports two high-severity transiti
 |---|---|
 | Author | vkehfdl1 |
 | Original repository | https://github.com/NomaDamas/slides-grab |
-| Version | `0.1.2` |
+| Version | `0.1.3` |
 | Original commit | b904568fc8a56e7ec8ca13fffdfcc6b1952c5284 |
 | License | MIT |
 | Source platform | multi-host |

--- a/profiles/nomadamas/slides-grab/for-claude/.forgecat/profiles/@forgecat/nomadamas_slides-grab/README.md
+++ b/profiles/nomadamas/slides-grab/for-claude/.forgecat/profiles/@forgecat/nomadamas_slides-grab/README.md
@@ -62,7 +62,7 @@ A fresh `slides-grab@1.5.1` install currently reports two high-severity transiti
 |---|---|
 | Author | vkehfdl1 |
 | Original repository | https://github.com/NomaDamas/slides-grab |
-| Version | `0.1.2` |
+| Version | `0.1.3` |
 | Original commit | b904568fc8a56e7ec8ca13fffdfcc6b1952c5284 |
 | License | MIT |
 | Source platform | multi-host |

--- a/profiles/nomadamas/slides-grab/for-codex/.forgecat/profiles/@forgecat/nomadamas_slides-grab/README.md
+++ b/profiles/nomadamas/slides-grab/for-codex/.forgecat/profiles/@forgecat/nomadamas_slides-grab/README.md
@@ -62,7 +62,7 @@ A fresh `slides-grab@1.5.1` install currently reports two high-severity transiti
 |---|---|
 | Author | vkehfdl1 |
 | Original repository | https://github.com/NomaDamas/slides-grab |
-| Version | `0.1.2` |
+| Version | `0.1.3` |
 | Original commit | b904568fc8a56e7ec8ca13fffdfcc6b1952c5284 |
 | License | MIT |
 | Source platform | multi-host |

--- a/profiles/nomadamas/slides-grab/for-cursor/.forgecat/profiles/@forgecat/nomadamas_slides-grab/README.md
+++ b/profiles/nomadamas/slides-grab/for-cursor/.forgecat/profiles/@forgecat/nomadamas_slides-grab/README.md
@@ -62,7 +62,7 @@ A fresh `slides-grab@1.5.1` install currently reports two high-severity transiti
 |---|---|
 | Author | vkehfdl1 |
 | Original repository | https://github.com/NomaDamas/slides-grab |
-| Version | `0.1.2` |
+| Version | `0.1.3` |
 | Original commit | b904568fc8a56e7ec8ca13fffdfcc6b1952c5284 |
 | License | MIT |
 | Source platform | multi-host |

--- a/profiles/nomadamas/slides-grab/for-forgecat/README.md
+++ b/profiles/nomadamas/slides-grab/for-forgecat/README.md
@@ -62,7 +62,7 @@ A fresh `slides-grab@1.5.1` install currently reports two high-severity transiti
 |---|---|
 | Author | vkehfdl1 |
 | Original repository | https://github.com/NomaDamas/slides-grab |
-| Version | `0.1.2` |
+| Version | `0.1.3` |
 | Original commit | b904568fc8a56e7ec8ca13fffdfcc6b1952c5284 |
 | License | MIT |
 | Source platform | multi-host |


### PR DESCRIPTION
## Summary

This PR updates the five ForgeCat-authored README version rows to `0.1.3`. It does not change any skill, reference, manifest, template, dataset, or native agent byte.

## Release evidence

| Field | Result |
|---|---|
| Profile | `@forgecat/nomadamas_slides-grab@0.1.3` |
| Source | `NomaDamas/slides-grab@b904568fc8a56e7ec8ca13fffdfcc6b1952c5284` |
| Registry | Private, 41 files |
| Integrity | `sha256-ce125983cd11f9e0d1d0a078f422abeae313f5ef689834db00b5ca1b226ddc42` |
| Shipping SHA | `0a74dde04f607932782c2da1a76af28e447e53c1160ea7de7f4d3aaa2e5b5b05` |
| Runtime | 11/11 component receipts on each of five platforms |
| Cleanup | Five uninstalls passed; temporary OpenClaw and Hermes objects removed |

The direct Claude and Codex artifacts intentionally retain source-native design-critic adapters outside the portable Registry package. Their complete trees are bound as:

- Claude Code: `sha256-b7eb8005c62bb1baa754f060eda976308693575f368e33762470a3635070b85f`
- Codex: `sha256-7b84bf431a6d40fc87e24bdef5934a3b4773ca4f8483a1dbd3f6732833cc54cc`

Actual image generation was not invoked. Delivery and routing passed, and the capability remains explicitly unverified.

## Review checklist

| Check | Result |
|---|---|
| PR scope | Pass, five README rows only |
| Strict validate, plan, and scan | Pass |
| Profile catalog check | Pass |
| Changed-profile artifact check | Pass |
| Private exact-version runtime | Pass |
| Release gate | Pass |
| Public visibility | Not approved; Registry remains private |

Merge approval does not authorize public visibility.

Paired History PR: https://github.com/nota-america/forgecat-profile-converter-history/pull/5
