### PR TITLE
profile: backfill six OpenClaw and Hermes claims

### DIFF
--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_small-business/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_small-business/README.md
@@ -80,7 +80,7 @@ Trigger this skill whenever the user mentions: quarterly taxes, estimated tax pa
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/small-business |
-| Version | `0.1.13` |
+| Version | `0.1.14` |
 | Original commit | 69d3780 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -94,6 +94,8 @@ Trigger this skill whenever the user mentions: quarterly taxes, estimated tax pa
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Partial |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_small-business/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_small-business/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_small-business/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_small-business/README.md
@@ -82,7 +82,7 @@ Trigger this skill whenever the user mentions: quarterly taxes, estimated tax pa
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/small-business |
-| Version | `pending-registry-publish` |
+| Version | `0.1.14` |
 | Original commit | 69d3780 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_small-business/for-forgecat/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_small-business/for-forgecat/README.md
@@ -82,7 +82,7 @@ Trigger this skill whenever the user mentions: quarterly taxes, estimated tax pa
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/small-business |
-| Version | `0.1.13` |
+| Version | `0.1.14` |
 | Original commit | 69d3780 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -96,6 +96,8 @@ Trigger this skill whenever the user mentions: quarterly taxes, estimated tax pa
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Partial |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_small-business/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_small-business/for-forgecat/profile.yml
@@ -9,10 +9,12 @@ sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:
-    - claude-code
-    - cursor
+      - claude-code
+      - cursor
     partial:
-    - codex
+      - codex
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/googleworkspace/cli/googleworkspace_cli-skills/README.md
+++ b/profiles/googleworkspace/cli/googleworkspace_cli-skills/README.md
@@ -122,7 +122,7 @@ npx forgecat install @forgecat/googleworkspace_cli-skills
 |---|---|
 | Author | Justin Poehnelt |
 | Original repository | https://github.com/googleworkspace/cli/tree/main/skills |
-| Version | `0.1.2` |
+| Version | `0.1.3` |
 | Original commit | `a3768d0e82ad83cca2da97724e46bea4ff0e6dbd` |
 | License | Apache-2.0 |
 | Source platform | Agent Skills |
@@ -136,6 +136,8 @@ npx forgecat install @forgecat/googleworkspace_cli-skills
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/googleworkspace/cli/googleworkspace_cli-skills/for-forgecat/README.md
+++ b/profiles/googleworkspace/cli/googleworkspace_cli-skills/for-forgecat/README.md
@@ -124,7 +124,7 @@ npx forgecat install @forgecat/googleworkspace_cli-skills
 |---|---|
 | Author | Justin Poehnelt |
 | Original repository | https://github.com/googleworkspace/cli/tree/main/skills |
-| Version | `0.1.2` |
+| Version | `0.1.3` |
 | Original commit | `a3768d0e82ad83cca2da97724e46bea4ff0e6dbd` |
 | License | Apache-2.0 |
 | Source platform | Agent Skills |
@@ -138,6 +138,8 @@ npx forgecat install @forgecat/googleworkspace_cli-skills
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/googleworkspace/cli/googleworkspace_cli-skills/for-forgecat/profile.yml
+++ b/profiles/googleworkspace/cli/googleworkspace_cli-skills/for-forgecat/profile.yml
@@ -7,10 +7,12 @@ sourcePlatform: agent-skills
 compatibility:
   platforms:
     tested:
-    - claude-code
-    - codex
-    - cursor
-    partial: []
+      - claude-code
+      - codex
+      - cursor
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/mattpocock/skills/README.md
+++ b/profiles/mattpocock/skills/README.md
@@ -47,7 +47,7 @@ npx forgecat install @forgecat/mattpocock_skills
 |---|---|
 | Author | Matt Pocock |
 | Original repository | https://github.com/mattpocock/skills |
