### PR TITLE
profiles: backfill home claims for 78 legacy profiles

### DIFF
--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-code-setup/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-code-setup/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_claude-code-se
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/claude-code-setup |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `cf62a6c` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -40,3 +40,5 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_claude-code-se
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-code-setup/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_claude-code-setup/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-code-setup/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_claude-code-setup/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_claude-code-se
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/claude-code-setup |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `cf62a6c` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-code-setup/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_claude-code-setup/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-code-setup/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_claude-code-setup/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_claude-code-se
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/claude-code-setup |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `cf62a6c` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-code-setup/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_claude-code-setup/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-code-setup/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_claude-code-setup/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_claude-code-se
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/claude-code-setup |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `cf62a6c` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-code-setup/for-forgecat/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-code-setup/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_claude-code-se
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/claude-code-setup |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `cf62a6c` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_claude-code-se
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ---
 *written by original source*

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-code-setup/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-code-setup/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/anthropics_claude-plugins-official_claude-code-setup"
-version: 0.0.4
 description: Analyze codebases and recommend tailored Claude Code automations such
   as hooks, skills, MCP servers, and subagents.
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/claude-code-setup
@@ -12,6 +11,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-md-management/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-md-management/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_claude-md-mana
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/claude-md-management |
-| Version | `0.0.3` |
+| Version | `0.0.4` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -44,3 +44,5 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_claude-md-mana
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Partial |
+| OpenClaw | Partial |
+| Hermes | Partial |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-md-management/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_claude-md-management/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-md-management/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_claude-md-management/README.md
@@ -32,7 +32,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_claude-md-mana
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/claude-md-management |
-| Version | `0.0.0` |
+| Version | `0.0.4` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-md-management/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_claude-md-management/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-md-management/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_claude-md-management/README.md
@@ -32,7 +32,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_claude-md-mana
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/claude-md-management |
-| Version | `0.0.0` |
+| Version | `0.0.4` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-md-management/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_claude-md-management/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-md-management/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_claude-md-management/README.md
@@ -32,7 +32,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_claude-md-mana
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/claude-md-management |
-| Version | `0.0.0` |
+| Version | `0.0.4` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-md-management/for-forgecat/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-md-management/for-forgecat/README.md
@@ -32,7 +32,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_claude-md-mana
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/claude-md-management |
-| Version | `0.0.3` |
+| Version | `0.0.4` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -46,6 +46,8 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_claude-md-mana
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Partial |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ---
 *written by original source*

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-md-management/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_claude-md-management/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/anthropics_claude-plugins-official_claude-md-management"
-version: 0.0.3
 description: Tools to maintain and improve CLAUDE.md files - audit quality, capture
   session learnings, and keep project memory current.
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/claude-md-management
@@ -13,6 +12,8 @@ compatibility:
       - cursor
     partial:
       - codex
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-review/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-review/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_code-review
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `cf62a6c` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -40,3 +40,5 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_code-review
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Partial |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-review/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_code-review/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-review/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_code-review/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_code-review
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review |
-| Version | `0.0.0` |
+| Version | `0.0.3` |
 | Original commit | `cf62a6c` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-review/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_code-review/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-review/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_code-review/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_code-review
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review |
-| Version | `0.0.0` |
+| Version | `0.0.3` |
 | Original commit | `cf62a6c` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-review/for-forgecat/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-review/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_code-review
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `cf62a6c` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_code-review
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Partial |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ---
 *written by original source*

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-review/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-review/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/anthropics_claude-plugins-official_code-review"
-version: 0.0.2
 description: Automated code review for pull requests using multiple specialized agents
   with confidence-based scoring
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review
@@ -13,6 +12,9 @@ compatibility:
       - cursor
     partial:
       - codex
+    unsupported:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-simplifier/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-simplifier/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_code-simplifie
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-simplifier |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -40,3 +40,5 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_code-simplifie
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-simplifier/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_code-simplifier/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-simplifier/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_code-simplifier/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_code-simplifie
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-simplifier |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-simplifier/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_code-simplifier/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-simplifier/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_code-simplifier/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_code-simplifie
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-simplifier |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-simplifier/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_code-simplifier/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-simplifier/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_code-simplifier/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_code-simplifie
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-simplifier |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-simplifier/for-forgecat/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-simplifier/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_code-simplifie
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-simplifier |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -42,3 +42,5 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_code-simplifie
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-simplifier/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_code-simplifier/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/anthropics_claude-plugins-official_code-simplifier"
-version: 0.0.4
 description: Agent that simplifies and refines code for clarity, consistency, and
   maintainability while preserving functionality
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-simplifier
@@ -12,6 +11,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    unsupported:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_commit-commands/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_commit-commands/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_commit-command
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/commit-commands |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `cf62a6c` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -42,3 +42,5 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_commit-command
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Partial |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_commit-commands/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_commit-commands/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_commit-commands/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_commit-commands/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_commit-command
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/commit-commands |
-| Version | `0.0.0` |
+| Version | `0.0.3` |
 | Original commit | `cf62a6c` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_commit-commands/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_commit-commands/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_commit-commands/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_commit-commands/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_commit-command
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/commit-commands |
-| Version | `0.0.0` |
+| Version | `0.0.3` |
 | Original commit | `cf62a6c` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_commit-commands/for-forgecat/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_commit-commands/for-forgecat/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_commit-command
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/commit-commands |
-| Version | `0.0.2` |
+| Version | `0.0.3` |
 | Original commit | `cf62a6c` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -44,6 +44,8 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_commit-command
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Partial |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ---
 *written by original source*

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_commit-commands/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_commit-commands/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/anthropics_claude-plugins-official_commit-commands"
-version: 0.0.2
 description: Streamline your git workflow with simple commands for committing, pushing,
   and creating pull requests
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/commit-commands
@@ -13,6 +12,9 @@ compatibility:
       - cursor
     partial:
       - codex
+    unsupported:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_example-plugin/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_example-plugin/README.md
@@ -31,7 +31,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_example-plugin
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/example-plugin |
-| Version | `0.0.3` |
+| Version | `0.0.4` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -45,3 +45,5 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_example-plugin
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Partial |
+| OpenClaw | Partial |
+| Hermes | Partial |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_example-plugin/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_example-plugin/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_example-plugin/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_example-plugin/README.md
@@ -33,7 +33,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_example-plugin
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/example-plugin |
-| Version | `0.0.0` |
+| Version | `0.0.4` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_example-plugin/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_example-plugin/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_example-plugin/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_example-plugin/README.md
@@ -33,7 +33,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_example-plugin
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/example-plugin |
-| Version | `0.0.0` |
+| Version | `0.0.4` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_example-plugin/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_example-plugin/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_example-plugin/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_example-plugin/README.md
@@ -33,7 +33,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_example-plugin
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/example-plugin |
-| Version | `0.0.0` |
+| Version | `0.0.4` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_example-plugin/for-forgecat/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_example-plugin/for-forgecat/README.md
@@ -33,7 +33,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_example-plugin
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/example-plugin |
-| Version | `0.0.3` |
+| Version | `0.0.4` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -47,6 +47,8 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_example-plugin
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Partial |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ---
 *written by original source*

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_example-plugin/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_example-plugin/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/anthropics_claude-plugins-official_example-plugin"
-version: 0.0.3
 description: A comprehensive example plugin demonstrating all Claude Code extension
   options including commands, agents, skills, hooks, and MCP servers
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/example-plugin
@@ -13,6 +12,8 @@ compatibility:
       - cursor
     partial:
       - codex
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_feature-dev/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_feature-dev/README.md
@@ -32,7 +32,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_feature-dev
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/feature-dev |
-| Version | `0.0.3` |
+| Version | `0.0.4` |
 | Original commit | `cf62a6c` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -46,3 +46,5 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_feature-dev
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Partial |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_feature-dev/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_feature-dev/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_feature-dev/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_feature-dev/README.md
@@ -34,7 +34,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_feature-dev
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/feature-dev |
-| Version | `0.0.0` |
+| Version | `0.0.4` |
 | Original commit | `cf62a6c` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_feature-dev/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_feature-dev/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_feature-dev/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_feature-dev/README.md
@@ -34,7 +34,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_feature-dev
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/feature-dev |
-| Version | `0.0.0` |
+| Version | `0.0.4` |
 | Original commit | `cf62a6c` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_feature-dev/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_feature-dev/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_feature-dev/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_feature-dev/README.md
@@ -34,7 +34,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_feature-dev
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/feature-dev |
-| Version | `0.0.0` |
+| Version | `0.0.4` |
 | Original commit | `cf62a6c` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_feature-dev/for-forgecat/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_feature-dev/for-forgecat/README.md
@@ -34,7 +34,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_feature-dev
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/feature-dev |
-| Version | `0.0.3` |
+| Version | `0.0.4` |
 | Original commit | `cf62a6c` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -48,6 +48,8 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_feature-dev
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Partial |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ---
 *written by original source*

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_feature-dev/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_feature-dev/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/anthropics_claude-plugins-official_feature-dev"
-version: 0.0.3
 description: Comprehensive feature development workflow with specialized agents for
   codebase exploration, architecture design, and quality review
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/feature-dev
@@ -13,6 +12,9 @@ compatibility:
       - cursor
     partial:
       - codex
+    unsupported:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_frontend-design/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_frontend-design/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_frontend-desig
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/frontend-design |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `cf62a6c` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -40,3 +40,5 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_frontend-desig
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_frontend-design/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_frontend-design/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_frontend-design/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_frontend-design/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_frontend-desig
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/frontend-design |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `cf62a6c` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_frontend-design/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_frontend-design/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_frontend-design/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_frontend-design/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_frontend-desig
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/frontend-design |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `cf62a6c` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_frontend-design/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_frontend-design/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_frontend-design/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_frontend-design/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_frontend-desig
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/frontend-design |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `cf62a6c` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_frontend-design/for-forgecat/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_frontend-design/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_frontend-desig
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/frontend-design |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `cf62a6c` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_frontend-desig
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ---
 *written by original source*

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_frontend-design/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_frontend-design/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/anthropics_claude-plugins-official_frontend-design"
-version: 0.0.4
 description: Frontend design skill for UI/UX implementation
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/frontend-design
 license: Apache-2.0
@@ -11,6 +10,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_mcp-server-dev/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_mcp-server-dev/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_mcp-server-dev
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/mcp-server-dev |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -42,3 +42,5 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_mcp-server-dev
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_mcp-server-dev/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_mcp-server-dev/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_mcp-server-dev/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_mcp-server-dev/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_mcp-server-dev
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/mcp-server-dev |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_mcp-server-dev/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_mcp-server-dev/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_mcp-server-dev/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_mcp-server-dev/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_mcp-server-dev
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/mcp-server-dev |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_mcp-server-dev/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_mcp-server-dev/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_mcp-server-dev/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_mcp-server-dev/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_mcp-server-dev
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/mcp-server-dev |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_mcp-server-dev/for-forgecat/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_mcp-server-dev/for-forgecat/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_mcp-server-dev
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/mcp-server-dev |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -44,6 +44,8 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_mcp-server-dev
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ---
 *written by original source*

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_mcp-server-dev/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_mcp-server-dev/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/anthropics_claude-plugins-official_mcp-server-dev"
-version: 0.0.4
 description: Skills for designing and building MCP servers that work seamlessly with
   Claude — guides you through deployment models (remote HTTP, MCPB, local), tool design
   patterns, auth, and interactive MCP apps.
@@ -13,6 +12,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_playground/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_playground/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_playground
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/playground |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -40,3 +40,5 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_playground
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_playground/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_playground/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_playground/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_playground/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_playground
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/playground |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_playground/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_playground/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_playground/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_playground/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_playground
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/playground |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_playground/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_playground/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_playground/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_playground/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_playground
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/playground |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_playground/for-forgecat/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_playground/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_playground
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/playground |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_playground
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ---
 *written by original source*

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_playground/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_playground/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/anthropics_claude-plugins-official_playground"
-version: 0.0.4
 description: Creates interactive HTML playgrounds — self-contained single-file explorers
   with visual controls, live preview, and prompt output with copy button
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/playground
@@ -12,6 +11,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_session-report/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_session-report/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_session-report
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/session-report |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -40,3 +40,5 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_session-report
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_session-report/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_session-report/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_session-report/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_session-report/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_session-report
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/session-report |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_session-report/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_session-report/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_session-report/for-codex/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_session-report/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_session-report
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/session-report |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_session-report/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_session-report/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_session-report/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_session-report/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_session-report
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/session-report |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_session-report/for-forgecat/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_session-report/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_session-report
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/claude-plugins-official/tree/main/plugins/session-report |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `7e401ed` |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -42,3 +42,5 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_session-report
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_session-report/for-forgecat/profile.yml
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_session-report/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/anthropics_claude-plugins-official_session-report"
-version: 0.0.4
 description: Generate an explorable HTML report of Claude Code session usage (tokens,
   cache, subagents, skills, expensive prompts) from ~/.claude/projects transcripts.
 repository: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/session-report
