### PR TITLE
Profile: backfill i-have-adhd home claims

### DIFF
--- a/profiles/ayghri/i-have-adhd/README.md
+++ b/profiles/ayghri/i-have-adhd/README.md
@@ -27,7 +27,7 @@ npx forgecat install @forgecat/ayghri_i-have-adhd
 |---|---|
 | Author | Ayoub G. |
 | Original repository | https://github.com/ayghri/i-have-adhd |
-| Version | `0.1.2` |
+| Version | `0.1.3` |
 | Original commit | 559f8e0 |
 | License | MIT |
 | Source platform | multi-host |
@@ -41,6 +41,8 @@ npx forgecat install @forgecat/ayghri_i-have-adhd
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/ayghri/i-have-adhd/for-claude/.forgecat/profiles/@forgecat/ayghri_i-have-adhd/README.md
+++ b/profiles/ayghri/i-have-adhd/for-claude/.forgecat/profiles/@forgecat/ayghri_i-have-adhd/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/ayghri_i-have-adhd
 |---|---|
 | Author | Ayoub G. |
 | Original repository | https://github.com/ayghri/i-have-adhd |
-| Version | `0.1.2` |
+| Version | `0.1.3` |
 | Original commit | 559f8e0 |
 | License | MIT |
 | Source platform | multi-host |

--- a/profiles/ayghri/i-have-adhd/for-codex/.forgecat/profiles/@forgecat/ayghri_i-have-adhd/README.md
+++ b/profiles/ayghri/i-have-adhd/for-codex/.forgecat/profiles/@forgecat/ayghri_i-have-adhd/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/ayghri_i-have-adhd
 |---|---|
 | Author | Ayoub G. |
 | Original repository | https://github.com/ayghri/i-have-adhd |
-| Version | `0.1.2` |
+| Version | `0.1.3` |
 | Original commit | 559f8e0 |
 | License | MIT |
 | Source platform | multi-host |

--- a/profiles/ayghri/i-have-adhd/for-cursor/.forgecat/profiles/@forgecat/ayghri_i-have-adhd/README.md
+++ b/profiles/ayghri/i-have-adhd/for-cursor/.forgecat/profiles/@forgecat/ayghri_i-have-adhd/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/ayghri_i-have-adhd
 |---|---|
 | Author | Ayoub G. |
 | Original repository | https://github.com/ayghri/i-have-adhd |
-| Version | `0.1.2` |
+| Version | `0.1.3` |
 | Original commit | 559f8e0 |
 | License | MIT |
 | Source platform | multi-host |

--- a/profiles/ayghri/i-have-adhd/for-forgecat/README.md
+++ b/profiles/ayghri/i-have-adhd/for-forgecat/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/ayghri_i-have-adhd
 |---|---|
 | Author | Ayoub G. |
 | Original repository | https://github.com/ayghri/i-have-adhd |
-| Version | `0.1.2` |
+| Version | `0.1.3` |
 | Original commit | 559f8e0 |
 | License | MIT |
 | Source platform | multi-host |
@@ -43,6 +43,8 @@ npx forgecat install @forgecat/ayghri_i-have-adhd
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/ayghri/i-have-adhd/for-forgecat/profile.yml
+++ b/profiles/ayghri/i-have-adhd/for-forgecat/profile.yml
@@ -10,7 +10,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []


### PR DESCRIPTION
## Summary

Adds the missing OpenClaw and Hermes `Partial` claims for `@forgecat/ayghri_i-have-adhd` and stamps ForgeCat-authored README receipts for the proposed `0.1.3` patch.

## Scope

- [ ] New profile
- [x] Existing profile fix
- [x] Platform artifact or compatibility update
- [x] README, metadata, or license correction
- [ ] Repo maintenance

## Source and License

- Source repository: https://github.com/ayghri/i-have-adhd
- Source path or subdirectory: repository root at `559f8e041dc92de0c47032a8a9289cea2ef5496b`
- License evidence: shipped MIT `LICENSE`, unchanged from Registry `0.1.2`