-| Version | `0.1.1` |
+| Version | `0.1.2` |
 | Original commit | `e3d8b735ef92ec9554b07f11f408089d81289eed` |
 | License | MIT |
 | Source platform | Claude Code plugin |
@@ -61,6 +61,8 @@ npx forgecat install @forgecat/mattpocock_skills
 | Claude Code | Tested |
 | Cursor | Partial |
 | Codex | Partial |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 

--- a/profiles/mattpocock/skills/for-forgecat/README.md
+++ b/profiles/mattpocock/skills/for-forgecat/README.md
@@ -49,7 +49,7 @@ npx forgecat install @forgecat/mattpocock_skills
 |---|---|
 | Author | Matt Pocock |
 | Original repository | https://github.com/mattpocock/skills |
-| Version | `0.1.1` |
+| Version | `0.1.2` |
 | Original commit | `e3d8b735ef92ec9554b07f11f408089d81289eed` |
 | License | MIT |
 | Source platform | Claude Code plugin |
@@ -63,6 +63,8 @@ npx forgecat install @forgecat/mattpocock_skills
 | Claude Code | Tested |
 | Cursor | Partial |
 | Codex | Partial |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 

--- a/profiles/mattpocock/skills/for-forgecat/profile.yml
+++ b/profiles/mattpocock/skills/for-forgecat/profile.yml
@@ -11,6 +11,8 @@ compatibility:
     partial:
       - cursor
       - codex
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/paramchoudhary/resumeskills/README.md
+++ b/profiles/paramchoudhary/resumeskills/README.md
@@ -49,7 +49,7 @@ npx forgecat install @forgecat/paramchoudhary_resumeskills
 |---|---|
 | Author | Param Choudhary |
 | Original repository | https://github.com/Paramchoudhary/ResumeSkills/tree/main/skills |
-| Version | `0.1.1` |
+| Version | `0.1.2` |
 | Original commit | `24c6edc8942edceba609e897ee8ec24f09d7581f` (2026-05-20) |
 | License | MIT |
 | Source platform | Agent Skills |
@@ -63,6 +63,8 @@ npx forgecat install @forgecat/paramchoudhary_resumeskills
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/paramchoudhary/resumeskills/for-forgecat/README.md
+++ b/profiles/paramchoudhary/resumeskills/for-forgecat/README.md
@@ -51,7 +51,7 @@ npx forgecat install @forgecat/paramchoudhary_resumeskills
 |---|---|
 | Author | Param Choudhary |
 | Original repository | https://github.com/Paramchoudhary/ResumeSkills/tree/main/skills |
-| Version | `0.1.1` |
+| Version | `0.1.2` |
 | Original commit | `24c6edc8942edceba609e897ee8ec24f09d7581f` (2026-05-20) |
 | License | MIT |
 | Source platform | Agent Skills |
@@ -65,6 +65,8 @@ npx forgecat install @forgecat/paramchoudhary_resumeskills
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/paramchoudhary/resumeskills/for-forgecat/profile.yml
+++ b/profiles/paramchoudhary/resumeskills/for-forgecat/profile.yml
@@ -10,7 +10,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/yeachan-heo/oh-my-claudecode_agents/README.md
+++ b/profiles/yeachan-heo/oh-my-claudecode_agents/README.md
@@ -48,7 +48,7 @@ npx forgecat install @forgecat/yeachan-heo_oh-my-claudecode_agents
 |---|---|
 | Author | Yeachan Heo |
 | Original repository | https://github.com/Yeachan-Heo/oh-my-claudecode/tree/main/agents |
-| Registry version | `0.1.4` |
+| Registry version | `0.1.5` |
 | Original commit | `deee3a446dadc9bfea31cdc8b19b00b16718082e` (2026-06-09) |
 | License | MIT |
 | Source platform | Claude Code |
@@ -60,8 +60,10 @@ npx forgecat install @forgecat/yeachan-heo_oh-my-claudecode_agents
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Tested |
 | Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 