@@ -12,6 +11,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/anthropics/skills/anthropics_skills_doc-coauthoring/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_doc-coauthoring/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/anthropics_skills_doc-coauthoring
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `5128e18` |
 | License | MIT |
 | Source platform | Claude Code |
@@ -40,6 +40,8 @@ npx forgecat install @forgecat/anthropics_skills_doc-coauthoring
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/skills/anthropics_skills_doc-coauthoring/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_doc-coauthoring/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_doc-coauthoring/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_doc-coauthoring/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_skills_doc-coauthoring
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `5128e18` |
 | License | MIT |
 | Source platform | Claude Code |

--- a/profiles/anthropics/skills/anthropics_skills_doc-coauthoring/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_doc-coauthoring/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_doc-coauthoring/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_doc-coauthoring/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_skills_doc-coauthoring
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `5128e18` |
 | License | MIT |
 | Source platform | Claude Code |

--- a/profiles/anthropics/skills/anthropics_skills_doc-coauthoring/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_doc-coauthoring/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_doc-coauthoring/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_doc-coauthoring/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_skills_doc-coauthoring
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `5128e18` |
 | License | MIT |
 | Source platform | Claude Code |

--- a/profiles/anthropics/skills/anthropics_skills_doc-coauthoring/for-forgecat/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_doc-coauthoring/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_skills_doc-coauthoring
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `5128e18` |
 | License | MIT |
 | Source platform | Claude Code |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/anthropics_skills_doc-coauthoring
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/skills/anthropics_skills_doc-coauthoring/for-forgecat/profile.yml
+++ b/profiles/anthropics/skills/anthropics_skills_doc-coauthoring/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/anthropics_skills_doc-coauthoring"
-version: 0.0.4
 description: Guide users through a structured workflow for co-authoring documentation.
   Use when user wants to write documentation, proposals, technical specs, decision
   docs, or similar structured content. This workflow helps users efficiently transfer
@@ -16,6 +15,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/awslabs/aidlc-workflows/README.md
+++ b/profiles/awslabs/aidlc-workflows/README.md
@@ -36,7 +36,7 @@ npx forgecat install @forgecat/awslabs_aidlc-workflows
 |---|---|
 | Author | AWS Labs |
 | Original repository | https://github.com/awslabs/aidlc-workflows |
-| Version | `0.0.7` |
+| Version | `0.0.8` |
 | Original commit | 182b6e9edcbfca5357987ed22dccc8582ee52288 |
 | License | MIT-0 |
 | Source platform | Multi-agent rules (Claude Code, Cursor) |
@@ -50,6 +50,8 @@ npx forgecat install @forgecat/awslabs_aidlc-workflows
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ## Dependencies
 

--- a/profiles/awslabs/aidlc-workflows/for-claude/.forgecat/profiles/@forgecat/awslabs_aidlc-workflows/README.md
+++ b/profiles/awslabs/aidlc-workflows/for-claude/.forgecat/profiles/@forgecat/awslabs_aidlc-workflows/README.md
@@ -38,7 +38,7 @@ npx forgecat install @forgecat/awslabs_aidlc-workflows
 |---|---|
 | Author | AWS Labs |
 | Original repository | https://github.com/awslabs/aidlc-workflows |
-| Version | `0.0.3` |
+| Version | `0.0.8` |
 | Original commit | 182b6e9edcbfca5357987ed22dccc8582ee52288 |
 | License | MIT-0 |
 | Source platform | Multi-agent rules (Claude Code, Cursor) |

--- a/profiles/awslabs/aidlc-workflows/for-codex/.forgecat/profiles/@forgecat/awslabs_aidlc-workflows/README.md
+++ b/profiles/awslabs/aidlc-workflows/for-codex/.forgecat/profiles/@forgecat/awslabs_aidlc-workflows/README.md
@@ -38,7 +38,7 @@ npx forgecat install @forgecat/awslabs_aidlc-workflows
 |---|---|
 | Author | AWS Labs |
 | Original repository | https://github.com/awslabs/aidlc-workflows |
-| Version | `0.0.3` |
+| Version | `0.0.8` |
 | Original commit | 182b6e9edcbfca5357987ed22dccc8582ee52288 |
 | License | MIT-0 |
 | Source platform | Multi-agent rules (Claude Code, Cursor) |

--- a/profiles/awslabs/aidlc-workflows/for-cursor/.forgecat/profiles/@forgecat/awslabs_aidlc-workflows/README.md
+++ b/profiles/awslabs/aidlc-workflows/for-cursor/.forgecat/profiles/@forgecat/awslabs_aidlc-workflows/README.md
@@ -38,7 +38,7 @@ npx forgecat install @forgecat/awslabs_aidlc-workflows
 |---|---|
 | Author | AWS Labs |
 | Original repository | https://github.com/awslabs/aidlc-workflows |
-| Version | `0.0.3` |
+| Version | `0.0.8` |
 | Original commit | 182b6e9edcbfca5357987ed22dccc8582ee52288 |
 | License | MIT-0 |
 | Source platform | Multi-agent rules (Claude Code, Cursor) |

--- a/profiles/awslabs/aidlc-workflows/for-forgecat/README.md
+++ b/profiles/awslabs/aidlc-workflows/for-forgecat/README.md
@@ -38,7 +38,7 @@ npx forgecat install @forgecat/awslabs_aidlc-workflows
 |---|---|
 | Author | AWS Labs |
 | Original repository | https://github.com/awslabs/aidlc-workflows |
-| Version | `0.0.7` |
+| Version | `0.0.8` |
 | Original commit | 182b6e9edcbfca5357987ed22dccc8582ee52288 |
 | License | MIT-0 |
 | Source platform | Multi-agent rules (Claude Code, Cursor) |
@@ -52,6 +52,8 @@ npx forgecat install @forgecat/awslabs_aidlc-workflows
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ## Dependencies
 

--- a/profiles/awslabs/aidlc-workflows/for-forgecat/profile.yml
+++ b/profiles/awslabs/aidlc-workflows/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/awslabs_aidlc-workflows"
-version: 0.0.7
 description: AI-DLC adaptive workflow rules profile for project-level agent guidance
   and stage-by-stage software delivery.
 repository: https://github.com/awslabs/aidlc-workflows
@@ -12,6 +11,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    unsupported:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/cursor/plugins/cursor_plugins_team-kit/README.md
+++ b/profiles/cursor/plugins/cursor_plugins_team-kit/README.md
@@ -37,7 +37,7 @@ npx forgecat install @forgecat/cursor_plugins_team-kit
 |---|---|
 | Author | `Cursor` |
 | Original repository | `https://github.com/cursor/plugins` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `9c39b57` (2026-03-13) |
 | License | `MIT` |
 | Source platform | `cursor` |
@@ -50,6 +50,8 @@ npx forgecat install @forgecat/cursor_plugins_team-kit
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/cursor/plugins/cursor_plugins_team-kit/for-claude/.forgecat/profiles/@forgecat/cursor_plugins_team-kit/README.md
+++ b/profiles/cursor/plugins/cursor_plugins_team-kit/for-claude/.forgecat/profiles/@forgecat/cursor_plugins_team-kit/README.md
@@ -39,7 +39,7 @@ npx forgecat install @forgecat/cursor-team-kit
 |---|---|
 | Author | `Cursor` |
 | Original repository | `https://github.com/cursor/plugins` |
-| Version | `0.0.5` |
+| Version | `0.0.11` |
 | Original commit | `9c39b57` (2026-03-13) |
 | License | `MIT` |
 | Source platform | `cursor` |

--- a/profiles/cursor/plugins/cursor_plugins_team-kit/for-codex/.forgecat/profiles/@forgecat/cursor_plugins_team-kit/README.md
+++ b/profiles/cursor/plugins/cursor_plugins_team-kit/for-codex/.forgecat/profiles/@forgecat/cursor_plugins_team-kit/README.md
@@ -39,7 +39,7 @@ npx forgecat install @forgecat/cursor-team-kit
 |---|---|
 | Author | `Cursor` |
 | Original repository | `https://github.com/cursor/plugins` |
-| Version | `0.0.5` |
+| Version | `0.0.11` |
 | Original commit | `9c39b57` (2026-03-13) |
 | License | `MIT` |
 | Source platform | `cursor` |

--- a/profiles/cursor/plugins/cursor_plugins_team-kit/for-cursor/.forgecat/profiles/@forgecat/cursor_plugins_team-kit/README.md
+++ b/profiles/cursor/plugins/cursor_plugins_team-kit/for-cursor/.forgecat/profiles/@forgecat/cursor_plugins_team-kit/README.md
@@ -39,7 +39,7 @@ npx forgecat install @forgecat/cursor-team-kit
 |---|---|
 | Author | `Cursor` |
 | Original repository | `https://github.com/cursor/plugins` |
-| Version | `0.0.5` |
+| Version | `0.0.11` |
 | Original commit | `9c39b57` (2026-03-13) |
 | License | `MIT` |
 | Source platform | `cursor` |

--- a/profiles/cursor/plugins/cursor_plugins_team-kit/for-forgecat/README.md
+++ b/profiles/cursor/plugins/cursor_plugins_team-kit/for-forgecat/README.md
@@ -39,7 +39,7 @@ npx forgecat install @forgecat/cursor-team-kit
 |---|---|
 | Author | `Cursor` |
 | Original repository | `https://github.com/cursor/plugins` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `9c39b57` (2026-03-13) |
 | License | `MIT` |
 | Source platform | `cursor` |
@@ -52,6 +52,8 @@ npx forgecat install @forgecat/cursor-team-kit
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/cursor/plugins/cursor_plugins_team-kit/for-forgecat/profile.yml
+++ b/profiles/cursor/plugins/cursor_plugins_team-kit/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/cursor_plugins_team-kit"
-version: 0.0.10
 description: 'Internal workflows used by Cursor developers for CI, code review, and
   shipping. Covers the full dev loop: CI monitoring and fixing, PR creation, merge
   conflicts, smoke tests, compiler checks, code cleanup, and work summaries.'
@@ -13,6 +12,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-appinsights-instrumentation/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-appinsights-instrumentation/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-appinsights-instrumentatio
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -40,6 +40,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-appinsights-instrumentatio
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-appinsights-instrumentation/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-appinsights-instrumentation/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-appinsights-instrumentation/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-appinsights-instrumentation/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-appinsights-instrumentatio
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-appinsights-instrumentation/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-appinsights-instrumentation/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-appinsights-instrumentation/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-appinsights-instrumentation/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-appinsights-instrumentatio
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-appinsights-instrumentation/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-appinsights-instrumentation/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-appinsights-instrumentation/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-appinsights-instrumentation/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-appinsights-instrumentatio
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-appinsights-instrumentation/for-forgecat/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-appinsights-instrumentation/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-appinsights-instrumentatio
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-appinsights-instrumentatio
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-appinsights-instrumentation/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-appinsights-instrumentation/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/microsoft-azure_skills-appinsights-instrumentation"
-version: 0.0.4
 description: 'Guidance for instrumenting webapps with Azure Application Insights.
   Provides telemetry patterns, SDK setup, and configuration references. WHEN: how
   to instrument app, App Insights SDK, telemetry patterns, what is App Insights, Application
@@ -14,6 +13,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-ai/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-ai/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-ai
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -40,6 +40,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-ai
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-ai/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-ai/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-ai/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-ai/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-ai
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-ai/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-ai/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-ai/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-ai/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-ai
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-ai/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-ai/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-ai/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-ai/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-ai
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-ai/for-forgecat/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-ai/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-ai
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-ai
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-ai/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-ai/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/microsoft-azure_skills-azure-ai"
-version: 0.0.4
 description: 'Use for Azure AI: Search, Speech, OpenAI, Document Intelligence. Helps
   with search, vector/hybrid search, speech-to-text, text-to-speech, transcription,
   OCR. WHEN: AI Search, query search, vector search, hybrid search, semantic search,
@@ -14,6 +13,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-aigateway/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-aigateway/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-aigateway
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -40,6 +40,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-aigateway
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-aigateway/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-aigateway/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-aigateway/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-aigateway/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-aigateway
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-aigateway/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-aigateway/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-aigateway/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-aigateway/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-aigateway
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-aigateway/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-aigateway/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-aigateway/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-aigateway/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-aigateway
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-aigateway/for-forgecat/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-aigateway/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-aigateway
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-aigateway
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-aigateway/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-aigateway/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/microsoft-azure_skills-azure-aigateway"
-version: 0.0.4
 description: 'Configure Azure API Management as an AI Gateway for AI models, MCP tools,
   and agents. WHEN: semantic caching, token limit, content safety, load balancing,
   AI model governance, MCP rate limiting, jailbreak detection, add Azure OpenAI backend,