Checklist:

- [x] I inspected the upstream source repository directly.
- [x] I preserved source attribution in the profile README or metadata.
- [x] I confirmed the license and reflected it in `for-forgecat/profile.yml`.
- [x] I did not add files that are unrelated to the profile runtime.

## Validation

Commands run:

```text
forgecat validate --strict --json
forgecat plan --json
forgecat scan --json
bin/convert home-patch-verify ...
forgecat push --dry-run --json --visibility public --bump patch
ruby scripts/check-readme-catalog.rb
ruby scripts/check-profile-artifacts.rb --changed-only origin/main..HEAD
ruby scripts/check-license-evidence.rb --changed-only origin/main..HEAD
```

Results:

```text
strict validation: pass, no warnings
scan: 0 untracked files
install plan: byte-identical to Registry 0.1.2
functional files: 2, byte-identical to Registry 0.1.2
dry-run: @forgecat/ayghri_i-have-adhd@0.1.3, public, 4 files, no warnings
shipping SHA: 0b9a3b37a5736fdd6e72232c49aadc2f3649685ce13c5eb055eb7b8423687b9d
catalog, artifact, and license checks: pass
```

Checklist:

- [x] `forgecat validate` passes from the profile's `for-forgecat/` directory.
- [x] README install commands and profile metadata agree.
- [x] No secrets, local state, logs, or generated tool cache files are included.

## Converter Agent Checklist

### At a glance

| Field | Value |
|---|---|
| Profile | `@forgecat/ayghri_i-have-adhd` |
| Source repo | `ayghri/i-have-adhd@559f8e0` |
| Profile PR | This PR |
| Registry version | Current `0.1.2`; proposed `0.1.3` |
| Overall status | Claims-only preview ready |
| Main caveat | No new runtime claim or tested promotion |
| Operator next action | Review this PR with the paired history PR |

### Review checklist

| Area | Status | Evidence | Risk / next action | Notes / special cases |
|---|---|---|---|---|
| PR scope | Pass | Six changed files under one profile | Review exact diff | Three claim files, three version-only native README receipts |
| Profile identity | Pass | Name and source pin unchanged | None | Existing public profile |
| Source inventory | Pass | Verified handoff | None | One skill and MIT license ship |
| Converted components | Pass | Functional bytes equal Registry `0.1.2` | None | Skill and license unchanged |
| Internal file edits | Pass | Claim receipt and version stamp receipt | None | No source-authored prose changed |
| Behavior parity risk | Pass | Full install plan unchanged | None | Metadata-only patch |
| Manifest/schema | Pass | Strict validation | None | Adds only OpenClaw and Hermes partial claims |
| README/docs | Pass | Generated table and version checks | None | All ForgeCat receipts show `0.1.3` |
| QA findings | Pass | Independent conversion QA ready | Keep archived-source caveat in history | No blocking findings |
| Validation gates | Pass | Exact Registry equivalence gate | None | Converter tests 29/29 |
| Registry/version | Preview | Public dry-run `0.1.3` | Real push needs separate approval | Current Registry remains `0.1.2` |
| Platform install/runtime | Preserved | No existing claim changed | No new runtime assertion | OpenClaw and Hermes remain partial |
| Native artifacts | Pass | Only version rows changed | None | Claude, Codex, Cursor receipts |
| License/security | Pass | MIT license unchanged; prior scan low risk | None | No dependency change |
| Archive/history | Ready | Paired history snapshot prepared | Review paired PR | Exact four-file snapshot |
| Operator decision | Pending | This PR and paired history PR | Review before Registry push | Registry remains unchanged |

Checklist:

- [x] Tested platforms have matching native `for-<platform>` directories.
- [x] Partial platforms list known limitations.
- [ ] Runtime testing exercised the installed surface. No runtime assertion is added by this claims-only patch.
- [x] The same release facts are recorded in the paired history snapshot.

## Notes

PR #165 is treated as a withdrawn branch and none of its changes are included here. The existing `tested` claims are preserved. This patch adds no new `tested` claim.
