### PR TITLE
profile: normalize two Registry version rows

### DIFF
--- a/profiles/epoko77-ai/im-not-ai/for-forgecat/README.md
+++ b/profiles/epoko77-ai/im-not-ai/for-forgecat/README.md
@@ -16,6 +16,17 @@ Claude Code and Cursor receive the source Claude workflow through ForgeCat's sta
 
 Upstream files are copied without editorial rewriting. The only change inside an upstream skill is replacement of five executable script paths with ForgeCat reference paths. A separate ForgeCat adapter keeps generated `_workspace/` output in the user's current directory without modifying the original Python shim.
 
+## Details
+
+| Field | Value |
+|---|---|
+| Author | epoko77-ai |
+| Original repository | https://github.com/epoko77-ai/im-not-ai |
+| Version | `0.1.3` |
+| Original commit | `53e24e8f92cf344efcb812103f7c2b203e7efffc` |
+| License | MIT |
+| Source platform | multi-host |
+
 ---
 *written by original source*
 

--- a/profiles/everyinc/compound-engineering-plugin/README.md
+++ b/profiles/everyinc/compound-engineering-plugin/README.md
@@ -60,6 +60,7 @@ npx forgecat install @forgecat/everyinc_compound-engineering-plugin
 |---|---|
 | Author | Kieran Klaassen and Trevin Chow |
 | Original repository | https://github.com/EveryInc/compound-engineering-plugin |
+| Registry version | `0.0.6` |
 | Original plugin version | `3.15.0` |
 | Original commit | `2b38897` |
 | License | `MIT` |

--- a/profiles/everyinc/compound-engineering-plugin/for-forgecat/README.md
+++ b/profiles/everyinc/compound-engineering-plugin/for-forgecat/README.md
@@ -62,6 +62,7 @@ npx forgecat install @forgecat/everyinc_compound-engineering-plugin
 |---|---|
 | Author | Kieran Klaassen and Trevin Chow |
 | Original repository | https://github.com/EveryInc/compound-engineering-plugin |
+| Registry version | `0.0.6` |
 | Original plugin version | `3.15.0` |
 | Original commit | `2b38897` |
 | License | `MIT` |


### PR DESCRIPTION
## Summary

Adds the current Registry version rows needed before two metadata-only compatibility patches can be prepared.

## Changes

- EveryInc Compound Engineering: add `Registry version: 0.0.6` to the catalog and canonical README tables.
- `im-not-ai`: add the standard Details table with current version `0.1.3` to the canonical README.

No platform claim, manifest, component, executable, or Registry entry changes in this PR.

## Verification

- Frozen version stamp check: 2/2 passed
- README catalog check: passed
- Profile artifact check: passed
- License evidence check: passed
- Changed files: 3

After this PR merges, the separate claims-only candidates will add the reviewed OpenClaw and Hermes rows and select new patch versions through a fresh Registry dry-run.