@@ -15,6 +14,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-compliance/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-compliance/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-compliance
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -40,6 +40,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-compliance
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-compliance/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-compliance/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-compliance/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-compliance/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-compliance
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-compliance/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-compliance/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-compliance/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-compliance/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-compliance
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-compliance/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-compliance/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-compliance/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-compliance/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-compliance
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-compliance/for-forgecat/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-compliance/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-compliance
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-compliance
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-compliance/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-compliance/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/microsoft-azure_skills-azure-compliance"
-version: 0.0.4
 description: 'Run Azure compliance and security audits with azqr plus Key Vault expiration
   checks. Covers best-practice assessment, resource review, policy/compliance validation,
   and security posture checks. WHEN: compliance scan, security audit, BEFORE running
@@ -15,6 +14,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-cost-optimization/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-cost-optimization/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-cost-optimization
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -40,6 +40,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-cost-optimization
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-cost-optimization/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-cost-optimization/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-cost-optimization/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-cost-optimization/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-cost-optimization
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-cost-optimization/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-cost-optimization/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-cost-optimization/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-cost-optimization/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-cost-optimization
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-cost-optimization/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-cost-optimization/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-cost-optimization/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-cost-optimization/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-cost-optimization
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-cost-optimization/for-forgecat/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-cost-optimization/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-cost-optimization
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-cost-optimization
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-cost-optimization/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-cost-optimization/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/microsoft-azure_skills-azure-cost-optimization"
-version: 0.0.4
 description: 'Unified Azure cost management: query historical costs, forecast future
   spending, and optimize to reduce waste. WHEN: "Azure costs", "Azure spending", "Azure
   bill", "cost breakdown", "cost by service", "cost by resource", "how much am I spending",
@@ -22,6 +21,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-deploy/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-deploy/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-deploy
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -40,6 +40,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-deploy
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-deploy/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-deploy/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-deploy/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-deploy/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-deploy
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-deploy/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-deploy/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-deploy/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-deploy/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-deploy
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-deploy/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-deploy/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-deploy/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-deploy/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-deploy
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-deploy/for-forgecat/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-deploy/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-deploy
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-deploy
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-deploy/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-deploy/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/microsoft-azure_skills-azure-deploy"
-version: 0.0.4
 description: 'Execute Azure deployments for ALREADY-PREPARED applications that have
   existing .azure/deployment-plan.md and infrastructure files. DO NOT use this skill
   when the user asks to CREATE a new application — use azure-prepare instead. This
@@ -20,6 +19,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-diagnostics/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-diagnostics/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-diagnostics
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -40,6 +40,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-diagnostics
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-diagnostics/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-diagnostics/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-diagnostics/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-diagnostics/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-diagnostics
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-diagnostics/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-diagnostics/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-diagnostics/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-diagnostics/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-diagnostics
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-diagnostics/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-diagnostics/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-diagnostics/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-diagnostics/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-diagnostics
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-diagnostics/for-forgecat/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-diagnostics/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-diagnostics
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-diagnostics
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-diagnostics/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-diagnostics/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/microsoft-azure_skills-azure-diagnostics"
-version: 0.0.4
 description: 'Debug Azure production issues on Azure using AppLens, Azure Monitor,
   resource health, and safe triage. WHEN: debug production issues, troubleshoot app
   service, app service high CPU, app service deployment failure, troubleshoot container
@@ -19,6 +18,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-hosted-copilot-sdk/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-hosted-copilot-sdk/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-hosted-copilot-sdk
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -40,6 +40,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-hosted-copilot-sdk
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-hosted-copilot-sdk/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-hosted-copilot-sdk/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-hosted-copilot-sdk/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-hosted-copilot-sdk/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-hosted-copilot-sdk
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-hosted-copilot-sdk/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-hosted-copilot-sdk/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-hosted-copilot-sdk/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-hosted-copilot-sdk/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-hosted-copilot-sdk
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-hosted-copilot-sdk/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-hosted-copilot-sdk/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-hosted-copilot-sdk/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-hosted-copilot-sdk/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-hosted-copilot-sdk
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-hosted-copilot-sdk/for-forgecat/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-hosted-copilot-sdk/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-hosted-copilot-sdk
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-hosted-copilot-sdk
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-hosted-copilot-sdk/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-hosted-copilot-sdk/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/microsoft-azure_skills-azure-hosted-copilot-sdk"
-version: 0.0.4
 description: 'Build, deploy, modify GitHub Copilot SDK apps on Azure. MANDATORY when
   codebase contains @github/copilot-sdk or CopilotClient — use this skill instead
   of azure-prepare. PREFER OVER azure-prepare when codebase contains copilot-sdk markers.
@@ -17,6 +16,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-kusto/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-kusto/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-kusto
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -40,6 +40,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-kusto
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-kusto/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-kusto/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-kusto/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-kusto/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-kusto
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-kusto/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-kusto/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-kusto/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-kusto/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-kusto
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-kusto/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-kusto/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-kusto/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-kusto/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-kusto
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-kusto/for-forgecat/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-kusto/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-kusto
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-kusto
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-kusto/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-kusto/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/microsoft-azure_skills-azure-kusto"
-version: 0.0.4
 description: 'Query and analyze data in Azure Data Explorer (Kusto/ADX) using KQL
   for log analytics, telemetry, and time series analysis. WHEN: KQL queries, Kusto
   database queries, Azure Data Explorer, ADX clusters, log analytics, time series
@@ -14,6 +13,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-messaging/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-messaging/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-messaging
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -40,6 +40,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-messaging
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-messaging/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-messaging/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-messaging/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-messaging/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-messaging
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-messaging/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-messaging/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-messaging/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-messaging/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-messaging
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-messaging/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-messaging/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-messaging/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-messaging/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-messaging
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-messaging/for-forgecat/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-messaging/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-messaging
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-messaging
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-messaging/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-messaging/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/microsoft-azure_skills-azure-messaging"
-version: 0.0.4
 description: 'Troubleshoot and resolve issues with Azure Messaging SDKs for Event
   Hubs and Service Bus. Covers connection failures, authentication errors, message
   processing issues, and SDK configuration problems. WHEN: event hub SDK error, service
@@ -22,6 +21,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-observability/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-observability/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-observability
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -40,6 +40,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-observability
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-observability/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-observability/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-observability/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-observability/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-observability
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-observability/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-observability/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-observability/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-observability/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-observability
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-observability/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-observability/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-observability/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-observability/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-observability
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-observability/for-forgecat/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-observability/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-observability
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-observability
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-observability/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-observability/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/microsoft-azure_skills-azure-observability"
-version: 0.0.4
 description: 'Debug Azure production issues on Azure using AppLens, Azure Monitor,
   resource health, and safe triage. WHEN: debug production issues, troubleshoot app
   service, app service high CPU, app service deployment failure, troubleshoot container
@@ -19,6 +18,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-prepare/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-prepare/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-prepare
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -40,6 +40,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-prepare
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-prepare/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-prepare/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-prepare/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-prepare/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-prepare
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-prepare/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-prepare/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-prepare/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-prepare/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-prepare
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-prepare/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-prepare/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-prepare/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-prepare/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-prepare
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-prepare/for-forgecat/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-prepare/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-prepare
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-prepare
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-prepare/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-prepare/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/microsoft-azure_skills-azure-prepare"
-version: 0.0.4
 description: 'Prepare Azure apps for deployment (infra Bicep/Terraform, azure.yaml,
   Dockerfiles). Use for create/modernize or create+deploy; not cross-cloud migration
   (use azure-cloud-migrate). WHEN: "create app", "build web app", "create API", "create
@@ -22,6 +21,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-rbac/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-rbac/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-rbac
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -40,6 +40,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-rbac
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-rbac/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-rbac/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-rbac/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-rbac/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-rbac
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-rbac/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-rbac/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-rbac/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-rbac/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-rbac
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-rbac/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-rbac/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-rbac/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-rbac/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-rbac
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-rbac/for-forgecat/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-rbac/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-rbac
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-rbac
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-rbac/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-rbac/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/microsoft-azure_skills-azure-rbac"
-version: 0.0.4
 description: 'Helps users find the right Azure RBAC role for an identity with least
   privilege access, then generate CLI commands and Bicep code to assign it. Also provides
   guidance on permissions required to grant roles. WHEN: bicep for role assignment,
@@ -16,6 +15,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-lookup/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-lookup/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-resource-lookup
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -40,6 +40,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-resource-lookup
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-lookup/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-resource-lookup/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-lookup/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-resource-lookup/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-resource-lookup
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-lookup/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-resource-lookup/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-lookup/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-resource-lookup/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-resource-lookup
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-lookup/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-resource-lookup/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-lookup/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-resource-lookup/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-resource-lookup
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-lookup/for-forgecat/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-lookup/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-resource-lookup
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-resource-lookup
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-lookup/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-lookup/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/microsoft-azure_skills-azure-resource-lookup"
-version: 0.0.4
 description: 'List, find, and show Azure resources across subscriptions or resource
   groups. Handles prompts like "list the websites in my subscription", "list my web
   apps", "show my app services", "list virtual machines", "list my VMs", "show storage
@@ -19,6 +18,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-visualizer/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-visualizer/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-resource-visualizer
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -40,6 +40,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-resource-visualizer
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-visualizer/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-resource-visualizer/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-visualizer/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-resource-visualizer/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-resource-visualizer
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-visualizer/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-resource-visualizer/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-visualizer/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-resource-visualizer/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-resource-visualizer
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-visualizer/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-resource-visualizer/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-visualizer/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-resource-visualizer/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-resource-visualizer
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-visualizer/for-forgecat/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-visualizer/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-resource-visualizer
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-resource-visualizer
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-visualizer/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-resource-visualizer/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/microsoft-azure_skills-azure-resource-visualizer"
-version: 0.0.4
 description: 'Analyze Azure resource groups and generate detailed Mermaid architecture
   diagrams showing the relationships between individual resources. WHEN: create architecture
   diagram, visualize Azure resources, show resource relationships, generate Mermaid
@@ -15,6 +14,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-storage/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-storage/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-storage
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -40,6 +40,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-storage
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-storage/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-storage/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-storage/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-storage/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-storage
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-storage/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-storage/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-storage/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-storage/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-storage
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-storage/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-storage/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-storage/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-storage/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-storage
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-storage/for-forgecat/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-storage/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-storage
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-storage
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-storage/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-storage/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/microsoft-azure_skills-azure-storage"
-version: 0.0.4
 description: 'Azure Storage Services including Blob Storage, File Shares, Queue Storage,
   Table Storage, and Data Lake. Answers questions about storage access tiers (hot,
   cool, cold, archive), when to use each tier, and tier comparison. Provides object
@@ -20,6 +19,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-validate/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-validate/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-validate
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -40,6 +40,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-validate
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-validate/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-validate/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-validate/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-validate/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-validate
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-validate/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-validate/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-validate/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-validate/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-validate
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-validate/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-validate/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-validate/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-azure-validate/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-validate
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-validate/for-forgecat/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-validate/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-validate
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-azure-validate
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-validate/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-azure-validate/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/microsoft-azure_skills-azure-validate"
-version: 0.0.4
 description: 'Pre-deployment validation for Azure readiness. Run deep checks on configuration,
   infrastructure (Bicep or Terraform), RBAC role assignments, managed identity permissions,
   and prerequisites before deploying. WHEN: validate my app, check deployment readiness,
