### PR TITLE
Profile: backfill Obsidian Skills home claims

### DIFF
--- a/profiles/kepano/obsidian-skills/README.md
+++ b/profiles/kepano/obsidian-skills/README.md
@@ -35,7 +35,7 @@ npx forgecat install @forgecat/kepano_obsidian-skills
 |---|---|
 | Author | Steph Ango |
 | Original repository | https://github.com/kepano/obsidian-skills |
-| Version | `0.1.1` |
+| Version | `0.1.2` |
 | Original commit | `a1dc48e68138490d522c04cbf5822214c6eb1202` |
 | License | MIT |
 | Source platform | Claude Code plugin |
@@ -53,6 +53,8 @@ npx forgecat install @forgecat/kepano_obsidian-skills
 | Claude Code | Tested |
 | Cursor | Partial |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 

--- a/profiles/kepano/obsidian-skills/for-claude/.forgecat/profiles/@forgecat/kepano_obsidian-skills/README.md
+++ b/profiles/kepano/obsidian-skills/for-claude/.forgecat/profiles/@forgecat/kepano_obsidian-skills/README.md
@@ -37,7 +37,7 @@ npx forgecat install @forgecat/kepano_obsidian-skills
 |---|---|
 | Author | Steph Ango |
 | Original repository | https://github.com/kepano/obsidian-skills |
-| Version | `0.1.0` |
+| Version | `0.1.2` |
 | Original commit | `a1dc48e68138490d522c04cbf5822214c6eb1202` |
 | License | MIT |
 | Source platform | Claude Code plugin |

--- a/profiles/kepano/obsidian-skills/for-codex/.forgecat/profiles/@forgecat/kepano_obsidian-skills/README.md
+++ b/profiles/kepano/obsidian-skills/for-codex/.forgecat/profiles/@forgecat/kepano_obsidian-skills/README.md
@@ -37,7 +37,7 @@ npx forgecat install @forgecat/kepano_obsidian-skills
 |---|---|
 | Author | Steph Ango |
 | Original repository | https://github.com/kepano/obsidian-skills |
-| Version | `0.1.0` |
+| Version | `0.1.2` |
 | Original commit | `a1dc48e68138490d522c04cbf5822214c6eb1202` |
 | License | MIT |
 | Source platform | Claude Code plugin |

--- a/profiles/kepano/obsidian-skills/for-forgecat/README.md
+++ b/profiles/kepano/obsidian-skills/for-forgecat/README.md
@@ -37,7 +37,7 @@ npx forgecat install @forgecat/kepano_obsidian-skills
 |---|---|
 | Author | Steph Ango |
 | Original repository | https://github.com/kepano/obsidian-skills |
-| Version | `0.1.1` |
+| Version | `0.1.2` |
 | Original commit | `a1dc48e68138490d522c04cbf5822214c6eb1202` |
 | License | MIT |
 | Source platform | Claude Code plugin |
@@ -55,6 +55,8 @@ npx forgecat install @forgecat/kepano_obsidian-skills
 | Claude Code | Tested |
 | Cursor | Partial |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 

--- a/profiles/kepano/obsidian-skills/for-forgecat/profile.yml
+++ b/profiles/kepano/obsidian-skills/for-forgecat/profile.yml
@@ -11,6 +11,8 @@ compatibility:
       - codex
     partial:
       - cursor
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []


### PR DESCRIPTION
## Summary

Adds the missing OpenClaw and Hermes `Partial` claims for `@forgecat/kepano_obsidian-skills` and stamps ForgeCat-authored README receipts for the proposed `0.1.2` patch.

## Scope

- [x] Existing profile fix
- [x] Platform artifact or compatibility update
- [x] README or metadata correction

## Source and license

- Source: `kepano/obsidian-skills@a1dc48e68138490d522c04cbf5822214c6eb1202`
- License: shipped MIT `LICENSE`, unchanged from Registry `0.1.1`
- Components: five skills and their functional references

## Validation

- Strict validation: pass, no warnings
- Coverage: 11 present, 1 README sandwich modification, 2 intentional native-manifest exclusions, 0 missing
- Registry equivalence: all 11 functional files and the full install plan match exact `0.1.1`
- Dry-run: `@forgecat/kepano_obsidian-skills@0.1.2`, public, 13 files, no warnings
- Shipping SHA: `86c52a2e67ef43ab7572e961341405c80775fc75c3ed68e748b73a3dadfcb324`
- Independent QA: pass/ready

## Notes

No existing claim changes and no platform is promoted to tested. The Registry README's legacy `Forgecat` writer marker is normalized to `ForgeCat`; no other Registry prose changes.