--- a/profiles/yeachan-heo/oh-my-claudecode_agents/for-claude/.forgecat/profiles/@forgecat/yeachan-heo_oh-my-claudecode_agents/README.md
+++ b/profiles/yeachan-heo/oh-my-claudecode_agents/for-claude/.forgecat/profiles/@forgecat/yeachan-heo_oh-my-claudecode_agents/README.md
@@ -9,7 +9,7 @@ This profile packages only the upstream `agents/` directory from `Yeachan-Heo/oh
 | Field | Value |
 |---|---|
 | Original repository | https://github.com/Yeachan-Heo/oh-my-claudecode/tree/main/agents |
-| Registry version | `0.1.0` |
+| Registry version | `0.1.5` |
 | Original commit | `deee3a446dadc9bfea31cdc8b19b00b16718082e` (2026-06-09) |
 | License | MIT |
 | Source platform | claude-code |

--- a/profiles/yeachan-heo/oh-my-claudecode_agents/for-codex/.forgecat/profiles/@forgecat/yeachan-heo_oh-my-claudecode_agents/README.md
+++ b/profiles/yeachan-heo/oh-my-claudecode_agents/for-codex/.forgecat/profiles/@forgecat/yeachan-heo_oh-my-claudecode_agents/README.md
@@ -9,7 +9,7 @@ This profile packages only the upstream `agents/` directory from `Yeachan-Heo/oh
 | Field | Value |
 |---|---|
 | Original repository | https://github.com/Yeachan-Heo/oh-my-claudecode/tree/main/agents |
-| Registry version | `0.1.0` |
+| Registry version | `0.1.5` |
 | Original commit | `deee3a446dadc9bfea31cdc8b19b00b16718082e` (2026-06-09) |
 | License | MIT |
 | Source platform | claude-code |

--- a/profiles/yeachan-heo/oh-my-claudecode_agents/for-cursor/.forgecat/profiles/@forgecat/yeachan-heo_oh-my-claudecode_agents/README.md
+++ b/profiles/yeachan-heo/oh-my-claudecode_agents/for-cursor/.forgecat/profiles/@forgecat/yeachan-heo_oh-my-claudecode_agents/README.md
@@ -9,7 +9,7 @@ This profile packages only the upstream `agents/` directory from `Yeachan-Heo/oh
 | Field | Value |
 |---|---|
 | Original repository | https://github.com/Yeachan-Heo/oh-my-claudecode/tree/main/agents |
-| Registry version | `0.1.0` |
+| Registry version | `0.1.5` |
 | Original commit | `deee3a446dadc9bfea31cdc8b19b00b16718082e` (2026-06-09) |
 | License | MIT |
 | Source platform | claude-code |

--- a/profiles/yeachan-heo/oh-my-claudecode_agents/for-forgecat/README.md
+++ b/profiles/yeachan-heo/oh-my-claudecode_agents/for-forgecat/README.md
@@ -9,7 +9,7 @@ This profile packages only the upstream `agents/` directory from `Yeachan-Heo/oh
 | Field | Value |
 |---|---|
 | Original repository | https://github.com/Yeachan-Heo/oh-my-claudecode/tree/main/agents |
-| Registry version | `0.1.4` |
+| Registry version | `0.1.5` |
 | Original commit | `deee3a446dadc9bfea31cdc8b19b00b16718082e` (2026-06-09) |
 | License | MIT |
 | Source platform | claude-code |
