### PR TITLE
fix(profile): sync native artifact README versions

### DIFF
--- a/profiles/juliusbrussee/caveman/for-claude/.forgecat/profiles/@forgecat/juliusbrussee_caveman/README.md
+++ b/profiles/juliusbrussee/caveman/for-claude/.forgecat/profiles/@forgecat/juliusbrussee_caveman/README.md
@@ -40,7 +40,7 @@ npx forgecat install @forgecat/juliusbrussee_caveman
 |---|---|
 | Author | Julius Brussee |
 | Original repository | https://github.com/JuliusBrussee/caveman |
-| Version | `0.1.5` |
+| Version | `0.1.7` |
 | Original commit | `655b7d9c5431f822264b7732e9901c5578ac84cf` |
 | License | MIT |
 | Source platform | Multi-platform: Claude Code plugin, Codex plugin/config, Gemini extension, opencode plugin, and skills installer |

--- a/profiles/juliusbrussee/caveman/for-cursor/.forgecat/profiles/@forgecat/juliusbrussee_caveman/README.md
+++ b/profiles/juliusbrussee/caveman/for-cursor/.forgecat/profiles/@forgecat/juliusbrussee_caveman/README.md
@@ -40,7 +40,7 @@ npx forgecat install @forgecat/juliusbrussee_caveman
 |---|---|
 | Author | Julius Brussee |
 | Original repository | https://github.com/JuliusBrussee/caveman |
-| Version | `0.1.5` |
+| Version | `0.1.7` |
 | Original commit | `655b7d9c5431f822264b7732e9901c5578ac84cf` |
 | License | MIT |
 | Source platform | Multi-platform: Claude Code plugin, Codex plugin/config, Gemini extension, opencode plugin, and skills installer |

--- a/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-view-transitions/for-claude/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_react-view-transitions/README.md
+++ b/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-view-transitions/for-claude/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_react-view-transitions/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/vercel-labs_agent-skills_react-view-transitions
 |---|---|
 | Author | vercel |
 | Original repository | https://github.com/vercel-labs/agent-skills |
-| Version | `0.0.12` |
+| Version | `0.0.13` |
 | Original commit | `47863b2` |
 | License | MIT |
 | Source platform | Claude Code skills (Agent Skills format) |

--- a/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-view-transitions/for-codex/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_react-view-transitions/README.md
+++ b/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-view-transitions/for-codex/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_react-view-transitions/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/vercel-labs_agent-skills_react-view-transitions
 |---|---|
 | Author | vercel |
 | Original repository | https://github.com/vercel-labs/agent-skills |
-| Version | `0.0.12` |
+| Version | `0.0.13` |
 | Original commit | `47863b2` |
 | License | MIT |
 | Source platform | Claude Code skills (Agent Skills format) |

--- a/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-view-transitions/for-cursor/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_react-view-transitions/README.md
+++ b/profiles/vercel-labs/agent-skills/vercel-labs_agent-skills_react-view-transitions/for-cursor/.forgecat/profiles/@forgecat/vercel-labs_agent-skills_react-view-transitions/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/vercel-labs_agent-skills_react-view-transitions
 |---|---|
 | Author | vercel |
 | Original repository | https://github.com/vercel-labs/agent-skills |
-| Version | `0.0.12` |
+| Version | `0.0.13` |
 | Original commit | `47863b2` |
 | License | MIT |
 | Source platform | Claude Code skills (Agent Skills format) |


### PR DESCRIPTION
## Summary