@@ -18,6 +17,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-microsoft-foundry/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-microsoft-foundry/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-microsoft-foundry
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -40,6 +40,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-microsoft-foundry
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-microsoft-foundry/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-microsoft-foundry/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-microsoft-foundry/for-claude/.forgecat/profiles/@forgecat/microsoft-azure_skills-microsoft-foundry/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-microsoft-foundry
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-microsoft-foundry/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-microsoft-foundry/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-microsoft-foundry/for-codex/.forgecat/profiles/@forgecat/microsoft-azure_skills-microsoft-foundry/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-microsoft-foundry
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-microsoft-foundry/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-microsoft-foundry/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-microsoft-foundry/for-cursor/.forgecat/profiles/@forgecat/microsoft-azure_skills-microsoft-foundry/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-microsoft-foundry
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.0` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-microsoft-foundry/for-forgecat/README.md
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-microsoft-foundry/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/microsoft-azure_skills-microsoft-foundry
 |---|---|
 | Author | Microsoft |
 | Original repository | https://github.com/microsoft/azure-skills |
-| Version | `0.0.4` |
+| Version | `0.0.5` |
 | Original commit | `a990650` |
 | License | MIT |
 | Source platform | Claude Code, Cursor |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/microsoft-azure_skills-microsoft-foundry
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/microsoft/azure-skills/microsoft-azure_skills-microsoft-foundry/for-forgecat/profile.yml
+++ b/profiles/microsoft/azure-skills/microsoft-azure_skills-microsoft-foundry/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/microsoft-azure_skills-microsoft-foundry"
-version: 0.0.4
 description: 'Deploy, evaluate, and manage Foundry agents end-to-end: Docker build,
   ACR push, hosted/prompt agent create, container start, batch eval, continuous eval,
   prompt optimizer workflows, agent.yaml, dataset curation from traces. USE FOR: deploy
@@ -23,6 +22,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-academic/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-academic/README.md
@@ -25,7 +25,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-academic
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -38,6 +38,8 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-academic
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-academic/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-academic/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-academic/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-academic/README.md
@@ -27,7 +27,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-academic
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-academic/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-academic/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-academic/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-academic/README.md
@@ -27,7 +27,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-academic
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-academic/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-academic/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-academic/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-academic/README.md
@@ -27,7 +27,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-academic
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-academic/for-forgecat/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-academic/for-forgecat/README.md
@@ -27,7 +27,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-academic
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -40,6 +40,8 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-academic
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-academic/for-forgecat/profile.yml
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-academic/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/msitarzewski_agency-agents_agency-academic"
-version: 0.0.10
 description: Academic division from The Agency — 5 specialized academic agent personalities
   from msitarzewski/agency-agents.
 repository: https://github.com/msitarzewski/agency-agents
@@ -12,6 +11,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    unsupported:
+      - openclaw
+      - hermes
   models:
     recommended:
     - claude-4-opus

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-design/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-design/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-design
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.11` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -41,6 +41,8 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-design
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-design/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-design/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-design/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-design/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-design
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-design/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-design/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-design/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-design/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-design
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-design/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-design/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-design/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-design/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-design
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-design/for-forgecat/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-design/for-forgecat/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-design
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.11` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -43,6 +43,8 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-design
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-design/for-forgecat/profile.yml
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-design/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/msitarzewski_agency-agents_agency-design"
-version: 0.0.11
 description: Design division from The Agency — 8 specialized agent personalities from
   msitarzewski/agency-agents. Each agent has deep domain expertise, unique personality,
   and production-ready workflows.
@@ -13,6 +12,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    unsupported:
+      - openclaw
+      - hermes
   models:
     recommended:
     - claude-4-opus

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-game-development/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-game-development/README.md
@@ -40,7 +40,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-game-developmen
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.11` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -53,6 +53,8 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-game-developmen
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-game-development/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-game-development/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-game-development/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-game-development/README.md
@@ -42,7 +42,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-game-developmen
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-game-development/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-game-development/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-game-development/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-game-development/README.md
@@ -42,7 +42,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-game-developmen
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-game-development/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-game-development/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-game-development/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-game-development/README.md
@@ -42,7 +42,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-game-developmen
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-game-development/for-forgecat/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-game-development/for-forgecat/README.md
@@ -42,7 +42,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-game-developmen
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.11` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -55,6 +55,8 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-game-developmen
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-game-development/for-forgecat/profile.yml
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-game-development/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/msitarzewski_agency-agents_agency-game-development"
-version: 0.0.11
 description: Game Development division from The Agency — 20 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise, unique personality,
   and production-ready workflows.
@@ -13,6 +12,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    unsupported:
+      - openclaw
+      - hermes
   models:
     recommended:
     - claude-4-opus

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-marketing/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-marketing/README.md
@@ -47,7 +47,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-marketing
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.11` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -60,6 +60,8 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-marketing
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-marketing/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-marketing/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-marketing/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-marketing/README.md
@@ -49,7 +49,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-marketing
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-marketing/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-marketing/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-marketing/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-marketing/README.md
@@ -49,7 +49,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-marketing
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-marketing/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-marketing/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-marketing/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-marketing/README.md
@@ -49,7 +49,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-marketing
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-marketing/for-forgecat/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-marketing/for-forgecat/README.md
@@ -49,7 +49,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-marketing
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.11` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -62,6 +62,8 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-marketing
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-marketing/for-forgecat/profile.yml
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-marketing/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/msitarzewski_agency-agents_agency-marketing"
-version: 0.0.11
 description: Marketing division from The Agency — 27 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise, unique personality,
   and production-ready workflows.
@@ -13,6 +12,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    unsupported:
+      - openclaw
+      - hermes
   models:
     recommended:
     - claude-4-opus

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-paid-media/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-paid-media/README.md
@@ -27,7 +27,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-paid-media
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.11` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -40,6 +40,8 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-paid-media
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-paid-media/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-paid-media/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-paid-media/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-paid-media/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-paid-media
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-paid-media/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-paid-media/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-paid-media/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-paid-media/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-paid-media
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-paid-media/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-paid-media/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-paid-media/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-paid-media/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-paid-media
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-paid-media/for-forgecat/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-paid-media/for-forgecat/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-paid-media
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.11` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-paid-media
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-paid-media/for-forgecat/profile.yml
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-paid-media/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/msitarzewski_agency-agents_agency-paid-media"
-version: 0.0.11
 description: Paid Media division from The Agency — 7 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise, unique personality,
   and production-ready workflows.
@@ -13,6 +12,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    unsupported:
+      - openclaw
+      - hermes
   models:
     recommended:
     - claude-4-opus

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-product/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-product/README.md
@@ -25,7 +25,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-product
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.11` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -38,6 +38,8 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-product
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-product/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-product/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-product/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-product/README.md
@@ -27,7 +27,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-product
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-product/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-product/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-product/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-product/README.md
@@ -27,7 +27,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-product
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-product/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-product/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-product/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-product/README.md
@@ -27,7 +27,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-product
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-product/for-forgecat/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-product/for-forgecat/README.md
@@ -27,7 +27,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-product
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.11` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -40,6 +40,8 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-product
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-product/for-forgecat/profile.yml
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-product/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/msitarzewski_agency-agents_agency-product"
-version: 0.0.11
 description: Product division from The Agency — 5 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise, unique personality,
   and production-ready workflows.
@@ -13,6 +12,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    unsupported:
+      - openclaw
+      - hermes
   models:
     recommended:
     - claude-4-opus

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-project-management/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-project-management/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-project-managem
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.11` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -39,6 +39,8 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-project-managem
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-project-management/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-project-management/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-project-management/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-project-management/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-project-managem
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-project-management/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-project-management/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-project-management/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-project-management/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-project-managem
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-project-management/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-project-management/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-project-management/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-project-management/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-project-managem
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-project-management/for-forgecat/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-project-management/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-project-managem
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.11` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -41,6 +41,8 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-project-managem
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-project-management/for-forgecat/profile.yml
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-project-management/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/msitarzewski_agency-agents_agency-project-management"
-version: 0.0.11
 description: Project Management division from The Agency — 6 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise, unique personality,
   and production-ready workflows.
@@ -13,6 +12,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    unsupported:
+      - openclaw
+      - hermes
   models:
     recommended:
     - claude-4-opus

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-sales/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-sales/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-sales
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.11` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -41,6 +41,8 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-sales
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-sales/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-sales/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-sales/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-sales/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-sales
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-sales/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-sales/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-sales/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-sales/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-sales
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-sales/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-sales/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-sales/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-sales/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-sales
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-sales/for-forgecat/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-sales/for-forgecat/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-sales
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.11` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -43,6 +43,8 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-sales
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-sales/for-forgecat/profile.yml
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-sales/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/msitarzewski_agency-agents_agency-sales"
-version: 0.0.11
 description: Sales division from The Agency — 8 specialized agent personalities from
   msitarzewski/agency-agents. Each agent has deep domain expertise, unique personality,
   and production-ready workflows.
@@ -13,6 +12,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    unsupported:
+      - openclaw
+      - hermes
   models:
     recommended:
     - claude-4-opus

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-spatial-computing/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-spatial-computing/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-spatial-computi
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.11` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -39,6 +39,8 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-spatial-computi
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-spatial-computing/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-spatial-computing/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-spatial-computing/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-spatial-computing/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-spatial-computi
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-spatial-computing/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-spatial-computing/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-spatial-computing/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-spatial-computing/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-spatial-computi
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-spatial-computing/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-spatial-computing/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-spatial-computing/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-spatial-computing/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-spatial-computi
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-spatial-computing/for-forgecat/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-spatial-computing/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-spatial-computi
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.11` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -41,6 +41,8 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-spatial-computi
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-spatial-computing/for-forgecat/profile.yml
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-spatial-computing/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/msitarzewski_agency-agents_agency-spatial-computing"
-version: 0.0.11
 description: Spatial Computing division from The Agency — 6 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise, unique personality,
   and production-ready workflows.
@@ -13,6 +12,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    unsupported:
+      - openclaw
+      - hermes
   models:
     recommended:
     - claude-4-opus

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-support/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-support/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-support
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.11` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -39,6 +39,8 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-support
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-support/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-support/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-support/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-support/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-support
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-support/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-support/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-support/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-support/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-support
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-support/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-support/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-support/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-support/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-support
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.7` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-support/for-forgecat/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-support/for-forgecat/README.md
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-support
 |---|---|
 | Author | `msitarzewski` |
 | Original repository | `https://github.com/msitarzewski/agency-agents` |
-| Version | `0.0.11` |
+| Version | `0.0.12` |
 | Original commit | `9c31d86` (2026-03-23) |
 | License | `MIT` |
 | Source platform | `claude-code` |
@@ -41,6 +41,8 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-support
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-support/for-forgecat/profile.yml
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-support/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/msitarzewski_agency-agents_agency-support"
-version: 0.0.11
 description: Support division from The Agency — 6 specialized agent personalities
   from msitarzewski/agency-agents. Each agent has deep domain expertise, unique personality,
   and production-ready workflows.
@@ -13,6 +12,9 @@ compatibility:
       - claude-code
       - cursor
       - codex
+    unsupported:
+      - openclaw
+      - hermes
   models:
     recommended:
     - claude-4-opus

--- a/profiles/openai/skills/openai_skills_aspnet-core/README.md
+++ b/profiles/openai/skills/openai_skills_aspnet-core/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai_skills_aspnet-core
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx forgecat install @forgecat/openai_skills_aspnet-core
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_aspnet-core/for-claude/.forgecat/profiles/@forgecat/openai_skills_aspnet-core/README.md
+++ b/profiles/openai/skills/openai_skills_aspnet-core/for-claude/.forgecat/profiles/@forgecat/openai_skills_aspnet-core/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_aspnet-core
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_aspnet-core/for-codex/.forgecat/profiles/@forgecat/openai_skills_aspnet-core/README.md
+++ b/profiles/openai/skills/openai_skills_aspnet-core/for-codex/.forgecat/profiles/@forgecat/openai_skills_aspnet-core/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_aspnet-core
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_aspnet-core/for-cursor/.forgecat/profiles/@forgecat/openai_skills_aspnet-core/README.md
+++ b/profiles/openai/skills/openai_skills_aspnet-core/for-cursor/.forgecat/profiles/@forgecat/openai_skills_aspnet-core/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_aspnet-core
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_aspnet-core/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_aspnet-core/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_aspnet-core
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx forgecat install @forgecat/openai_skills_aspnet-core
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_aspnet-core/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_aspnet-core/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_aspnet-core"
-version: 0.0.10
 description: Build, review, refactor, or architect ASP.NET Core web applications using
   current official guidance for .NET web development. Use when working on Blazor Web
   Apps, Razor Pages, MVC, Minimal APIs, controller-based Web APIs, SignalR, gRPC,
@@ -15,7 +14,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_chatgpt-apps/README.md
+++ b/profiles/openai/skills/openai_skills_chatgpt-apps/README.md
@@ -24,7 +24,7 @@ npx forgecat install @forgecat/openai_skills_chatgpt-apps
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -37,6 +37,8 @@ npx forgecat install @forgecat/openai_skills_chatgpt-apps
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_chatgpt-apps/for-claude/.forgecat/profiles/@forgecat/openai_skills_chatgpt-apps/README.md
+++ b/profiles/openai/skills/openai_skills_chatgpt-apps/for-claude/.forgecat/profiles/@forgecat/openai_skills_chatgpt-apps/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai_skills_chatgpt-apps
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_chatgpt-apps/for-codex/.forgecat/profiles/@forgecat/openai_skills_chatgpt-apps/README.md
+++ b/profiles/openai/skills/openai_skills_chatgpt-apps/for-codex/.forgecat/profiles/@forgecat/openai_skills_chatgpt-apps/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai_skills_chatgpt-apps
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_chatgpt-apps/for-cursor/.forgecat/profiles/@forgecat/openai_skills_chatgpt-apps/README.md
+++ b/profiles/openai/skills/openai_skills_chatgpt-apps/for-cursor/.forgecat/profiles/@forgecat/openai_skills_chatgpt-apps/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai_skills_chatgpt-apps
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_chatgpt-apps/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_chatgpt-apps/for-forgecat/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai_skills_chatgpt-apps
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -39,6 +39,8 @@ npx forgecat install @forgecat/openai_skills_chatgpt-apps
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_chatgpt-apps/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_chatgpt-apps/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_chatgpt-apps"
-version: 0.0.10
 description: Build, scaffold, refactor, and troubleshoot ChatGPT Apps SDK applications
   that combine an MCP server and widget UI. Use when Codex needs to design tools,
   register UI resources, wire the MCP Apps bridge or ChatGPT compatibility APIs, apply
