### PR TITLE
profile: backfill two home compatibility claims

### DIFF
--- a/profiles/epoko77-ai/im-not-ai/README.md
+++ b/profiles/epoko77-ai/im-not-ai/README.md
@@ -36,7 +36,7 @@ npx forgecat install @forgecat/im-not-ai
 |---|---|
 | Author | epoko77-ai |
 | Original repository | https://github.com/epoko77-ai/im-not-ai |
-| Version | `0.1.3` |
+| Version | `0.1.4` |
 | Original commit | `53e24e8f92cf344efcb812103f7c2b203e7efffc` |
 | License | MIT |
 | Source platform | multi-host |
@@ -51,6 +51,7 @@ npx forgecat install @forgecat/im-not-ai
 | Cursor | Tested |
 | Codex | Tested |
 | OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 

--- a/profiles/epoko77-ai/im-not-ai/for-forgecat/README.md
+++ b/profiles/epoko77-ai/im-not-ai/for-forgecat/README.md
@@ -22,10 +22,23 @@ Upstream files are copied without editorial rewriting. The only change inside an
 |---|---|
 | Author | epoko77-ai |
 | Original repository | https://github.com/epoko77-ai/im-not-ai |
-| Version | `0.1.3` |
+| Version | `0.1.4` |
 | Original commit | `53e24e8f92cf344efcb812103f7c2b203e7efffc` |
 | License | MIT |
 | Source platform | multi-host |
+
+
+## Compatibility
+
+### Platforms
+
+| Platform | Status |
+|---|---|
+| Claude Code | Tested |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ---
 *written by original source*

--- a/profiles/epoko77-ai/im-not-ai/for-forgecat/profile.yml
+++ b/profiles/epoko77-ai/im-not-ai/for-forgecat/profile.yml
@@ -12,6 +12,7 @@ compatibility:
       - codex
     partial:
       - openclaw
+      - hermes
   models:
     recommended:
       - opus

--- a/profiles/everyinc/compound-engineering-plugin/README.md
+++ b/profiles/everyinc/compound-engineering-plugin/README.md
@@ -60,7 +60,7 @@ npx forgecat install @forgecat/everyinc_compound-engineering-plugin
 |---|---|
 | Author | Kieran Klaassen and Trevin Chow |
 | Original repository | https://github.com/EveryInc/compound-engineering-plugin |
-| Registry version | `0.0.6` |
+| Registry version | `0.0.7` |
 | Original plugin version | `3.15.0` |
 | Original commit | `2b38897` |
 | License | `MIT` |
@@ -75,6 +75,8 @@ npx forgecat install @forgecat/everyinc_compound-engineering-plugin
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 > Platform artifacts have been refreshed from the upstream skills-only plugin layout and are marked tested for Claude Code, Cursor, and Codex.
 

--- a/profiles/everyinc/compound-engineering-plugin/for-forgecat/README.md
+++ b/profiles/everyinc/compound-engineering-plugin/for-forgecat/README.md
@@ -62,7 +62,7 @@ npx forgecat install @forgecat/everyinc_compound-engineering-plugin
 |---|---|
 | Author | Kieran Klaassen and Trevin Chow |
 | Original repository | https://github.com/EveryInc/compound-engineering-plugin |
-| Registry version | `0.0.6` |
+| Registry version | `0.0.7` |
 | Original plugin version | `3.15.0` |
 | Original commit | `2b38897` |
 | License | `MIT` |
@@ -77,6 +77,8 @@ npx forgecat install @forgecat/everyinc_compound-engineering-plugin
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 > Platform artifacts have been refreshed from the upstream skills-only plugin layout and are marked tested for Claude Code, Cursor, and Codex.
 

--- a/profiles/everyinc/compound-engineering-plugin/for-forgecat/profile.yml
+++ b/profiles/everyinc/compound-engineering-plugin/for-forgecat/profile.yml
@@ -10,7 +10,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []


### PR DESCRIPTION
## Summary

Adds the remaining reviewed OpenClaw and Hermes compatibility rows to two existing profiles.

## Profiles

| Profile | Patch | Added status |
|---|---:|---|
| `@forgecat/everyinc_compound-engineering-plugin` | `0.0.7` | OpenClaw Partial, Hermes Partial |
| `@forgecat/im-not-ai` | `0.1.4` | Hermes Partial |

## Scope

- Existing Claude Code, Cursor, Codex, and OpenClaw claims stay unchanged.
- No component, executable, file mode, or install destination changes.
- The README version receipts move to the proposed patch versions.
- The Registry comparison records the version metadata normalized in Profile #182.

## Verification

- Claims-only verification: 2/2 passed
- Functional files unchanged: 262
- Install plans unchanged: 2/2
- Strict validation: 2/2 passed
- Baseline scan parity: 2/2 passed
- Public dry-run: 2/2 passed, 266 shipping files
- Independent conversion QA: `pass / ready`, no findings
- Converter: [forgecat-profile-converter#3](https://github.com/nota-america/forgecat-profile-converter/pull/3), commit `5a5358edd6b9d6b52da8a0e669b76824215e2994`
- Registry writes: none