Fix the stale version receipts left inside the native artifacts added by [nota-america/forgecat-agent-profiles#173](https://github.com/nota-america/forgecat-agent-profiles/pull/173):

- Caveman `for-claude` and `for-cursor`: `0.1.5` → `0.1.7`
- React View Transitions `for-claude`, `for-cursor`, and `for-codex`: `0.0.12` → `0.0.13`

This is metadata-only. It does not change profile manifests, runtime payloads, registry versions, visibility, or published package bytes.

## Validation

- `git diff --check origin/main...HEAD` — pass
- `ruby scripts/check-profile-artifacts.rb --changed-only origin/main...HEAD` — pass (`profiles=2`)
- `ruby scripts/check-readme-catalog.rb` — pass (`profiles=190`, `collections=40`)
- Targeted registry/repo sync gate — pass (`hubOnly=0`, `repoOnly=0`, `versionDrift=0`, `platformDrift=0`)
- `forgecat push --dry-run --json` — pass for both canonical packages (50 and 9 files)
- Independent QA — no blockers; exactly five `Version` rows changed

## Profile Conversion PR Review Checklist

| Area | Human review question | Status | Evidence | Risk / next action | Notes / special cases |
|---|---|---|---|---|---|
| PR scope | Does the PR contain only profile artifacts under `profiles/<source-owner>/<collection>/...`, with no source snapshots, history docs, scratch reports, or generated CSVs? | Pass | Branch `fix/pr173-native-readme-versions`; five native receipt README paths; diff is 5+/5- | None | Follow-up to merged profile PR 173 |
| Profile identity | Do `profile.yml` name, profile folder, source owner, collection, source URL, and source commit line up? | Pass | Both `for-forgecat/profile.yml` files are unchanged; targeted sync gate passes | None | Identity metadata is outside this diff |
| Source inventory | Were all source runtime surfaces inventoried? | N/A | No source or runtime surface changes | None | Metadata-only follow-up |
| Converted components | Are required source surfaces present or explicitly classified? | N/A | No converted component changes | None | Existing artifacts remain unchanged except receipt version rows |
| Internal file edits | Were file contents changed beyond relocation? | Pass | Caveman Claude/Cursor receipt README `0.1.5`→`0.1.7`; React Claude/Cursor/Codex receipt README `0.0.12`→`0.0.13` | Review the five one-line diffs | Corrects stale installed-profile receipts |
| Behavior parity risk | Could behavior differ because of runtime gaps or rewrites? | Pass | Payload, hooks, skills, agents, commands, and manifests have zero diff | None | No executable content changed |
| Manifest/schema | Does `for-forgecat/profile.yml` pass current schema rules? | Partial | React strict validation passes; Caveman normal validation passes with three pre-existing `hook_platform_skip` warnings, while strict treats warnings as errors | No new warning introduced; retain existing platform limitations | Both manifests are unchanged |
| README/docs | Do READMEs follow current rules? | Pass | `check-readme-catalog.rb` passes; all root, canonical, and native receipt version rows now agree | None | Only five internal receipt rows changed |
| QA findings | Did independent QA run, with blockers resolved? | Pass | Independent QA reports exact five-file/one-line scope and no blockers | None | Payload and manifest diff confirmed empty |
| Validation gates | Did post-conversion validation, scan, and dry-run publish pass? | Partial | Artifact check, catalog check, sync gate, and both publish dry-runs pass; Caveman strict validate has only pre-existing hook-platform warnings | No new publish is required | Resource scans report only non-trackable docs/assets |
| Registry/version | Is the registry-assigned version synced and does the targeted sync gate pass? | Pass | Live registry: Caveman `0.1.7` integrity `sha256-959c7619e11f66be7f974a16356288116bf9374d18c0b23986c7974c1ea01f96`; React `0.0.13` integrity `sha256-0e53cc8968634b8e91726ed7055330b7bafae9d869e88078e5896fb2757c6dd4`; sync gate pass | Do not republish | Registry versions and bytes remain unchanged |
| Platform install/runtime | Are install and runtime results recorded separately? | N/A | No installable payload changed. Existing registry state: Caveman Claude/Cursor tested and Codex partial; React Claude/Codex tested and Cursor partial. OpenClaw/Hermes were manually attested by the operator | No runtime rerun needed for receipt-only edits | This PR does not change compatibility claims |
| Native artifacts | Do native artifacts exist only when intentionally generated and tested? | Pass | Existing Caveman Claude/Cursor and React Claude/Cursor/Codex artifacts are unchanged except their embedded receipt version | None | Versions now match their public releases |
| License/security | Are license/notices and security scans clean? | N/A | No license, notice, security-sensitive, or shipping-package bytes changed; dry-run security gates pass | None | Existing registry evaluations remain authoritative |
| Archive/history | Is post-merge history sync complete or clearly pending? | Pending | [nota-america/forgecat-profile-history#55](https://github.com/nota-america/forgecat-profile-history/pull/55) currently reflects the pre-fix merged tree | Merge this PR, then refresh history PR 55 before merging it | History must match final merged profile state |
| Operator decision | Should the operator merge, request fixes, reject, or decide? | Pass | Narrow metadata-only diff; all change-scoped gates and independent QA pass | Merge this PR, then refresh and merge history PR 55 | No registry publish is needed |

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 (Codex context, high reasoning) via [Codex](https://openai.com/codex/)