@@ -16,7 +15,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_develop-web-game/README.md
+++ b/profiles/openai/skills/openai_skills_develop-web-game/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai_skills_develop-web-game
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx forgecat install @forgecat/openai_skills_develop-web-game
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_develop-web-game/for-claude/.forgecat/profiles/@forgecat/openai_skills_develop-web-game/README.md
+++ b/profiles/openai/skills/openai_skills_develop-web-game/for-claude/.forgecat/profiles/@forgecat/openai_skills_develop-web-game/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_develop-web-game
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_develop-web-game/for-codex/.forgecat/profiles/@forgecat/openai_skills_develop-web-game/README.md
+++ b/profiles/openai/skills/openai_skills_develop-web-game/for-codex/.forgecat/profiles/@forgecat/openai_skills_develop-web-game/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_develop-web-game
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_develop-web-game/for-cursor/.forgecat/profiles/@forgecat/openai_skills_develop-web-game/README.md
+++ b/profiles/openai/skills/openai_skills_develop-web-game/for-cursor/.forgecat/profiles/@forgecat/openai_skills_develop-web-game/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_develop-web-game
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_develop-web-game/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_develop-web-game/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_develop-web-game
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx forgecat install @forgecat/openai_skills_develop-web-game
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_develop-web-game/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_develop-web-game/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_develop-web-game"
-version: 0.0.10
 description: 'Use when Codex is building or iterating on a web game (HTML/JS) and
   needs a reliable development + testing loop: implement small changes, run a Playwright-based
   test script with short input bursts and intentional pauses, inspect screenshots/text,
@@ -14,7 +13,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_doc/README.md
+++ b/profiles/openai/skills/openai_skills_doc/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai_skills_doc
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx forgecat install @forgecat/openai_skills_doc
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_doc/for-claude/.forgecat/profiles/@forgecat/openai_skills_doc/README.md
+++ b/profiles/openai/skills/openai_skills_doc/for-claude/.forgecat/profiles/@forgecat/openai_skills_doc/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_doc
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_doc/for-codex/.forgecat/profiles/@forgecat/openai_skills_doc/README.md
+++ b/profiles/openai/skills/openai_skills_doc/for-codex/.forgecat/profiles/@forgecat/openai_skills_doc/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_doc
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_doc/for-cursor/.forgecat/profiles/@forgecat/openai_skills_doc/README.md
+++ b/profiles/openai/skills/openai_skills_doc/for-cursor/.forgecat/profiles/@forgecat/openai_skills_doc/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_doc
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_doc/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_doc/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_doc
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx forgecat install @forgecat/openai_skills_doc
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_doc/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_doc/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_doc"
-version: 0.0.10
 description: Use when the task involves reading, creating, or editing `.docx` documents,
   especially when formatting or layout fidelity matters; prefer `python-docx` plus
   the bundled `scripts/render_docx.py` for visual checks.
@@ -13,7 +12,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_frontend-skill/README.md
+++ b/profiles/openai/skills/openai_skills_frontend-skill/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai_skills_frontend-skill
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx forgecat install @forgecat/openai_skills_frontend-skill
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_frontend-skill/for-claude/.forgecat/profiles/@forgecat/openai_skills_frontend-skill/README.md
+++ b/profiles/openai/skills/openai_skills_frontend-skill/for-claude/.forgecat/profiles/@forgecat/openai_skills_frontend-skill/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_frontend-skill
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_frontend-skill/for-codex/.forgecat/profiles/@forgecat/openai_skills_frontend-skill/README.md
+++ b/profiles/openai/skills/openai_skills_frontend-skill/for-codex/.forgecat/profiles/@forgecat/openai_skills_frontend-skill/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_frontend-skill
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_frontend-skill/for-cursor/.forgecat/profiles/@forgecat/openai_skills_frontend-skill/README.md
+++ b/profiles/openai/skills/openai_skills_frontend-skill/for-cursor/.forgecat/profiles/@forgecat/openai_skills_frontend-skill/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_frontend-skill
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_frontend-skill/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_frontend-skill/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_frontend-skill
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx forgecat install @forgecat/openai_skills_frontend-skill
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_frontend-skill/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_frontend-skill/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_frontend-skill"
-version: 0.0.10
 description: Use when the task asks for a visually strong landing page, website, app,
   prototype, demo, or game UI. This skill enforces restrained composition, image-led
   hierarchy, cohesive content structure, and tasteful motion while avoiding generic
@@ -14,7 +13,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_gh-address-comments/README.md
+++ b/profiles/openai/skills/openai_skills_gh-address-comments/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai_skills_gh-address-comments
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx forgecat install @forgecat/openai_skills_gh-address-comments
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_gh-address-comments/for-claude/.forgecat/profiles/@forgecat/openai_skills_gh-address-comments/README.md
+++ b/profiles/openai/skills/openai_skills_gh-address-comments/for-claude/.forgecat/profiles/@forgecat/openai_skills_gh-address-comments/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_gh-address-comments
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_gh-address-comments/for-codex/.forgecat/profiles/@forgecat/openai_skills_gh-address-comments/README.md
+++ b/profiles/openai/skills/openai_skills_gh-address-comments/for-codex/.forgecat/profiles/@forgecat/openai_skills_gh-address-comments/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_gh-address-comments
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_gh-address-comments/for-cursor/.forgecat/profiles/@forgecat/openai_skills_gh-address-comments/README.md
+++ b/profiles/openai/skills/openai_skills_gh-address-comments/for-cursor/.forgecat/profiles/@forgecat/openai_skills_gh-address-comments/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_gh-address-comments
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_gh-address-comments/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_gh-address-comments/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_gh-address-comments
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx forgecat install @forgecat/openai_skills_gh-address-comments
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_gh-address-comments/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_gh-address-comments/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_gh-address-comments"
-version: 0.0.10
 description: Help address review/issue comments on the open GitHub PR for the current
   branch using gh CLI; verify gh auth first and prompt the user to authenticate if
   not logged in.
@@ -13,7 +12,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_gh-fix-ci/README.md
+++ b/profiles/openai/skills/openai_skills_gh-fix-ci/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai_skills_gh-fix-ci
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx forgecat install @forgecat/openai_skills_gh-fix-ci
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_gh-fix-ci/for-claude/.forgecat/profiles/@forgecat/openai_skills_gh-fix-ci/README.md
+++ b/profiles/openai/skills/openai_skills_gh-fix-ci/for-claude/.forgecat/profiles/@forgecat/openai_skills_gh-fix-ci/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_gh-fix-ci
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_gh-fix-ci/for-codex/.forgecat/profiles/@forgecat/openai_skills_gh-fix-ci/README.md
+++ b/profiles/openai/skills/openai_skills_gh-fix-ci/for-codex/.forgecat/profiles/@forgecat/openai_skills_gh-fix-ci/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_gh-fix-ci
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_gh-fix-ci/for-cursor/.forgecat/profiles/@forgecat/openai_skills_gh-fix-ci/README.md
+++ b/profiles/openai/skills/openai_skills_gh-fix-ci/for-cursor/.forgecat/profiles/@forgecat/openai_skills_gh-fix-ci/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_gh-fix-ci
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_gh-fix-ci/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_gh-fix-ci/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_gh-fix-ci
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx forgecat install @forgecat/openai_skills_gh-fix-ci
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_gh-fix-ci/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_gh-fix-ci/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_gh-fix-ci"
-version: 0.0.10
 description: Use when a user asks to debug or fix failing GitHub PR checks that run
   in GitHub Actions; use `gh` to inspect checks and logs, summarize failure context,
   draft a fix plan, and implement only after explicit approval. Treat external providers
@@ -14,7 +13,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_imagegen/README.md
+++ b/profiles/openai/skills/openai_skills_imagegen/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai_skills_imagegen
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx forgecat install @forgecat/openai_skills_imagegen
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_imagegen/for-claude/.forgecat/profiles/@forgecat/openai_skills_imagegen/README.md
+++ b/profiles/openai/skills/openai_skills_imagegen/for-claude/.forgecat/profiles/@forgecat/openai_skills_imagegen/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_imagegen
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_imagegen/for-codex/.forgecat/profiles/@forgecat/openai_skills_imagegen/README.md
+++ b/profiles/openai/skills/openai_skills_imagegen/for-codex/.forgecat/profiles/@forgecat/openai_skills_imagegen/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_imagegen
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_imagegen/for-cursor/.forgecat/profiles/@forgecat/openai_skills_imagegen/README.md
+++ b/profiles/openai/skills/openai_skills_imagegen/for-cursor/.forgecat/profiles/@forgecat/openai_skills_imagegen/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_imagegen
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_imagegen/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_imagegen/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_imagegen
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx forgecat install @forgecat/openai_skills_imagegen
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_imagegen/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_imagegen/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_imagegen"
-version: 0.0.10
 description: Generate or edit raster images when the task benefits from AI-created
   bitmap visuals such as photos, illustrations, textures, sprites, mockups, or transparent-background
   cutouts. Use when Codex should create a brand-new image, transform an existing image,
@@ -17,7 +16,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_jupyter-notebook/README.md
+++ b/profiles/openai/skills/openai_skills_jupyter-notebook/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai_skills_jupyter-notebook
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx forgecat install @forgecat/openai_skills_jupyter-notebook
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_jupyter-notebook/for-claude/.forgecat/profiles/@forgecat/openai_skills_jupyter-notebook/README.md
+++ b/profiles/openai/skills/openai_skills_jupyter-notebook/for-claude/.forgecat/profiles/@forgecat/openai_skills_jupyter-notebook/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_jupyter-notebook
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_jupyter-notebook/for-codex/.forgecat/profiles/@forgecat/openai_skills_jupyter-notebook/README.md
+++ b/profiles/openai/skills/openai_skills_jupyter-notebook/for-codex/.forgecat/profiles/@forgecat/openai_skills_jupyter-notebook/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_jupyter-notebook
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_jupyter-notebook/for-cursor/.forgecat/profiles/@forgecat/openai_skills_jupyter-notebook/README.md
+++ b/profiles/openai/skills/openai_skills_jupyter-notebook/for-cursor/.forgecat/profiles/@forgecat/openai_skills_jupyter-notebook/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_jupyter-notebook
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_jupyter-notebook/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_jupyter-notebook/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_jupyter-notebook
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx forgecat install @forgecat/openai_skills_jupyter-notebook
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_jupyter-notebook/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_jupyter-notebook/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_jupyter-notebook"
-version: 0.0.10
 description: Use when the user asks to create, scaffold, or edit Jupyter notebooks
   (`.ipynb`) for experiments, explorations, or tutorials; prefer the bundled templates
   and run the helper script `new_notebook.py` to generate a clean starting notebook.
@@ -13,7 +12,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_linear/README.md
+++ b/profiles/openai/skills/openai_skills_linear/README.md
@@ -24,7 +24,7 @@ npx forgecat install @forgecat/openai_skills_linear
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -37,6 +37,8 @@ npx forgecat install @forgecat/openai_skills_linear
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_linear/for-claude/.forgecat/profiles/@forgecat/openai_skills_linear/README.md
+++ b/profiles/openai/skills/openai_skills_linear/for-claude/.forgecat/profiles/@forgecat/openai_skills_linear/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai_skills_linear
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_linear/for-codex/.forgecat/profiles/@forgecat/openai_skills_linear/README.md
+++ b/profiles/openai/skills/openai_skills_linear/for-codex/.forgecat/profiles/@forgecat/openai_skills_linear/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai_skills_linear
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_linear/for-cursor/.forgecat/profiles/@forgecat/openai_skills_linear/README.md
+++ b/profiles/openai/skills/openai_skills_linear/for-cursor/.forgecat/profiles/@forgecat/openai_skills_linear/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai_skills_linear
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_linear/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_linear/for-forgecat/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai_skills_linear
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -39,6 +39,8 @@ npx forgecat install @forgecat/openai_skills_linear
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_linear/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_linear/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_linear"
-version: 0.0.10
 description: Manage issues, projects & team workflows in Linear. Use when the user
   wants to read, create or updates tickets in Linear.
 repository: https://github.com/openai/skills
