### PR TITLE
fix(profile): mark GENEXIS GPT image platforms tested

### DIFF
--- a/profiles/genexis-ai/gpt-image-skill/README.md
+++ b/profiles/genexis-ai/gpt-image-skill/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/genexis-ai_gpt-image-skill
 |---|---|
 | Author | GENEXIS-AI |
 | Original repository | https://github.com/GENEXIS-AI/gpt-image-skill |
-| Version | `0.1.1` |
+| Version | `0.1.2` |
 | Original commit | 9da68649d1e0eb8d618a6960cbdee88af11313ec |
 | License | Unknown |
 | Source platform | multi-host |
@@ -40,11 +40,11 @@ npx forgecat install @forgecat/genexis-ai_gpt-image-skill
 
 | Platform | Status |
 |---|---|
-| Claude Code | Partial |
-| Cursor | Partial |
-| Codex | Partial |
-| OpenClaw | Partial |
-| Hermes | Partial |
+| Claude Code | Tested |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 

--- a/profiles/genexis-ai/gpt-image-skill/for-claude/.forgecat/profiles/@forgecat/genexis-ai_gpt-image-skill/README.md
+++ b/profiles/genexis-ai/gpt-image-skill/for-claude/.forgecat/profiles/@forgecat/genexis-ai_gpt-image-skill/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/genexis-ai_gpt-image-skill
 |---|---|
 | Author | GENEXIS-AI |
 | Original repository | https://github.com/GENEXIS-AI/gpt-image-skill |
-| Version | `0.1.1` |
+| Version | `0.1.2` |
 | Original commit | 9da68649d1e0eb8d618a6960cbdee88af11313ec |
 | License | Unknown |
 | Source platform | multi-host |
@@ -40,11 +40,11 @@ npx forgecat install @forgecat/genexis-ai_gpt-image-skill
 
 | Platform | Status |
 |---|---|
-| Claude Code | Partial |
-| Cursor | Partial |
-| Codex | Partial |
-| OpenClaw | Partial |
-| Hermes | Partial |
+| Claude Code | Tested |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 

--- a/profiles/genexis-ai/gpt-image-skill/for-codex/.forgecat/profiles/@forgecat/genexis-ai_gpt-image-skill/README.md
+++ b/profiles/genexis-ai/gpt-image-skill/for-codex/.forgecat/profiles/@forgecat/genexis-ai_gpt-image-skill/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/genexis-ai_gpt-image-skill
 |---|---|
 | Author | GENEXIS-AI |
 | Original repository | https://github.com/GENEXIS-AI/gpt-image-skill |
-| Version | `0.1.1` |
+| Version | `0.1.2` |
 | Original commit | 9da68649d1e0eb8d618a6960cbdee88af11313ec |
 | License | Unknown |
 | Source platform | multi-host |
@@ -40,11 +40,11 @@ npx forgecat install @forgecat/genexis-ai_gpt-image-skill
 
 | Platform | Status |
 |---|---|
-| Claude Code | Partial |
-| Cursor | Partial |
-| Codex | Partial |
-| OpenClaw | Partial |
-| Hermes | Partial |
+| Claude Code | Tested |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 

--- a/profiles/genexis-ai/gpt-image-skill/for-cursor/.forgecat/profiles/@forgecat/genexis-ai_gpt-image-skill/README.md
+++ b/profiles/genexis-ai/gpt-image-skill/for-cursor/.forgecat/profiles/@forgecat/genexis-ai_gpt-image-skill/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/genexis-ai_gpt-image-skill
 |---|---|
 | Author | GENEXIS-AI |
 | Original repository | https://github.com/GENEXIS-AI/gpt-image-skill |
-| Version | `0.1.1` |
+| Version | `0.1.2` |
 | Original commit | 9da68649d1e0eb8d618a6960cbdee88af11313ec |
 | License | Unknown |
 | Source platform | multi-host |
@@ -40,11 +40,11 @@ npx forgecat install @forgecat/genexis-ai_gpt-image-skill
 
 | Platform | Status |
 |---|---|
-| Claude Code | Partial |
-| Cursor | Partial |
-| Codex | Partial |
-| OpenClaw | Partial |
-| Hermes | Partial |
+| Claude Code | Tested |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 

--- a/profiles/genexis-ai/gpt-image-skill/for-forgecat/README.md
+++ b/profiles/genexis-ai/gpt-image-skill/for-forgecat/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/genexis-ai_gpt-image-skill
 |---|---|
 | Author | GENEXIS-AI |
 | Original repository | https://github.com/GENEXIS-AI/gpt-image-skill |
-| Version | `0.1.1` |
+| Version | `0.1.2` |
 | Original commit | 9da68649d1e0eb8d618a6960cbdee88af11313ec |
 | License | Unknown |
 | Source platform | multi-host |
@@ -40,11 +40,11 @@ npx forgecat install @forgecat/genexis-ai_gpt-image-skill
 
 | Platform | Status |
 |---|---|
-| Claude Code | Partial |
-| Cursor | Partial |
-| Codex | Partial |
-| OpenClaw | Partial |
-| Hermes | Partial |
+| Claude Code | Tested |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 

--- a/profiles/genexis-ai/gpt-image-skill/for-forgecat/profile.yml
+++ b/profiles/genexis-ai/gpt-image-skill/for-forgecat/profile.yml
@@ -6,13 +6,13 @@ license: Unknown
 sourcePlatform: multi-host
 compatibility:
   platforms:
-    tested: []
-    partial:
+    tested:
     - claude-code
     - cursor
     - codex
     - openclaw
     - hermes
+    partial: []
   models:
     recommended: []
     minimum: []


### PR DESCRIPTION
## Summary

Promotes all five platform claims for `@forgecat/genexis-ai_gpt-image-skill` from `Partial` to `Tested` and stamps the ForgeCat-authored READMEs as `0.1.2`.

- Source: `GENEXIS-AI/gpt-image-skill@9da68649d1e0eb8d618a6960cbdee88af11313ec`
- Private canary: `@forgecat/genexis-ai_gpt-image-skill@0.1.2`
- Integrity: `sha256-053aa16cb7ee9d067b3f58aa7f08e271ca2afcb2f10f162ec5ebfbc54b2c75aa`
- Shipping SHA: `3beb2ea3a8998328d340fb95b9fcdacb9d361b2f0dce210013f7e2a7fdbed4e7`
- Registry visibility: private
- History PR: https://github.com/nota-america/forgecat-profile-converter-history/pull/8

## Scope

The skill, references, and runtime script are byte-identical to public `0.1.1`. This PR changes only `profile.yml` platform claims and the version and compatibility rows in five ForgeCat-authored READMEs.

## Validation

- strict ForgeCat validate, plan, and scan passed
- converter validation and version-stamp check passed
- security evaluation passed Low in Source, Agent Intent, Permissions, and MCP
- exact `0.1.2` install, lock, component-specific runtime probe, uninstall, and cleanup passed on Claude Code, Cursor, Codex, OpenClaw, and Hermes
- temporary OpenClaw agent and Hermes profile were deleted through native cleanup
- claim-binding release gate passed with all five audit outcomes mapped to `Tested`
- Codex direct native artifact bound as `sha256-726f8858d18e04896497e4aa1c603febb207637b85c8bfcbdf3d0b2c01d794e2`

Image generation was not repeated for `0.1.2`; its behavior-bearing files are unchanged from `0.1.1`, whose history record preserves five direct PNG receipts. The `0.1.2` audit records image generation separately as unverified.

Public Registry visibility is not part of this PR.