@@ -21,8 +21,10 @@ This profile packages only the upstream `agents/` directory from `Yeachan-Heo/oh
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Tested |
 | Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ## Included
 

--- a/profiles/yeachan-heo/oh-my-claudecode_agents/for-forgecat/profile.yml
+++ b/profiles/yeachan-heo/oh-my-claudecode_agents/for-forgecat/profile.yml
@@ -10,10 +10,13 @@ sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:
-    - claude-code
-    - codex
-    - cursor
+      - claude-code
+      - codex
+      - cursor
     partial: []
+    unsupported:
+      - openclaw
+      - hermes
   models:
     recommended:
     - opus

--- a/profiles/zubair-trabzada/geo-seo-claude/README.md
+++ b/profiles/zubair-trabzada/geo-seo-claude/README.md
@@ -41,7 +41,7 @@ npx forgecat install @forgecat/zubair-trabzada_geo-seo-claude
 |---|---|
 | Author | Zubair Trabzada |
 | Original repository | https://github.com/zubair-trabzada/geo-seo-claude |
-| Version | `0.1.2` |
+| Version | `0.1.3` |
 | Original commit | `9eec32f5f700a1e6c3cb1cb735a56ee5ec49a964` |
 | License | MIT |
 | Source platform | Claude Code skills (non-plugin) |
@@ -55,6 +55,8 @@ npx forgecat install @forgecat/zubair-trabzada_geo-seo-claude
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/zubair-trabzada/geo-seo-claude/for-forgecat/README.md
+++ b/profiles/zubair-trabzada/geo-seo-claude/for-forgecat/README.md
@@ -43,7 +43,7 @@ npx forgecat install @forgecat/zubair-trabzada_geo-seo-claude
 |---|---|
 | Author | Zubair Trabzada |
 | Original repository | https://github.com/zubair-trabzada/geo-seo-claude |
-| Version | `0.1.2` |
+| Version | `0.1.3` |
 | Original commit | `9eec32f5f700a1e6c3cb1cb735a56ee5ec49a964` |
 | License | MIT |
 | Source platform | Claude Code skills (non-plugin) |
@@ -57,6 +57,8 @@ npx forgecat install @forgecat/zubair-trabzada_geo-seo-claude
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/zubair-trabzada/geo-seo-claude/for-forgecat/profile.yml
+++ b/profiles/zubair-trabzada/geo-seo-claude/for-forgecat/profile.yml
@@ -7,10 +7,12 @@ sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:
-    - claude-code
-    - cursor
-    - codex
-    partial: []
+      - claude-code
+      - cursor
+      - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []


### PR DESCRIPTION
## Summary

Adds the missing OpenClaw and Hermes compatibility rows to six existing profiles.

## What changes

- Five profiles add OpenClaw and Hermes as `Partial`.
- `@forgecat/yeachan-heo_oh-my-claudecode_agents` adds both as `Unsupported`.
- ForgeCat-authored README files move to the proposed patch version.
- Existing Claude Code, Cursor, and Codex claims stay unchanged.
- No functional file, file mode, or install destination changes.

## Profiles

| Profile | Patch | New home status |
|---|---:|---|
| `@forgecat/anthropics_knowledge-work-plugins_small-business` | `0.1.14` | Partial |
| `@forgecat/googleworkspace_cli-skills` | `0.1.3` | Partial |
| `@forgecat/mattpocock_skills` | `0.1.2` | Partial |
| `@forgecat/paramchoudhary_resumeskills` | `0.1.2` | Partial |
| `@forgecat/yeachan-heo_oh-my-claudecode_agents` | `0.1.5` | Unsupported |
| `@forgecat/zubair-trabzada_geo-seo-claude` | `0.1.3` | Partial |

## Verification

- Claims-only verification: 6/6 passed
- Strict validation: 6/6 passed
- Baseline scan parity: 6/6 passed
- Functional files unchanged: 385
- Install plans unchanged: 6/6
- Public dry-run: 6/6 passed, 397 shipping files
- Independent conversion QA: `pass / ready`, no findings
- Converter: `dbe92337ea513f90d87289c84baa044fce2db160`
- Registry writes: none

History evidence: [forgecat-profile-converter-history#13](https://github.com/nota-america/forgecat-profile-converter-history/pull/13)

## Not included

Ten reviewed candidates remain outside this PR. Two lack an existing Version row that the frozen stamp stage can update. Eight Contains Studio profiles are blocked by the repository's existing `license: Unknown` rule.