@@ -12,7 +11,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_netlify-deploy/README.md
+++ b/profiles/openai/skills/openai_skills_netlify-deploy/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai_skills_netlify-deploy
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx forgecat install @forgecat/openai_skills_netlify-deploy
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_netlify-deploy/for-claude/.forgecat/profiles/@forgecat/openai_skills_netlify-deploy/README.md
+++ b/profiles/openai/skills/openai_skills_netlify-deploy/for-claude/.forgecat/profiles/@forgecat/openai_skills_netlify-deploy/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_netlify-deploy
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_netlify-deploy/for-codex/.forgecat/profiles/@forgecat/openai_skills_netlify-deploy/README.md
+++ b/profiles/openai/skills/openai_skills_netlify-deploy/for-codex/.forgecat/profiles/@forgecat/openai_skills_netlify-deploy/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_netlify-deploy
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_netlify-deploy/for-cursor/.forgecat/profiles/@forgecat/openai_skills_netlify-deploy/README.md
+++ b/profiles/openai/skills/openai_skills_netlify-deploy/for-cursor/.forgecat/profiles/@forgecat/openai_skills_netlify-deploy/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_netlify-deploy
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_netlify-deploy/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_netlify-deploy/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_netlify-deploy
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx forgecat install @forgecat/openai_skills_netlify-deploy
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_netlify-deploy/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_netlify-deploy/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_netlify-deploy"
-version: 0.0.10
 description: Deploy web projects to Netlify using the Netlify CLI (`npx netlify`).
   Use when the user asks to deploy, host, publish, or link a site/repo on Netlify,
   including preview and production deploys.
@@ -13,7 +12,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_openai-docs/README.md
+++ b/profiles/openai/skills/openai_skills_openai-docs/README.md
@@ -24,7 +24,7 @@ npx forgecat install @forgecat/openai_skills_openai-docs
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -37,6 +37,8 @@ npx forgecat install @forgecat/openai_skills_openai-docs
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_openai-docs/for-claude/.forgecat/profiles/@forgecat/openai_skills_openai-docs/README.md
+++ b/profiles/openai/skills/openai_skills_openai-docs/for-claude/.forgecat/profiles/@forgecat/openai_skills_openai-docs/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai_skills_openai-docs
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_openai-docs/for-codex/.forgecat/profiles/@forgecat/openai_skills_openai-docs/README.md
+++ b/profiles/openai/skills/openai_skills_openai-docs/for-codex/.forgecat/profiles/@forgecat/openai_skills_openai-docs/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai_skills_openai-docs
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_openai-docs/for-cursor/.forgecat/profiles/@forgecat/openai_skills_openai-docs/README.md
+++ b/profiles/openai/skills/openai_skills_openai-docs/for-cursor/.forgecat/profiles/@forgecat/openai_skills_openai-docs/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai_skills_openai-docs
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_openai-docs/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_openai-docs/for-forgecat/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai_skills_openai-docs
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -39,6 +39,8 @@ npx forgecat install @forgecat/openai_skills_openai-docs
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_openai-docs/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_openai-docs/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_openai-docs"
-version: 0.0.10
 description: Use when the user asks how to build with OpenAI products or APIs and
   needs up-to-date official documentation with citations, help choosing the latest
   model for a use case, or explicit GPT-5.4 upgrade and prompt-upgrade guidance; prioritize
@@ -15,7 +14,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_pdf/README.md
+++ b/profiles/openai/skills/openai_skills_pdf/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai_skills_pdf
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx forgecat install @forgecat/openai_skills_pdf
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_pdf/for-claude/.forgecat/profiles/@forgecat/openai_skills_pdf/README.md
+++ b/profiles/openai/skills/openai_skills_pdf/for-claude/.forgecat/profiles/@forgecat/openai_skills_pdf/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_pdf
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_pdf/for-codex/.forgecat/profiles/@forgecat/openai_skills_pdf/README.md
+++ b/profiles/openai/skills/openai_skills_pdf/for-codex/.forgecat/profiles/@forgecat/openai_skills_pdf/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_pdf
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_pdf/for-cursor/.forgecat/profiles/@forgecat/openai_skills_pdf/README.md
+++ b/profiles/openai/skills/openai_skills_pdf/for-cursor/.forgecat/profiles/@forgecat/openai_skills_pdf/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_pdf
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_pdf/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_pdf/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_pdf
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx forgecat install @forgecat/openai_skills_pdf
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_pdf/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_pdf/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_pdf"
-version: 0.0.10
 description: Use when tasks involve reading, creating, or reviewing PDF files where
   rendering and layout matter; prefer visual checks by rendering pages (Poppler) and
   use Python tools such as `reportlab`, `pdfplumber`, and `pypdf` for generation and
@@ -14,7 +13,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_playwright-interactive/README.md
+++ b/profiles/openai/skills/openai_skills_playwright-interactive/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai_skills_playwright-interactive
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx forgecat install @forgecat/openai_skills_playwright-interactive
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_playwright-interactive/for-claude/.forgecat/profiles/@forgecat/openai_skills_playwright-interactive/README.md
+++ b/profiles/openai/skills/openai_skills_playwright-interactive/for-claude/.forgecat/profiles/@forgecat/openai_skills_playwright-interactive/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_playwright-interactive
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_playwright-interactive/for-codex/.forgecat/profiles/@forgecat/openai_skills_playwright-interactive/README.md
+++ b/profiles/openai/skills/openai_skills_playwright-interactive/for-codex/.forgecat/profiles/@forgecat/openai_skills_playwright-interactive/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_playwright-interactive
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_playwright-interactive/for-cursor/.forgecat/profiles/@forgecat/openai_skills_playwright-interactive/README.md
+++ b/profiles/openai/skills/openai_skills_playwright-interactive/for-cursor/.forgecat/profiles/@forgecat/openai_skills_playwright-interactive/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_playwright-interactive
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_playwright-interactive/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_playwright-interactive/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_playwright-interactive
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx forgecat install @forgecat/openai_skills_playwright-interactive
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_playwright-interactive/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_playwright-interactive/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_playwright-interactive"
-version: 0.0.10
 description: Persistent browser and Electron interaction through `js_repl` for fast
   iterative UI debugging.
 repository: https://github.com/openai/skills
@@ -12,7 +11,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_playwright/README.md
+++ b/profiles/openai/skills/openai_skills_playwright/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai_skills_playwright
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx forgecat install @forgecat/openai_skills_playwright
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_playwright/for-claude/.forgecat/profiles/@forgecat/openai_skills_playwright/README.md
+++ b/profiles/openai/skills/openai_skills_playwright/for-claude/.forgecat/profiles/@forgecat/openai_skills_playwright/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_playwright
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_playwright/for-codex/.forgecat/profiles/@forgecat/openai_skills_playwright/README.md
+++ b/profiles/openai/skills/openai_skills_playwright/for-codex/.forgecat/profiles/@forgecat/openai_skills_playwright/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_playwright
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_playwright/for-cursor/.forgecat/profiles/@forgecat/openai_skills_playwright/README.md
+++ b/profiles/openai/skills/openai_skills_playwright/for-cursor/.forgecat/profiles/@forgecat/openai_skills_playwright/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_playwright
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_playwright/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_playwright/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_playwright
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx forgecat install @forgecat/openai_skills_playwright
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_playwright/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_playwright/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_playwright"
-version: 0.0.10
 description: Use when the task requires automating a real browser from the terminal
   (navigation, form filling, snapshots, screenshots, data extraction, UI-flow debugging)
   via `playwright-cli` or the bundled wrapper script.
@@ -13,7 +12,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_screenshot/README.md
+++ b/profiles/openai/skills/openai_skills_screenshot/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai_skills_screenshot
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx forgecat install @forgecat/openai_skills_screenshot
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_screenshot/for-claude/.forgecat/profiles/@forgecat/openai_skills_screenshot/README.md
+++ b/profiles/openai/skills/openai_skills_screenshot/for-claude/.forgecat/profiles/@forgecat/openai_skills_screenshot/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_screenshot
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_screenshot/for-codex/.forgecat/profiles/@forgecat/openai_skills_screenshot/README.md
+++ b/profiles/openai/skills/openai_skills_screenshot/for-codex/.forgecat/profiles/@forgecat/openai_skills_screenshot/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_screenshot
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_screenshot/for-cursor/.forgecat/profiles/@forgecat/openai_skills_screenshot/README.md
+++ b/profiles/openai/skills/openai_skills_screenshot/for-cursor/.forgecat/profiles/@forgecat/openai_skills_screenshot/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_screenshot
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_screenshot/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_screenshot/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_screenshot
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx forgecat install @forgecat/openai_skills_screenshot
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_screenshot/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_screenshot/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_screenshot"
-version: 0.0.10
 description: Use when the user explicitly asks for a desktop or system screenshot
   (full screen, specific app or window, or a pixel region), or when tool-specific
   capture capabilities are unavailable and an OS-level capture is needed.
@@ -13,7 +12,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_security-ownership-map/README.md
+++ b/profiles/openai/skills/openai_skills_security-ownership-map/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai_skills_security-ownership-map
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx forgecat install @forgecat/openai_skills_security-ownership-map
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_security-ownership-map/for-claude/.forgecat/profiles/@forgecat/openai_skills_security-ownership-map/README.md
+++ b/profiles/openai/skills/openai_skills_security-ownership-map/for-claude/.forgecat/profiles/@forgecat/openai_skills_security-ownership-map/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_security-ownership-map
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_security-ownership-map/for-codex/.forgecat/profiles/@forgecat/openai_skills_security-ownership-map/README.md
+++ b/profiles/openai/skills/openai_skills_security-ownership-map/for-codex/.forgecat/profiles/@forgecat/openai_skills_security-ownership-map/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_security-ownership-map
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_security-ownership-map/for-cursor/.forgecat/profiles/@forgecat/openai_skills_security-ownership-map/README.md
+++ b/profiles/openai/skills/openai_skills_security-ownership-map/for-cursor/.forgecat/profiles/@forgecat/openai_skills_security-ownership-map/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_security-ownership-map
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_security-ownership-map/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_security-ownership-map/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_security-ownership-map
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx forgecat install @forgecat/openai_skills_security-ownership-map
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_security-ownership-map/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_security-ownership-map/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_security-ownership-map"
-version: 0.0.10
 description: 'Analyze git repositories to build a security ownership topology (people-to-file),
   compute bus factor and sensitive-code ownership, and export CSV/JSON for graph databases
   and visualization. Trigger only when the user explicitly wants a security-oriented
@@ -17,7 +16,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_security-threat-model/README.md
+++ b/profiles/openai/skills/openai_skills_security-threat-model/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai_skills_security-threat-model
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx forgecat install @forgecat/openai_skills_security-threat-model
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_security-threat-model/for-claude/.forgecat/profiles/@forgecat/openai_skills_security-threat-model/README.md
+++ b/profiles/openai/skills/openai_skills_security-threat-model/for-claude/.forgecat/profiles/@forgecat/openai_skills_security-threat-model/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_security-threat-model
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_security-threat-model/for-codex/.forgecat/profiles/@forgecat/openai_skills_security-threat-model/README.md
+++ b/profiles/openai/skills/openai_skills_security-threat-model/for-codex/.forgecat/profiles/@forgecat/openai_skills_security-threat-model/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_security-threat-model
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_security-threat-model/for-cursor/.forgecat/profiles/@forgecat/openai_skills_security-threat-model/README.md
+++ b/profiles/openai/skills/openai_skills_security-threat-model/for-cursor/.forgecat/profiles/@forgecat/openai_skills_security-threat-model/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_security-threat-model
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_security-threat-model/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_security-threat-model/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_security-threat-model
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx forgecat install @forgecat/openai_skills_security-threat-model
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_security-threat-model/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_security-threat-model/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_security-threat-model"
-version: 0.0.10
 description: Repository-grounded threat modeling that enumerates trust boundaries,
   assets, attacker capabilities, abuse paths, and mitigations, and writes a concise
   Markdown threat model. Trigger only when the user explicitly asks to threat model
@@ -16,7 +15,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_sentry/README.md
+++ b/profiles/openai/skills/openai_skills_sentry/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai_skills_sentry
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx forgecat install @forgecat/openai_skills_sentry
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_sentry/for-claude/.forgecat/profiles/@forgecat/openai_skills_sentry/README.md
+++ b/profiles/openai/skills/openai_skills_sentry/for-claude/.forgecat/profiles/@forgecat/openai_skills_sentry/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_sentry
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_sentry/for-codex/.forgecat/profiles/@forgecat/openai_skills_sentry/README.md
+++ b/profiles/openai/skills/openai_skills_sentry/for-codex/.forgecat/profiles/@forgecat/openai_skills_sentry/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_sentry
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_sentry/for-cursor/.forgecat/profiles/@forgecat/openai_skills_sentry/README.md
+++ b/profiles/openai/skills/openai_skills_sentry/for-cursor/.forgecat/profiles/@forgecat/openai_skills_sentry/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_sentry
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_sentry/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_sentry/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_sentry
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx forgecat install @forgecat/openai_skills_sentry
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_sentry/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_sentry/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_sentry"
-version: 0.0.10
 description: Use when the user asks to inspect Sentry issues or events, summarize
   recent production errors, or pull basic Sentry health data via the Sentry API; perform
   read-only queries with the bundled script and require `SENTRY_AUTH_TOKEN`.
@@ -13,7 +12,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_slides/README.md
+++ b/profiles/openai/skills/openai_skills_slides/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai_skills_slides
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx forgecat install @forgecat/openai_skills_slides
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_slides/for-claude/.forgecat/profiles/@forgecat/openai_skills_slides/README.md
+++ b/profiles/openai/skills/openai_skills_slides/for-claude/.forgecat/profiles/@forgecat/openai_skills_slides/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_slides
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_slides/for-codex/.forgecat/profiles/@forgecat/openai_skills_slides/README.md
+++ b/profiles/openai/skills/openai_skills_slides/for-codex/.forgecat/profiles/@forgecat/openai_skills_slides/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_slides
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_slides/for-cursor/.forgecat/profiles/@forgecat/openai_skills_slides/README.md
+++ b/profiles/openai/skills/openai_skills_slides/for-cursor/.forgecat/profiles/@forgecat/openai_skills_slides/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_slides
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_slides/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_slides/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_slides
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx forgecat install @forgecat/openai_skills_slides
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_slides/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_slides/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_slides"
-version: 0.0.10
 description: Create and edit presentation slide decks (`.pptx`) with PptxGenJS, bundled
   layout helpers, and render/validation utilities. Use when tasks involve building
   a new PowerPoint deck, recreating slides from screenshots/PDFs/reference decks,
@@ -15,7 +14,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_sora/README.md
+++ b/profiles/openai/skills/openai_skills_sora/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai_skills_sora
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx forgecat install @forgecat/openai_skills_sora
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_sora/for-claude/.forgecat/profiles/@forgecat/openai_skills_sora/README.md
+++ b/profiles/openai/skills/openai_skills_sora/for-claude/.forgecat/profiles/@forgecat/openai_skills_sora/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_sora
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_sora/for-codex/.forgecat/profiles/@forgecat/openai_skills_sora/README.md
+++ b/profiles/openai/skills/openai_skills_sora/for-codex/.forgecat/profiles/@forgecat/openai_skills_sora/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_sora
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_sora/for-cursor/.forgecat/profiles/@forgecat/openai_skills_sora/README.md
+++ b/profiles/openai/skills/openai_skills_sora/for-cursor/.forgecat/profiles/@forgecat/openai_skills_sora/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_sora
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_sora/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_sora/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_sora
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx forgecat install @forgecat/openai_skills_sora
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_sora/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_sora/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_sora"
-version: 0.0.10
 description: 'Use when the user asks to generate, edit, extend, poll, list, download,
   or delete Sora videos, create reusable non-human Sora character references, or run
   local multi-video queues via the bundled CLI (`scripts/sora.py`); includes requests
@@ -16,7 +15,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_speech/README.md
+++ b/profiles/openai/skills/openai_skills_speech/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai_skills_speech
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx forgecat install @forgecat/openai_skills_speech
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_speech/for-claude/.forgecat/profiles/@forgecat/openai_skills_speech/README.md
+++ b/profiles/openai/skills/openai_skills_speech/for-claude/.forgecat/profiles/@forgecat/openai_skills_speech/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_speech
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_speech/for-codex/.forgecat/profiles/@forgecat/openai_skills_speech/README.md
+++ b/profiles/openai/skills/openai_skills_speech/for-codex/.forgecat/profiles/@forgecat/openai_skills_speech/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_speech
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_speech/for-cursor/.forgecat/profiles/@forgecat/openai_skills_speech/README.md
+++ b/profiles/openai/skills/openai_skills_speech/for-cursor/.forgecat/profiles/@forgecat/openai_skills_speech/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_speech
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_speech/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_speech/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_speech
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx forgecat install @forgecat/openai_skills_speech
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_speech/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_speech/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_speech"
-version: 0.0.10
 description: Use when the user asks for text-to-speech narration or voiceover, accessibility
   reads, audio prompts, or batch speech generation via the OpenAI Audio API; run the
   bundled CLI (`scripts/text_to_speech.py`) with built-in voices and require `OPENAI_API_KEY`
@@ -14,7 +13,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_spreadsheet/README.md
+++ b/profiles/openai/skills/openai_skills_spreadsheet/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai_skills_spreadsheet
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx forgecat install @forgecat/openai_skills_spreadsheet
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_spreadsheet/for-claude/.forgecat/profiles/@forgecat/openai_skills_spreadsheet/README.md
+++ b/profiles/openai/skills/openai_skills_spreadsheet/for-claude/.forgecat/profiles/@forgecat/openai_skills_spreadsheet/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_spreadsheet
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_spreadsheet/for-codex/.forgecat/profiles/@forgecat/openai_skills_spreadsheet/README.md
+++ b/profiles/openai/skills/openai_skills_spreadsheet/for-codex/.forgecat/profiles/@forgecat/openai_skills_spreadsheet/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_spreadsheet
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_spreadsheet/for-cursor/.forgecat/profiles/@forgecat/openai_skills_spreadsheet/README.md
+++ b/profiles/openai/skills/openai_skills_spreadsheet/for-cursor/.forgecat/profiles/@forgecat/openai_skills_spreadsheet/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_spreadsheet
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_spreadsheet/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_spreadsheet/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_spreadsheet
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx forgecat install @forgecat/openai_skills_spreadsheet
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_spreadsheet/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_spreadsheet/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_spreadsheet"
-version: 0.0.10
 description: Use when tasks involve creating, editing, analyzing, or formatting spreadsheets
   (`.xlsx`, `.csv`, `.tsv`) with formula-aware workflows, cached recalculation, and
   visual review.
@@ -13,7 +12,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_system-openai-docs/README.md
+++ b/profiles/openai/skills/openai_skills_system-openai-docs/README.md
@@ -24,7 +24,7 @@ npx forgecat install @forgecat/openai_skills_system-openai-docs
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -37,6 +37,8 @@ npx forgecat install @forgecat/openai_skills_system-openai-docs
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_system-openai-docs/for-claude/.forgecat/profiles/@forgecat/openai_skills_system-openai-docs/README.md
+++ b/profiles/openai/skills/openai_skills_system-openai-docs/for-claude/.forgecat/profiles/@forgecat/openai_skills_system-openai-docs/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai_skills_system-openai-docs
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_system-openai-docs/for-codex/.forgecat/profiles/@forgecat/openai_skills_system-openai-docs/README.md
+++ b/profiles/openai/skills/openai_skills_system-openai-docs/for-codex/.forgecat/profiles/@forgecat/openai_skills_system-openai-docs/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai_skills_system-openai-docs
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_system-openai-docs/for-cursor/.forgecat/profiles/@forgecat/openai_skills_system-openai-docs/README.md
+++ b/profiles/openai/skills/openai_skills_system-openai-docs/for-cursor/.forgecat/profiles/@forgecat/openai_skills_system-openai-docs/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai_skills_system-openai-docs
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_system-openai-docs/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_system-openai-docs/for-forgecat/README.md
@@ -26,7 +26,7 @@ npx forgecat install @forgecat/openai_skills_system-openai-docs
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -39,6 +39,8 @@ npx forgecat install @forgecat/openai_skills_system-openai-docs
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_system-openai-docs/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_system-openai-docs/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_system-openai-docs"
-version: 0.0.10
 description: Use when the user asks how to build with OpenAI products or APIs and
   needs up-to-date official documentation with citations, help choosing the latest
   model for a use case, or explicit GPT-5.4 upgrade and prompt-upgrade guidance; prioritize
@@ -15,7 +14,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_system-skill-creator/README.md
+++ b/profiles/openai/skills/openai_skills_system-skill-creator/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai_skills_system-skill-creator
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx forgecat install @forgecat/openai_skills_system-skill-creator
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_system-skill-creator/for-claude/.forgecat/profiles/@forgecat/openai_skills_system-skill-creator/README.md
+++ b/profiles/openai/skills/openai_skills_system-skill-creator/for-claude/.forgecat/profiles/@forgecat/openai_skills_system-skill-creator/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_system-skill-creator
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_system-skill-creator/for-codex/.forgecat/profiles/@forgecat/openai_skills_system-skill-creator/README.md
+++ b/profiles/openai/skills/openai_skills_system-skill-creator/for-codex/.forgecat/profiles/@forgecat/openai_skills_system-skill-creator/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_system-skill-creator
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_system-skill-creator/for-cursor/.forgecat/profiles/@forgecat/openai_skills_system-skill-creator/README.md
+++ b/profiles/openai/skills/openai_skills_system-skill-creator/for-cursor/.forgecat/profiles/@forgecat/openai_skills_system-skill-creator/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_system-skill-creator
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_system-skill-creator/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_system-skill-creator/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_system-skill-creator
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx forgecat install @forgecat/openai_skills_system-skill-creator
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_system-skill-creator/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_system-skill-creator/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_system-skill-creator"
-version: 0.0.10
 description: Guide for creating effective skills. This skill should be used when users
   want to create a new skill (or update an existing skill) that extends Codex's capabilities
   with specialized knowledge, workflows, or tool integrations.
@@ -13,7 +12,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_system-skill-installer/README.md
+++ b/profiles/openai/skills/openai_skills_system-skill-installer/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai_skills_system-skill-installer
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.12` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx forgecat install @forgecat/openai_skills_system-skill-installer
 | Claude Code | Partial |
 | Cursor | Partial |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_system-skill-installer/for-claude/.forgecat/profiles/@forgecat/openai_skills_system-skill-installer/README.md
+++ b/profiles/openai/skills/openai_skills_system-skill-installer/for-claude/.forgecat/profiles/@forgecat/openai_skills_system-skill-installer/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_system-skill-installer
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.12` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_system-skill-installer/for-codex/.forgecat/profiles/@forgecat/openai_skills_system-skill-installer/README.md
+++ b/profiles/openai/skills/openai_skills_system-skill-installer/for-codex/.forgecat/profiles/@forgecat/openai_skills_system-skill-installer/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_system-skill-installer
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.12` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_system-skill-installer/for-cursor/.forgecat/profiles/@forgecat/openai_skills_system-skill-installer/README.md
+++ b/profiles/openai/skills/openai_skills_system-skill-installer/for-cursor/.forgecat/profiles/@forgecat/openai_skills_system-skill-installer/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_system-skill-installer
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.12` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_system-skill-installer/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_system-skill-installer/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_system-skill-installer
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.12` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx forgecat install @forgecat/openai_skills_system-skill-installer
 | Claude Code | Partial |
 | Cursor | Partial |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_system-skill-installer/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_system-skill-installer/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_system-skill-installer"
-version: 0.0.10
 description: Install Codex skills into $CODEX_HOME/skills from a curated list or a
   GitHub repo path. Use when a user asks to list installable skills, install a curated
   skill, or install a skill from another repo (including private repos).
@@ -14,6 +13,8 @@ compatibility:
     partial:
       - claude-code
       - cursor
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_transcribe/README.md
+++ b/profiles/openai/skills/openai_skills_transcribe/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai_skills_transcribe
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx forgecat install @forgecat/openai_skills_transcribe
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_transcribe/for-claude/.forgecat/profiles/@forgecat/openai_skills_transcribe/README.md
+++ b/profiles/openai/skills/openai_skills_transcribe/for-claude/.forgecat/profiles/@forgecat/openai_skills_transcribe/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_transcribe
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_transcribe/for-codex/.forgecat/profiles/@forgecat/openai_skills_transcribe/README.md
+++ b/profiles/openai/skills/openai_skills_transcribe/for-codex/.forgecat/profiles/@forgecat/openai_skills_transcribe/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_transcribe
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_transcribe/for-cursor/.forgecat/profiles/@forgecat/openai_skills_transcribe/README.md
+++ b/profiles/openai/skills/openai_skills_transcribe/for-cursor/.forgecat/profiles/@forgecat/openai_skills_transcribe/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_transcribe
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_transcribe/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_transcribe/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_transcribe
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx forgecat install @forgecat/openai_skills_transcribe
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_transcribe/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_transcribe/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_transcribe"
-version: 0.0.10
 description: Transcribe audio files to text with optional diarization and known-speaker
   hints. Use when a user asks to transcribe speech from audio/video, extract text
   from recordings, or label speakers in interviews or meetings.
@@ -13,7 +12,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/openai/skills/openai_skills_yeet/README.md
+++ b/profiles/openai/skills/openai_skills_yeet/README.md
@@ -21,7 +21,7 @@ npx forgecat install @forgecat/openai_skills_yeet
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -34,6 +34,8 @@ npx forgecat install @forgecat/openai_skills_yeet
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_yeet/for-claude/.forgecat/profiles/@forgecat/openai_skills_yeet/README.md
+++ b/profiles/openai/skills/openai_skills_yeet/for-claude/.forgecat/profiles/@forgecat/openai_skills_yeet/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_yeet
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_yeet/for-codex/.forgecat/profiles/@forgecat/openai_skills_yeet/README.md
+++ b/profiles/openai/skills/openai_skills_yeet/for-codex/.forgecat/profiles/@forgecat/openai_skills_yeet/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_yeet
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_yeet/for-cursor/.forgecat/profiles/@forgecat/openai_skills_yeet/README.md
+++ b/profiles/openai/skills/openai_skills_yeet/for-cursor/.forgecat/profiles/@forgecat/openai_skills_yeet/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_yeet
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |

--- a/profiles/openai/skills/openai_skills_yeet/for-forgecat/README.md
+++ b/profiles/openai/skills/openai_skills_yeet/for-forgecat/README.md
@@ -23,7 +23,7 @@ npx forgecat install @forgecat/openai_skills_yeet
 |---|---|
 | Author | `OpenAI` |
 | Original repository | `https://github.com/openai/skills` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `0e7823cca07bc2cbf34718a383f9ae92525be6a5` (2026-03-24 14:48:51) |
 | License | `Apache-2.0` |
 | Source platform | `codex` |
@@ -36,6 +36,8 @@ npx forgecat install @forgecat/openai_skills_yeet
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |

--- a/profiles/openai/skills/openai_skills_yeet/for-forgecat/profile.yml
+++ b/profiles/openai/skills/openai_skills_yeet/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/openai_skills_yeet"
-version: 0.0.10
 description: Use only when the user explicitly asks to stage, commit, push, and open
   a GitHub pull request in one flow using the GitHub CLI (`gh`).
 repository: https://github.com/openai/skills
@@ -12,7 +11,9 @@ compatibility:
       - claude-code
       - codex
       - cursor
-    partial: []
+    partial:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_business-product/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_business-product/README.md
@@ -30,7 +30,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_business-produc
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -43,6 +43,8 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_business-produc
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_business-product/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_business-product/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_business-product/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_business-product/README.md
@@ -32,7 +32,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_business-produc
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_business-product/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_business-product/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_business-product/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_business-product/README.md
@@ -32,7 +32,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_business-produc
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_business-product/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_business-product/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_business-product/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_business-product/README.md
@@ -32,7 +32,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_business-produc
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_business-product/for-forgecat/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_business-product/for-forgecat/README.md
@@ -32,7 +32,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_business-produc
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -45,6 +45,8 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_business-produc
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_business-product/for-forgecat/profile.yml
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_business-product/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/voltagent_awesome-codex-subagents_business-product"
-version: 0.0.10
 description: Support agents for requirements, UX, and engineering-adjacent writing
   tasks. Includes 11 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 repository: https://github.com/VoltAgent/awesome-codex-subagents
@@ -13,6 +12,9 @@ compatibility:
       - codex
       - cursor
     partial: []
+    unsupported:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_core-development/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_core-development/README.md
@@ -31,7 +31,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_core-developmen
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.12` |
+| Version | `0.0.13` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -44,6 +44,8 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_core-developmen
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_core-development/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_core-development/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_core-development/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_core-development/README.md
@@ -33,7 +33,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_core-developmen
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.8` |
+| Version | `0.0.13` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_core-development/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_core-development/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_core-development/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_core-development/README.md
@@ -33,7 +33,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_core-developmen
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.8` |
+| Version | `0.0.13` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_core-development/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_core-development/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_core-development/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_core-development/README.md
@@ -33,7 +33,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_core-developmen
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.8` |
+| Version | `0.0.13` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_core-development/for-forgecat/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_core-development/for-forgecat/README.md
@@ -33,7 +33,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_core-developmen
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.12` |
+| Version | `0.0.13` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -46,6 +46,8 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_core-developmen
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_core-development/for-forgecat/profile.yml
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_core-development/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/voltagent_awesome-codex-subagents_core-development"
-version: 0.0.12
 description: Core agents for application architecture, cross-layer implementation,
   UI work, and protocol-specific development. Includes 12 Codex-native subagents from
   VoltAgent/awesome-codex-subagents.
@@ -14,6 +13,9 @@ compatibility:
       - codex
       - cursor
     partial: []
+    unsupported:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_data-ai/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_data-ai/README.md
@@ -31,7 +31,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_data-ai
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -44,6 +44,8 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_data-ai
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_data-ai/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_data-ai/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_data-ai/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_data-ai/README.md
@@ -33,7 +33,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_data-ai
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_data-ai/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_data-ai/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_data-ai/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_data-ai/README.md
@@ -33,7 +33,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_data-ai
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_data-ai/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_data-ai/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_data-ai/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_data-ai/README.md
@@ -33,7 +33,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_data-ai
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_data-ai/for-forgecat/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_data-ai/for-forgecat/README.md
@@ -33,7 +33,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_data-ai
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -46,6 +46,8 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_data-ai
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_data-ai/for-forgecat/profile.yml
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_data-ai/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/voltagent_awesome-codex-subagents_data-ai"
-version: 0.0.10
 description: Agents for data pipelines, LLM integrations, and database behavior. Includes
   12 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 repository: https://github.com/VoltAgent/awesome-codex-subagents
@@ -13,6 +12,9 @@ compatibility:
       - codex
       - cursor
     partial: []
+    unsupported:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_developer-experience/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_developer-experience/README.md
@@ -32,7 +32,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_developer-exper
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -45,6 +45,8 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_developer-exper
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_developer-experience/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_developer-experience/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_developer-experience/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_developer-experience/README.md
@@ -34,7 +34,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_developer-exper
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_developer-experience/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_developer-experience/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_developer-experience/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_developer-experience/README.md
@@ -34,7 +34,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_developer-exper
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_developer-experience/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_developer-experience/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_developer-experience/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_developer-experience/README.md
@@ -34,7 +34,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_developer-exper
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_developer-experience/for-forgecat/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_developer-experience/for-forgecat/README.md
@@ -34,7 +34,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_developer-exper
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -47,6 +47,8 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_developer-exper
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_developer-experience/for-forgecat/profile.yml
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_developer-experience/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/voltagent_awesome-codex-subagents_developer-experience"
-version: 0.0.10
 description: Agents for builds, developer tooling, documentation, MCP integrations,
   and refactors. Includes 13 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 repository: https://github.com/VoltAgent/awesome-codex-subagents
@@ -13,6 +12,9 @@ compatibility:
       - codex
       - cursor
     partial: []
+    unsupported:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_infrastructure/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_infrastructure/README.md
@@ -35,7 +35,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_infrastructure
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -48,6 +48,8 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_infrastructure
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_infrastructure/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_infrastructure/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_infrastructure/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_infrastructure/README.md
@@ -37,7 +37,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_infrastructure
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_infrastructure/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_infrastructure/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_infrastructure/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_infrastructure/README.md
@@ -37,7 +37,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_infrastructure
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_infrastructure/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_infrastructure/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_infrastructure/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_infrastructure/README.md
@@ -37,7 +37,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_infrastructure
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_infrastructure/for-forgecat/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_infrastructure/for-forgecat/README.md
@@ -37,7 +37,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_infrastructure
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -50,6 +50,8 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_infrastructure
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_infrastructure/for-forgecat/profile.yml
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_infrastructure/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/voltagent_awesome-codex-subagents_infrastructure"
-version: 0.0.10
 description: Infrastructure-focused agents for deployment, containerization, orchestration,
   and IaC work. Includes 16 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 repository: https://github.com/VoltAgent/awesome-codex-subagents
@@ -13,6 +12,9 @@ compatibility:
       - codex
       - cursor
     partial: []
+    unsupported:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_language-specialists/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_language-specialists/README.md
@@ -45,7 +45,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_language-specia
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -58,6 +58,8 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_language-specia
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_language-specialists/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_language-specialists/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_language-specialists/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_language-specialists/README.md
@@ -47,7 +47,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_language-specia
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_language-specialists/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_language-specialists/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_language-specialists/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_language-specialists/README.md
@@ -47,7 +47,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_language-specia
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_language-specialists/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_language-specialists/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_language-specialists/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_language-specialists/README.md
@@ -47,7 +47,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_language-specia
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_language-specialists/for-forgecat/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_language-specialists/for-forgecat/README.md
@@ -47,7 +47,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_language-specia
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -60,6 +60,8 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_language-specia
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_language-specialists/for-forgecat/profile.yml
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_language-specialists/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/voltagent_awesome-codex-subagents_language-specialists"
-version: 0.0.10
 description: Language and framework specialists for ecosystem-specific implementation,
   debugging, and architectural guidance. Includes 26 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 repository: https://github.com/VoltAgent/awesome-codex-subagents
@@ -13,6 +12,9 @@ compatibility:
       - codex
       - cursor
     partial: []
+    unsupported:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_meta-orchestration/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_meta-orchestration/README.md
@@ -29,7 +29,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_meta-orchestrat
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -42,6 +42,8 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_meta-orchestrat
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_meta-orchestration/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_meta-orchestration/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_meta-orchestration/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_meta-orchestration/README.md
@@ -31,7 +31,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_meta-orchestrat
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_meta-orchestration/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_meta-orchestration/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_meta-orchestration/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_meta-orchestration/README.md
@@ -31,7 +31,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_meta-orchestrat
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_meta-orchestration/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_meta-orchestration/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_meta-orchestration/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_meta-orchestration/README.md
@@ -31,7 +31,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_meta-orchestrat
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_meta-orchestration/for-forgecat/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_meta-orchestration/for-forgecat/README.md
@@ -31,7 +31,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_meta-orchestrat
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -44,6 +44,8 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_meta-orchestrat
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_meta-orchestration/for-forgecat/profile.yml
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_meta-orchestration/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/voltagent_awesome-codex-subagents_meta-orchestration"
-version: 0.0.10
 description: Agents that help plan or coordinate multi-agent Codex workflows without
   inventing unsupported mechanics. Includes 10 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 repository: https://github.com/VoltAgent/awesome-codex-subagents
@@ -13,6 +12,9 @@ compatibility:
       - codex
       - cursor
     partial: []
+    unsupported:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_specialized-domains/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_specialized-domains/README.md
@@ -31,7 +31,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_specialized-dom
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -44,6 +44,8 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_specialized-dom
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_specialized-domains/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_specialized-domains/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_specialized-domains/for-claude/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_specialized-domains/README.md
@@ -33,7 +33,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_specialized-dom
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_specialized-domains/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_specialized-domains/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_specialized-domains/for-codex/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_specialized-domains/README.md
@@ -33,7 +33,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_specialized-dom
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_specialized-domains/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_specialized-domains/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_specialized-domains/for-cursor/.forgecat/profiles/@forgecat/voltagent_awesome-codex-subagents_specialized-domains/README.md
@@ -33,7 +33,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_specialized-dom
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.6` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_specialized-domains/for-forgecat/README.md
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_specialized-domains/for-forgecat/README.md
@@ -33,7 +33,7 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_specialized-dom
 |---|---|
 | Author | `VoltAgent + community contributors` |
 | Original repository | `https://github.com/VoltAgent/awesome-codex-subagents` |
-| Version | `0.0.10` |
+| Version | `0.0.11` |
 | Original commit | `5b7a405` (2026-03-19) |
 | License | `MIT` |
 | Source platform | `codex` |
@@ -46,6 +46,8 @@ npx forgecat install @forgecat/voltagent_awesome-codex-subagents_specialized-dom
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_specialized-domains/for-forgecat/profile.yml
+++ b/profiles/voltagent/awesome-codex-subagents/voltagent_awesome-codex-subagents_specialized-domains/for-forgecat/profile.yml
@@ -1,5 +1,4 @@
 name: "@forgecat/voltagent_awesome-codex-subagents_specialized-domains"
-version: 0.0.10
 description: Focused domain agents that still have a clear implementation or verification
   boundary. Includes 12 Codex-native subagents from VoltAgent/awesome-codex-subagents.
 repository: https://github.com/VoltAgent/awesome-codex-subagents
@@ -13,6 +12,9 @@ compatibility:
       - codex
       - cursor
     partial: []
+    unsupported:
+      - openclaw
+      - hermes
   models:
     recommended:
     - gpt-5.4


### PR DESCRIPTION
## Summary

- add the reviewed OpenClaw and Hermes status to 78 legacy profiles
- remove the deprecated top-level `profile.yml version:` field
- stamp the next patch version in ForgeCat-authored README receipts

## Scope

- 55 profiles add `Partial`; 23 add `Unsupported`
- 466 changed files: 78 manifests and 388 README files
- 1,002 functional files and all 78 install plans remain byte-identical to the current Registry versions
- no new `Tested` claim, component, executable, file mode, or install destination

## Verification

- claims-only verification: 78/78 passed
- strict validation: 78/78 passed with no warnings
- scan parity: 78/78 matched the baseline
- Profile artifact and license checks: 78/78 passed
- independent conversion QA: pass / ready, no findings in the final set
- public dry-run: 78/78 matched the exact profile, patch version, visibility, and file count
- Registry push: 0

[HTML preflight dashboard](/api/pond?doc=notes%2Fhephai%2Fforgecat-home-claims-legacy-98-preflight-2026-08-31.html)

Twenty profiles were excluded before this PR: four failed the existing native-artifact CI rule, thirteen have broken installed `CONNECTORS.md` links, and three need source-backed repairs.
