### PR TITLE
profile(knowledge-work): add verified five-platform artifacts

### DIFF
--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/README.md
@@ -48,7 +48,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_customer-suppor
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/customer-support |
-| Version | `0.0.8` |
+| Version | `0.0.11` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -62,6 +62,8 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_customer-suppor
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-claude/.claude/skills/customer-escalation/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-claude/.claude/skills/customer-escalation/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <issue summary> [customer name]
 
 # /customer-escalation
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/CONNECTORS.md`).
 
 Package a support issue into a structured escalation brief for engineering, product, or leadership. Gathers context, structures reproduction steps, assesses business impact, and identifies the right escalation target.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-claude/.claude/skills/customer-research/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-claude/.claude/skills/customer-research/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <question or topic>
 
 # /customer-research
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/CONNECTORS.md`).
 
 Multi-source research on a customer question, product topic, or account-related inquiry. Synthesizes findings from all available sources with clear attribution and confidence scoring.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-claude/.claude/skills/draft-response/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-claude/.claude/skills/draft-response/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <situation description>
 
 # /draft-response
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/CONNECTORS.md`).
 
 Draft a professional, customer-facing response tailored to the situation, customer relationship, and communication context.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-claude/.claude/skills/kb-article/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-claude/.claude/skills/kb-article/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <resolved issue or ticket>
 
 # /kb-article
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/CONNECTORS.md`).
 
 Draft a publish-ready knowledge base article from a resolved support issue, common question, or documented workaround. Structures the content for searchability and self-service.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-claude/.claude/skills/ticket-triage/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-claude/.claude/skills/ticket-triage/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <ticket or issue description>
 
 # /ticket-triage
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/CONNECTORS.md`).
 
 Categorize, prioritize, and route an incoming support ticket or customer issue. Produces a structured triage assessment with a suggested initial response.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/CONNECTORS.md
@@ -1,0 +1,19 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~support platform` might mean Intercom, Zendesk, or any other support tool with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (support platform, CRM, chat, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Email | `~~email` | Microsoft 365 | — |
+| Cloud storage | `~~cloud storage` | Microsoft 365 | — |
+| Support platform | `~~support platform` | Intercom | Zendesk, Freshdesk, HubSpot Service Hub |
+| CRM | `~~CRM` | HubSpot | Salesforce, Pipedrive |
+| Knowledge base | `~~knowledge base` | Guru, Notion | Confluence, Help Scout |
+| Project tracker | `~~project tracker` | Atlassian (Jira/Confluence) | Linear, Asana |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Customer Support
@@ -50,7 +50,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_customer-suppor
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/customer-support |
-| Version | `0.0.4` |
+| Version | `0.0.11` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -62,8 +62,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_customer-suppor
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-codex/.agents/skills/customer-escalation/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-codex/.agents/skills/customer-escalation/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <issue summary> [customer name]
 
 # /customer-escalation
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/CONNECTORS.md`).
 
 Package a support issue into a structured escalation brief for engineering, product, or leadership. Gathers context, structures reproduction steps, assesses business impact, and identifies the right escalation target.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-codex/.agents/skills/customer-research/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-codex/.agents/skills/customer-research/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <question or topic>
 
 # /customer-research
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/CONNECTORS.md`).
 
 Multi-source research on a customer question, product topic, or account-related inquiry. Synthesizes findings from all available sources with clear attribution and confidence scoring.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-codex/.agents/skills/draft-response/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-codex/.agents/skills/draft-response/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <situation description>
 
 # /draft-response
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/CONNECTORS.md`).
 
 Draft a professional, customer-facing response tailored to the situation, customer relationship, and communication context.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-codex/.agents/skills/kb-article/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-codex/.agents/skills/kb-article/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <resolved issue or ticket>
 
 # /kb-article
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/CONNECTORS.md`).
 
 Draft a publish-ready knowledge base article from a resolved support issue, common question, or documented workaround. Structures the content for searchability and self-service.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-codex/.agents/skills/ticket-triage/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-codex/.agents/skills/ticket-triage/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <ticket or issue description>
 
 # /ticket-triage
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/CONNECTORS.md`).
 
 Categorize, prioritize, and route an incoming support ticket or customer issue. Produces a structured triage assessment with a suggested initial response.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/CONNECTORS.md
@@ -1,0 +1,19 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~support platform` might mean Intercom, Zendesk, or any other support tool with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (support platform, CRM, chat, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Email | `~~email` | Microsoft 365 | — |
+| Cloud storage | `~~cloud storage` | Microsoft 365 | — |
+| Support platform | `~~support platform` | Intercom | Zendesk, Freshdesk, HubSpot Service Hub |
+| CRM | `~~CRM` | HubSpot | Salesforce, Pipedrive |
+| Knowledge base | `~~knowledge base` | Guru, Notion | Confluence, Help Scout |
+| Project tracker | `~~project tracker` | Atlassian (Jira/Confluence) | Linear, Asana |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Customer Support
@@ -50,7 +50,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_customer-suppor
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/customer-support |
-| Version | `0.0.4` |
+| Version | `0.0.11` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -62,8 +62,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_customer-suppor
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-cursor/.cursor/skills/customer-escalation/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-cursor/.cursor/skills/customer-escalation/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <issue summary> [customer name]
 
 # /customer-escalation
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/CONNECTORS.md`).
 
 Package a support issue into a structured escalation brief for engineering, product, or leadership. Gathers context, structures reproduction steps, assesses business impact, and identifies the right escalation target.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-cursor/.cursor/skills/customer-research/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-cursor/.cursor/skills/customer-research/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <question or topic>
 
 # /customer-research
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/CONNECTORS.md`).
 
 Multi-source research on a customer question, product topic, or account-related inquiry. Synthesizes findings from all available sources with clear attribution and confidence scoring.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-cursor/.cursor/skills/draft-response/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-cursor/.cursor/skills/draft-response/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <situation description>
 
 # /draft-response
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/CONNECTORS.md`).
 
 Draft a professional, customer-facing response tailored to the situation, customer relationship, and communication context.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-cursor/.cursor/skills/kb-article/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-cursor/.cursor/skills/kb-article/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <resolved issue or ticket>
 
 # /kb-article
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/CONNECTORS.md`).
 
 Draft a publish-ready knowledge base article from a resolved support issue, common question, or documented workaround. Structures the content for searchability and self-service.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-cursor/.cursor/skills/ticket-triage/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-cursor/.cursor/skills/ticket-triage/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <ticket or issue description>
 
 # /ticket-triage
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/CONNECTORS.md`).
 
 Categorize, prioritize, and route an incoming support ticket or customer issue. Produces a structured triage assessment with a suggested initial response.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/CONNECTORS.md
@@ -1,0 +1,19 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~support platform` might mean Intercom, Zendesk, or any other support tool with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (support platform, CRM, chat, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Email | `~~email` | Microsoft 365 | — |
+| Cloud storage | `~~cloud storage` | Microsoft 365 | — |
+| Support platform | `~~support platform` | Intercom | Zendesk, Freshdesk, HubSpot Service Hub |
+| CRM | `~~CRM` | HubSpot | Salesforce, Pipedrive |
+| Knowledge base | `~~knowledge base` | Guru, Notion | Confluence, Help Scout |
+| Project tracker | `~~project tracker` | Atlassian (Jira/Confluence) | Linear, Asana |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_customer-support/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Customer Support
@@ -50,7 +50,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_customer-suppor
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/customer-support |
-| Version | `0.0.4` |
+| Version | `0.0.11` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -62,8 +62,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_customer-suppor
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-forgecat/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-forgecat/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-forgecat/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-forgecat/README.md
@@ -50,7 +50,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_customer-suppor
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/customer-support |
-| Version | `0.0.8` |
+| Version | `0.0.11` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin |
@@ -64,6 +64,8 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_customer-suppor
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-forgecat/platforms/claude-code/.claude-plugin/plugin.json
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-forgecat/platforms/claude-code/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "customer-support",
+  "version": "1.2.0",
+  "description": "Triage tickets, draft responses, escalate issues, and build your knowledge base. Research customer context and turn resolved issues into self-service content.",
+  "author": {
+    "name": "Anthropic"
+  }
+}

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-forgecat/platforms/claude-code/.mcp.json
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-forgecat/platforms/claude-code/.mcp.json
@@ -1,0 +1,40 @@
+{
+  "mcpServers": {
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
+    },
+    "intercom": {
+      "type": "http",
+      "url": "https://mcp.intercom.com/mcp"
+    },
+    "hubspot": {
+      "type": "http",
+      "url": "https://mcp.hubspot.com/anthropic"
+    },
+    "guru": {
+      "type": "http",
+      "url": "https://mcp.api.getguru.com/mcp"
+    },
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp"
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
+    },
+    "ms365": {
+      "type": "http",
+      "url": "https://microsoft365.mcp.claude.com/mcp"
+    },
+    "google-calendar": {
+      "type": "http",
+      "url": "https://gcal.mcp.claude.com/mcp"
+    },
+    "gmail": {
+      "type": "http",
+      "url": "https://gmail.mcp.claude.com/mcp"
+    }
+  }
+}

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-forgecat/profile.yml
@@ -1,50 +1,51 @@
-name: "@forgecat/anthropics_knowledge-work-plugins_customer-support"
-version: 0.0.8
-description: Triage tickets, draft responses, escalate issues, and build your knowledge
-  base. Research customer context and turn resolved issues into self-service content.
+name: '@forgecat/anthropics_knowledge-work-plugins_customer-support'
+description: Triage tickets, draft responses, escalate issues, and build your knowledge base. Research
+  customer context and turn resolved issues into self-service content.
+visibility: public
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/customer-support
 license: Apache-2.0
-visibility: public
 sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:
-      - claude-code
-      - cursor
-      - codex
+    - claude-code
+    - cursor
+    - codex
+    partial:
+    - openclaw
+    - hermes
   models:
     recommended: []
     minimum: []
 skills:
-- name: ticket-triage
-  path: skills/ticket-triage/SKILL.md
-  description: Triage and prioritize a support ticket or customer issue. Use when
-    a new ticket comes in and needs categorization, assigning P1-P4 priority, deciding
-    which team should handle it, or checking whether it's a duplicate or known issue
-    before routing.
-- name: customer-research
-  path: skills/customer-research/SKILL.md
-  description: Multi-source research on a customer question or topic with source attribution.
-    Use when a customer asks something you need to look up, investigating whether
-    a bug has been reported before, checking what was previously told to a specific
-    account, or gathering background before drafting a response.
-- name: draft-response
-  path: skills/draft-response/SKILL.md
-  description: Draft a professional customer-facing response tailored to the situation
-    and relationship. Use when answering a product question, responding to an escalation
-    or outage, delivering bad news like a delay or won't-fix, declining a feature
-    request, or replying to a billing issue.
 - name: customer-escalation
   path: skills/customer-escalation/SKILL.md
-  description: Package an escalation for engineering, product, or leadership with
-    full context. Use when a bug needs engineering attention beyond normal support,
-    multiple customers report the same issue, a customer is threatening to churn,
-    or an issue has sat unresolved past its SLA.
+  description: Package an escalation for engineering, product, or leadership with full context. Use when
+    a bug needs engineering attention beyond normal support, multiple customers report the same issue,
+    a customer is threatening to churn, or an issue has sat unresolved past its SLA.
+- name: customer-research
+  path: skills/customer-research/SKILL.md
+  description: Multi-source research on a customer question or topic with source attribution. Use when
+    a customer asks something you need to look up, investigating whether a bug has been reported before,
+    checking what was previously told to a specific account, or gathering background before drafting a
+    response.
+- name: draft-response
+  path: skills/draft-response/SKILL.md
+  description: Draft a professional customer-facing response tailored to the situation and relationship.
+    Use when answering a product question, responding to an escalation or outage, delivering bad news
+    like a delay or won't-fix, declining a feature request, or replying to a billing issue.
 - name: kb-article
   path: skills/kb-article/SKILL.md
-  description: Draft a knowledge base article from a resolved issue or common question.
-    Use when a ticket resolution is worth documenting for self-service, the same question
-    keeps coming up, a workaround needs to be published, or a known issue should be
-    communicated to customers.
+  description: Draft a knowledge base article from a resolved issue or common question. Use when a ticket
+    resolution is worth documenting for self-service, the same question keeps coming up, a workaround
+    needs to be published, or a known issue should be communicated to customers.
+- name: ticket-triage
+  path: skills/ticket-triage/SKILL.md
+  description: Triage and prioritize a support ticket or customer issue. Use when a new ticket comes in
+    and needs categorization, assigning P1-P4 priority, deciding which team should handle it, or checking
+    whether it's a duplicate or known issue before routing.
 mcp:
   path: mcp.jsonc
+references:
+- id: connectors
+  path: CONNECTORS.md

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-forgecat/skills/customer-escalation/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-forgecat/skills/customer-escalation/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<issue summary> [customer name]"
 
 # /customer-escalation
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Package a support issue into a structured escalation brief for engineering, product, or leadership. Gathers context, structures reproduction steps, assesses business impact, and identifies the right escalation target.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-forgecat/skills/customer-research/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-forgecat/skills/customer-research/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<question or topic>"
 
 # /customer-research
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Multi-source research on a customer question, product topic, or account-related inquiry. Synthesizes findings from all available sources with clear attribution and confidence scoring.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-forgecat/skills/draft-response/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-forgecat/skills/draft-response/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<situation description>"
 
 # /draft-response
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Draft a professional, customer-facing response tailored to the situation, customer relationship, and communication context.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-forgecat/skills/kb-article/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-forgecat/skills/kb-article/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<resolved issue or ticket>"
 
 # /kb-article
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Draft a publish-ready knowledge base article from a resolved support issue, common question, or documented workaround. Structures the content for searchability and self-service.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-forgecat/skills/ticket-triage/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_customer-support/for-forgecat/skills/ticket-triage/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<ticket or issue description>"
 
 # /ticket-triage
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Categorize, prioritize, and route an incoming support ticket or customer issue. Produces a structured triage assessment with a suggested initial response.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/README.md
@@ -51,7 +51,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_design
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/design |
-| Version | `0.0.8` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -65,6 +65,8 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_design
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-claude/.claude/skills/accessibility-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-claude/.claude/skills/accessibility-review/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <Figma URL, URL, or description>
 
 # /accessibility-review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/CONNECTORS.md`).
 
 Audit a design or page for WCAG 2.1 AA accessibility compliance.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-claude/.claude/skills/design-critique/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-claude/.claude/skills/design-critique/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <Figma URL, screenshot, or description>
 
 # /design-critique
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/CONNECTORS.md`).
 
 Get structured design feedback across multiple dimensions.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-claude/.claude/skills/design-handoff/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-claude/.claude/skills/design-handoff/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <Figma URL or design description>
 
 # /design-handoff
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/CONNECTORS.md`).
 
 Generate comprehensive developer handoff documentation from a design.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-claude/.claude/skills/design-system/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-claude/.claude/skills/design-system/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: "[audit | document | extend] <component or system>"
 
 # /design-system
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/CONNECTORS.md`).
 
 Manage your design system — audit for consistency, document components, or design new patterns.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-claude/.claude/skills/research-synthesis/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-claude/.claude/skills/research-synthesis/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <research data, transcripts, or survey results>
 
 # /research-synthesis
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/CONNECTORS.md`).
 
 Synthesize user research data into actionable insights. See the **user-research** skill for research methods, interview guides, and analysis frameworks.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-claude/.claude/skills/ux-copy/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-claude/.claude/skills/ux-copy/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <context or copy to review>
 
 # /ux-copy
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/CONNECTORS.md`).
 
 Write or review UX copy for any interface context.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/CONNECTORS.md
@@ -1,0 +1,18 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~design tool` might mean Figma, Sketch, or any other design tool with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (design tool, project tracker, user feedback, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Design tool | `~~design tool` | Figma | Sketch, Adobe XD, Framer |
+| Knowledge base | `~~knowledge base` | Notion | Confluence, Guru, Coda |
+| Project tracker | `~~project tracker` | Linear, Asana, Atlassian (Jira/Confluence) | Shortcut, ClickUp |
+| User feedback | `~~user feedback` | Intercom | Productboard, Canny, UserVoice, Dovetail |
+| Product analytics | `~~product analytics` | — | Amplitude, Mixpanel, Heap, FullStory |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Design
@@ -53,7 +53,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_design
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/design |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -65,8 +65,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_design
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-codex/.agents/skills/accessibility-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-codex/.agents/skills/accessibility-review/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <Figma URL, URL, or description>
 
 # /accessibility-review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/CONNECTORS.md`).
 
 Audit a design or page for WCAG 2.1 AA accessibility compliance.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-codex/.agents/skills/design-critique/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-codex/.agents/skills/design-critique/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <Figma URL, screenshot, or description>
 
 # /design-critique
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/CONNECTORS.md`).
 
 Get structured design feedback across multiple dimensions.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-codex/.agents/skills/design-handoff/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-codex/.agents/skills/design-handoff/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <Figma URL or design description>
 
 # /design-handoff
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/CONNECTORS.md`).
 
 Generate comprehensive developer handoff documentation from a design.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-codex/.agents/skills/design-system/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-codex/.agents/skills/design-system/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: "[audit | document | extend] <component or system>"
 
 # /design-system
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/CONNECTORS.md`).
 
 Manage your design system — audit for consistency, document components, or design new patterns.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-codex/.agents/skills/research-synthesis/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-codex/.agents/skills/research-synthesis/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <research data, transcripts, or survey results>
 
 # /research-synthesis
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/CONNECTORS.md`).
 
 Synthesize user research data into actionable insights. See the **user-research** skill for research methods, interview guides, and analysis frameworks.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-codex/.agents/skills/ux-copy/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-codex/.agents/skills/ux-copy/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <context or copy to review>
 
 # /ux-copy
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/CONNECTORS.md`).
 
 Write or review UX copy for any interface context.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/CONNECTORS.md
@@ -1,0 +1,18 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~design tool` might mean Figma, Sketch, or any other design tool with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (design tool, project tracker, user feedback, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Design tool | `~~design tool` | Figma | Sketch, Adobe XD, Framer |
+| Knowledge base | `~~knowledge base` | Notion | Confluence, Guru, Coda |
+| Project tracker | `~~project tracker` | Linear, Asana, Atlassian (Jira/Confluence) | Shortcut, ClickUp |
+| User feedback | `~~user feedback` | Intercom | Productboard, Canny, UserVoice, Dovetail |
+| Product analytics | `~~product analytics` | — | Amplitude, Mixpanel, Heap, FullStory |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Design
@@ -53,7 +53,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_design
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/design |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -65,8 +65,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_design
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-cursor/.cursor/skills/accessibility-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-cursor/.cursor/skills/accessibility-review/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <Figma URL, URL, or description>
 
 # /accessibility-review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/CONNECTORS.md`).
 
 Audit a design or page for WCAG 2.1 AA accessibility compliance.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-cursor/.cursor/skills/design-critique/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-cursor/.cursor/skills/design-critique/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <Figma URL, screenshot, or description>
 
 # /design-critique
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/CONNECTORS.md`).
 
 Get structured design feedback across multiple dimensions.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-cursor/.cursor/skills/design-handoff/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-cursor/.cursor/skills/design-handoff/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <Figma URL or design description>
 
 # /design-handoff
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/CONNECTORS.md`).
 
 Generate comprehensive developer handoff documentation from a design.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-cursor/.cursor/skills/design-system/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-cursor/.cursor/skills/design-system/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: "[audit | document | extend] <component or system>"
 
 # /design-system
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/CONNECTORS.md`).
 
 Manage your design system — audit for consistency, document components, or design new patterns.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-cursor/.cursor/skills/research-synthesis/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-cursor/.cursor/skills/research-synthesis/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <research data, transcripts, or survey results>
 
 # /research-synthesis
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/CONNECTORS.md`).
 
 Synthesize user research data into actionable insights. See the **user-research** skill for research methods, interview guides, and analysis frameworks.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-cursor/.cursor/skills/ux-copy/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-cursor/.cursor/skills/ux-copy/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <context or copy to review>
 
 # /ux-copy
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/CONNECTORS.md`).
 
 Write or review UX copy for any interface context.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/CONNECTORS.md
@@ -1,0 +1,18 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~design tool` might mean Figma, Sketch, or any other design tool with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (design tool, project tracker, user feedback, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Design tool | `~~design tool` | Figma | Sketch, Adobe XD, Framer |
+| Knowledge base | `~~knowledge base` | Notion | Confluence, Guru, Coda |
+| Project tracker | `~~project tracker` | Linear, Asana, Atlassian (Jira/Confluence) | Shortcut, ClickUp |
+| User feedback | `~~user feedback` | Intercom | Productboard, Canny, UserVoice, Dovetail |
+| Product analytics | `~~product analytics` | — | Amplitude, Mixpanel, Heap, FullStory |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_design/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Design
@@ -53,7 +53,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_design
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/design |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -65,8 +65,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_design
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-forgecat/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-forgecat/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-forgecat/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-forgecat/README.md
@@ -53,7 +53,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_design
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/design |
-| Version | `0.0.8` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -67,6 +67,8 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_design
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-forgecat/platforms/claude-code/.claude-plugin/plugin.json
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-forgecat/platforms/claude-code/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "design",
+  "version": "1.2.0",
+  "description": "Accelerate design workflows — critique, design system management, UX writing, accessibility audits, research synthesis, and dev handoff. From exploration to pixel-perfect specs.",
+  "author": {
+    "name": "Anthropic"
+  }
+}

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-forgecat/platforms/claude-code/.mcp.json
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-forgecat/platforms/claude-code/.mcp.json
@@ -1,0 +1,40 @@
+{
+  "mcpServers": {
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
+    },
+    "figma": {
+      "type": "http",
+      "url": "https://mcp.figma.com/mcp"
+    },
+    "linear": {
+      "type": "http",
+      "url": "https://mcp.linear.app/mcp"
+    },
+    "asana": {
+      "type": "http",
+      "url": "https://mcp.asana.com/v2/mcp"
+    },
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp"
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
+    },
+    "intercom": {
+      "type": "http",
+      "url": "https://mcp.intercom.com/mcp"
+    },
+    "google-calendar": {
+      "type": "http",
+      "url": "https://gcal.mcp.claude.com/mcp"
+    },
+    "gmail": {
+      "type": "http",
+      "url": "https://gmail.mcp.claude.com/mcp"
+    }
+  }
+}

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-forgecat/profile.yml
@@ -1,62 +1,60 @@
-name: "@forgecat/anthropics_knowledge-work-plugins_design"
-version: 0.0.8
-description: Accelerate design workflows — critique, design system management, UX
-  writing, accessibility audits, research synthesis, and dev handoff. From exploration
-  to pixel-perfect specs.
+name: '@forgecat/anthropics_knowledge-work-plugins_design'
+description: Accelerate design workflows — critique, design system management, UX writing, accessibility
+  audits, research synthesis, and dev handoff. From exploration to pixel-perfect specs.
+visibility: public
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/design
 license: Apache-2.0
-visibility: public
 sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:
-      - claude-code
-      - cursor
-      - codex
+    - claude-code
+    - cursor
+    - codex
+    partial:
+    - openclaw
+    - hermes
   models:
     recommended: []
     minimum: []
 skills:
-- name: design-critique
-  path: skills/design-critique/SKILL.md
-  description: Get structured design feedback on usability, hierarchy, and consistency.
-    Trigger with "review this design", "critique this mockup", "what do you think
-    of this screen?", or when sharing a Figma link or screenshot for feedback at any
-    stage from exploration to final polish.
-- name: design-system
-  path: skills/design-system/SKILL.md
-  description: Audit, document, or extend your design system. Use when checking for
-    naming inconsistencies or hardcoded values across components, writing documentation
-    for a component's variants, states, and accessibility notes, or designing a new
-    pattern that fits the existing system.
 - name: accessibility-review
   path: skills/accessibility-review/SKILL.md
-  description: Run a WCAG 2.1 AA accessibility audit on a design or page. Trigger
-    with "audit accessibility", "check a11y", "is this accessible?", or when reviewing
-    a design for color contrast, keyboard navigation, touch target size, or screen
-    reader behavior before handoff.
-- name: ux-copy
-  path: skills/ux-copy/SKILL.md
-  description: Write or review UX copy — microcopy, error messages, empty states,
-    CTAs. Trigger with "write copy for", "what should this button say?", "review this
-    error message", or when naming a CTA, wording a confirmation dialog, filling an
-    empty state, or writing onboarding text.
+  description: Run a WCAG 2.1 AA accessibility audit on a design or page. Trigger with "audit accessibility",
+    "check a11y", "is this accessible?", or when reviewing a design for color contrast, keyboard navigation,
+    touch target size, or screen reader behavior before handoff.
+- name: design-critique
+  path: skills/design-critique/SKILL.md
+  description: Get structured design feedback on usability, hierarchy, and consistency. Trigger with "review
+    this design", "critique this mockup", "what do you think of this screen?", or when sharing a Figma
+    link or screenshot for feedback at any stage from exploration to final polish.
 - name: design-handoff
   path: skills/design-handoff/SKILL.md
-  description: Generate developer handoff specs from a design. Use when a design is
-    ready for engineering and needs a spec sheet covering layout, design tokens, component
-    props, interaction states, responsive breakpoints, edge cases, and animation details.
-- name: user-research
-  path: skills/user-research/SKILL.md
-  description: Plan, conduct, and synthesize user research. Trigger with "user research
-    plan", "interview guide", "usability test", "survey design", "research questions",
-    or when the user needs help with any aspect of understanding their users through
-    research.
+  description: Generate developer handoff specs from a design. Use when a design is ready for engineering
+    and needs a spec sheet covering layout, design tokens, component props, interaction states, responsive
+    breakpoints, edge cases, and animation details.
+- name: design-system
+  path: skills/design-system/SKILL.md
+  description: Audit, document, or extend your design system. Use when checking for naming inconsistencies
+    or hardcoded values across components, writing documentation for a component's variants, states, and
+    accessibility notes, or designing a new pattern that fits the existing system.
 - name: research-synthesis
   path: skills/research-synthesis/SKILL.md
-  description: Synthesize user research into themes, insights, and recommendations.
-    Use when you have interview transcripts, survey results, usability test notes,
-    support tickets, or NPS responses that need to be distilled into patterns, user
-    segments, and prioritized next steps.
+  description: Synthesize user research into themes, insights, and recommendations. Use when you have
+    interview transcripts, survey results, usability test notes, support tickets, or NPS responses that
+    need to be distilled into patterns, user segments, and prioritized next steps.
+- name: user-research
+  path: skills/user-research/SKILL.md
+  description: Plan, conduct, and synthesize user research. Trigger with "user research plan", "interview
+    guide", "usability test", "survey design", "research questions", or when the user needs help with
+    any aspect of understanding their users through research.
+- name: ux-copy
+  path: skills/ux-copy/SKILL.md
+  description: Write or review UX copy — microcopy, error messages, empty states, CTAs. Trigger with "write
+    copy for", "what should this button say?", "review this error message", or when naming a CTA, wording
+    a confirmation dialog, filling an empty state, or writing onboarding text.
 mcp:
   path: mcp.jsonc
+references:
+- id: connectors
+  path: CONNECTORS.md

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-forgecat/skills/accessibility-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-forgecat/skills/accessibility-review/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<Figma URL, URL, or description>"
 
 # /accessibility-review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Audit a design or page for WCAG 2.1 AA accessibility compliance.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-forgecat/skills/design-critique/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-forgecat/skills/design-critique/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<Figma URL, screenshot, or description>"
 
 # /design-critique
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Get structured design feedback across multiple dimensions.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-forgecat/skills/design-handoff/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-forgecat/skills/design-handoff/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<Figma URL or design description>"
 
 # /design-handoff
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Generate comprehensive developer handoff documentation from a design.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-forgecat/skills/design-system/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-forgecat/skills/design-system/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[audit | document | extend] <component or system>"
 
 # /design-system
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Manage your design system — audit for consistency, document components, or design new patterns.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-forgecat/skills/research-synthesis/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-forgecat/skills/research-synthesis/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<research data, transcripts, or survey results>"
 
 # /research-synthesis
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Synthesize user research data into actionable insights. See the **user-research** skill for research methods, interview guides, and analysis frameworks.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-forgecat/skills/ux-copy/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_design/for-forgecat/skills/ux-copy/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<context or copy to review>"
 
 # /ux-copy
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Write or review UX copy for any interface context.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/README.md
@@ -55,7 +55,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_engineering
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/engineering |
-| Version | `0.0.8` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -69,6 +69,8 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_engineering
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-claude/.claude/skills/architecture/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-claude/.claude/skills/architecture/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <decision or system to design>
 
 # /architecture
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/CONNECTORS.md`).
 
 Create an Architecture Decision Record (ADR) or evaluate a system design.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-claude/.claude/skills/code-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-claude/.claude/skills/code-review/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <PR URL, diff, or file path>
 
 # /code-review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/CONNECTORS.md`).
 
 Review code changes with a structured lens on security, performance, correctness, and maintainability.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-claude/.claude/skills/debug/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-claude/.claude/skills/debug/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <error message or problem description>
 
 # /debug
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/CONNECTORS.md`).
 
 Run a structured debugging session to find and fix issues systematically.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-claude/.claude/skills/deploy-checklist/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-claude/.claude/skills/deploy-checklist/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: "[service or release name]"
 
 # /deploy-checklist
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/CONNECTORS.md`).
 
 Generate a pre-deployment checklist to verify readiness before shipping.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-claude/.claude/skills/incident-response/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-claude/.claude/skills/incident-response/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <incident description or alert>
 
 # /incident-response
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/CONNECTORS.md`).
 
 Manage an incident from detection through postmortem.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-claude/.claude/skills/standup/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-claude/.claude/skills/standup/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: "[yesterday | today | blockers]"
 
 # /standup
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/CONNECTORS.md`).
 
 Generate a standup update by pulling together recent activity across your tools.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/CONNECTORS.md
@@ -1,0 +1,19 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~source control` might mean GitHub, GitLab, or any other VCS with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (source control, CI/CD, monitoring, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Source control | `~~source control` | GitHub | GitLab, Bitbucket |
+| Project tracker | `~~project tracker` | Linear, Asana, Atlassian (Jira/Confluence) | Shortcut, ClickUp |
+| Knowledge base | `~~knowledge base` | Notion | Confluence, Guru, Coda |
+| Monitoring | `~~monitoring` | Datadog | New Relic, Grafana, Splunk |
+| Incident management | `~~incident management` | PagerDuty | Opsgenie, Incident.io, FireHydrant |
+| CI/CD | `~~CI/CD` | — | CircleCI, GitHub Actions, Jenkins, BuildKite |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Engineering
@@ -57,7 +57,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_engineering
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/engineering |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -69,8 +69,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_engineering
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-codex/.agents/skills/architecture/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-codex/.agents/skills/architecture/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <decision or system to design>
 
 # /architecture
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/CONNECTORS.md`).
 
 Create an Architecture Decision Record (ADR) or evaluate a system design.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-codex/.agents/skills/code-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-codex/.agents/skills/code-review/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <PR URL, diff, or file path>
 
 # /code-review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/CONNECTORS.md`).
 
 Review code changes with a structured lens on security, performance, correctness, and maintainability.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-codex/.agents/skills/debug/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-codex/.agents/skills/debug/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <error message or problem description>
 
 # /debug
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/CONNECTORS.md`).
 
 Run a structured debugging session to find and fix issues systematically.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-codex/.agents/skills/deploy-checklist/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-codex/.agents/skills/deploy-checklist/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: "[service or release name]"
 
 # /deploy-checklist
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/CONNECTORS.md`).
 
 Generate a pre-deployment checklist to verify readiness before shipping.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-codex/.agents/skills/incident-response/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-codex/.agents/skills/incident-response/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <incident description or alert>
 
 # /incident-response
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/CONNECTORS.md`).
 
 Manage an incident from detection through postmortem.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-codex/.agents/skills/standup/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-codex/.agents/skills/standup/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: "[yesterday | today | blockers]"
 
 # /standup
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/CONNECTORS.md`).
 
 Generate a standup update by pulling together recent activity across your tools.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/CONNECTORS.md
@@ -1,0 +1,19 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~source control` might mean GitHub, GitLab, or any other VCS with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (source control, CI/CD, monitoring, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Source control | `~~source control` | GitHub | GitLab, Bitbucket |
+| Project tracker | `~~project tracker` | Linear, Asana, Atlassian (Jira/Confluence) | Shortcut, ClickUp |
+| Knowledge base | `~~knowledge base` | Notion | Confluence, Guru, Coda |
+| Monitoring | `~~monitoring` | Datadog | New Relic, Grafana, Splunk |
+| Incident management | `~~incident management` | PagerDuty | Opsgenie, Incident.io, FireHydrant |
+| CI/CD | `~~CI/CD` | — | CircleCI, GitHub Actions, Jenkins, BuildKite |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Engineering
@@ -57,7 +57,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_engineering
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/engineering |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -69,8 +69,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_engineering
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-cursor/.cursor/skills/architecture/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-cursor/.cursor/skills/architecture/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <decision or system to design>
 
 # /architecture
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/CONNECTORS.md`).
 
 Create an Architecture Decision Record (ADR) or evaluate a system design.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-cursor/.cursor/skills/code-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-cursor/.cursor/skills/code-review/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <PR URL, diff, or file path>
 
 # /code-review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/CONNECTORS.md`).
 
 Review code changes with a structured lens on security, performance, correctness, and maintainability.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-cursor/.cursor/skills/debug/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-cursor/.cursor/skills/debug/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <error message or problem description>
 
 # /debug
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/CONNECTORS.md`).
 
 Run a structured debugging session to find and fix issues systematically.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-cursor/.cursor/skills/deploy-checklist/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-cursor/.cursor/skills/deploy-checklist/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: "[service or release name]"
 
 # /deploy-checklist
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/CONNECTORS.md`).
 
 Generate a pre-deployment checklist to verify readiness before shipping.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-cursor/.cursor/skills/incident-response/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-cursor/.cursor/skills/incident-response/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <incident description or alert>
 
 # /incident-response
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/CONNECTORS.md`).
 
 Manage an incident from detection through postmortem.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-cursor/.cursor/skills/standup/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-cursor/.cursor/skills/standup/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: "[yesterday | today | blockers]"
 
 # /standup
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/CONNECTORS.md`).
 
 Generate a standup update by pulling together recent activity across your tools.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/CONNECTORS.md
@@ -1,0 +1,19 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~source control` might mean GitHub, GitLab, or any other VCS with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (source control, CI/CD, monitoring, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Source control | `~~source control` | GitHub | GitLab, Bitbucket |
+| Project tracker | `~~project tracker` | Linear, Asana, Atlassian (Jira/Confluence) | Shortcut, ClickUp |
+| Knowledge base | `~~knowledge base` | Notion | Confluence, Guru, Coda |
+| Monitoring | `~~monitoring` | Datadog | New Relic, Grafana, Splunk |
+| Incident management | `~~incident management` | PagerDuty | Opsgenie, Incident.io, FireHydrant |
+| CI/CD | `~~CI/CD` | — | CircleCI, GitHub Actions, Jenkins, BuildKite |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_engineering/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Engineering
@@ -57,7 +57,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_engineering
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/engineering |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -69,8 +69,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_engineering
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-forgecat/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-forgecat/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-forgecat/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-forgecat/README.md
@@ -57,7 +57,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_engineering
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/engineering |
-| Version | `0.0.8` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -71,6 +71,8 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_engineering
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-forgecat/platforms/claude-code/.claude-plugin/plugin.json
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-forgecat/platforms/claude-code/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "engineering",
+  "version": "1.2.0",
+  "description": "Streamline engineering workflows — standups, code review, architecture decisions, incident response, and technical documentation. Works with your existing tools or standalone.",
+  "author": {
+    "name": "Anthropic"
+  }
+}

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-forgecat/platforms/claude-code/.mcp.json
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-forgecat/platforms/claude-code/.mcp.json
@@ -1,0 +1,44 @@
+{
+  "mcpServers": {
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
+    },
+    "linear": {
+      "type": "http",
+      "url": "https://mcp.linear.app/mcp"
+    },
+    "asana": {
+      "type": "http",
+      "url": "https://mcp.asana.com/v2/mcp"
+    },
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp"
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
+    },
+    "github": {
+      "type": "http",
+      "url": "https://api.github.com/mcp"
+    },
+    "pagerduty": {
+      "type": "http",
+      "url": "https://mcp.pagerduty.com/mcp"
+    },
+    "datadog": {
+      "type": "http",
+      "url": "https://mcp.datadoghq.com/mcp"
+    },
+    "google-calendar": {
+      "type": "http",
+      "url": "https://gcal.mcp.claude.com/mcp"
+    },
+    "gmail": {
+      "type": "http",
+      "url": "https://gmail.mcp.claude.com/mcp"
+    }
+  }
+}

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-forgecat/profile.yml
@@ -1,80 +1,75 @@
-name: "@forgecat/anthropics_knowledge-work-plugins_engineering"
-version: 0.0.8
-description: Streamline engineering workflows — standups, code review, architecture
-  decisions, incident response, and technical documentation. Works with your existing
-  tools or standalone.
+name: '@forgecat/anthropics_knowledge-work-plugins_engineering'
+description: Streamline engineering workflows — standups, code review, architecture decisions, incident
+  response, and technical documentation. Works with your existing tools or standalone.
+visibility: public
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/engineering
 license: Apache-2.0
-visibility: public
 sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:
-      - claude-code
-      - cursor
-      - codex
+    - claude-code
+    - cursor
+    - codex
+    partial:
+    - openclaw
+    - hermes
   models:
     recommended: []
     minimum: []
 skills:
-- name: standup
-  path: skills/standup/SKILL.md
-  description: Generate a standup update from recent activity. Use when preparing
-    for daily standup, summarizing yesterday's commits and PRs and ticket moves, formatting
-    work into yesterday/today/blockers, or structuring a few rough notes into a shareable
-    update.
-- name: code-review
-  path: skills/code-review/SKILL.md
-  description: Review code changes for security, performance, and correctness. Trigger
-    with a PR URL or diff, "review this before I merge", "is this code safe?", or
-    when checking a change for N+1 queries, injection risks, missing edge cases, or
-    error handling gaps.
 - name: architecture
   path: skills/architecture/SKILL.md
-  description: Create or evaluate an architecture decision record (ADR). Use when
-    choosing between technologies (e.g., Kafka vs SQS), documenting a design decision
-    with trade-offs and consequences, reviewing a system design proposal, or designing
-    a new component from requirements and constraints.
-- name: system-design
-  path: skills/system-design/SKILL.md
-  description: Design systems, services, and architectures. Trigger with "design a
-    system for", "how should we architect", "system design for", "what's the right
-    architecture for", or when the user needs help with API design, data modeling,
-    or service boundaries.
+  description: Create or evaluate an architecture decision record (ADR). Use when choosing between technologies
+    (e.g., Kafka vs SQS), documenting a design decision with trade-offs and consequences, reviewing a
+    system design proposal, or designing a new component from requirements and constraints.
+- name: code-review
+  path: skills/code-review/SKILL.md
+  description: Review code changes for security, performance, and correctness. Trigger with a PR URL or
+    diff, "review this before I merge", "is this code safe?", or when checking a change for N+1 queries,
+    injection risks, missing edge cases, or error handling gaps.
 - name: debug
   path: skills/debug/SKILL.md
-  description: Structured debugging session — reproduce, isolate, diagnose, and fix.
-    Trigger with an error message or stack trace, "this works in staging but not prod",
-    "something broke after the deploy", or when behavior diverges from expected and
-    the cause isn't obvious.
-- name: incident-response
-  path: skills/incident-response/SKILL.md
-  description: Run an incident response workflow — triage, communicate, and write
-    postmortem. Trigger with "we have an incident", "production is down", an alert
-    that needs severity assessment, a status update mid-incident, or when writing
-    a blameless postmortem after resolution.
+  description: Structured debugging session — reproduce, isolate, diagnose, and fix. Trigger with an error
+    message or stack trace, "this works in staging but not prod", "something broke after the deploy",
+    or when behavior diverges from expected and the cause isn't obvious.
 - name: deploy-checklist
   path: skills/deploy-checklist/SKILL.md
-  description: Pre-deployment verification checklist. Use when about to ship a release,
-    deploying a change with database migrations or feature flags, verifying CI status
-    and approvals before going to production, or documenting rollback triggers ahead
-    of time.
+  description: Pre-deployment verification checklist. Use when about to ship a release, deploying a change
+    with database migrations or feature flags, verifying CI status and approvals before going to production,
+    or documenting rollback triggers ahead of time.
 - name: documentation
   path: skills/documentation/SKILL.md
-  description: Write and maintain technical documentation. Trigger with "write docs
-    for", "document this", "create a README", "write a runbook", "onboarding guide",
-    or when the user needs help with any form of technical writing — API docs, architecture
-    docs, or operational runbooks.
+  description: Write and maintain technical documentation. Trigger with "write docs for", "document this",
+    "create a README", "write a runbook", "onboarding guide", or when the user needs help with any form
+    of technical writing — API docs, architecture docs, or operational runbooks.
+- name: incident-response
+  path: skills/incident-response/SKILL.md
+  description: Run an incident response workflow — triage, communicate, and write postmortem. Trigger
+    with "we have an incident", "production is down", an alert that needs severity assessment, a status
+    update mid-incident, or when writing a blameless postmortem after resolution.
+- name: standup
+  path: skills/standup/SKILL.md
+  description: Generate a standup update from recent activity. Use when preparing for daily standup, summarizing
+    yesterday's commits and PRs and ticket moves, formatting work into yesterday/today/blockers, or structuring
+    a few rough notes into a shareable update.
+- name: system-design
+  path: skills/system-design/SKILL.md
+  description: Design systems, services, and architectures. Trigger with "design a system for", "how should
+    we architect", "system design for", "what's the right architecture for", or when the user needs help
+    with API design, data modeling, or service boundaries.
 - name: tech-debt
   path: skills/tech-debt/SKILL.md
-  description: Identify, categorize, and prioritize technical debt. Trigger with "tech
-    debt", "technical debt audit", "what should we refactor", "code health", or when
-    the user asks about code quality, refactoring priorities, or maintenance backlog.
+  description: Identify, categorize, and prioritize technical debt. Trigger with "tech debt", "technical
+    debt audit", "what should we refactor", "code health", or when the user asks about code quality, refactoring
+    priorities, or maintenance backlog.
 - name: testing-strategy
   path: skills/testing-strategy/SKILL.md
-  description: Design test strategies and test plans. Trigger with "how should we
-    test", "test strategy for", "write tests for", "test plan", "what tests do we
-    need", or when the user needs help with testing approaches, coverage, or test
-    architecture.
+  description: Design test strategies and test plans. Trigger with "how should we test", "test strategy
+    for", "write tests for", "test plan", "what tests do we need", or when the user needs help with testing
+    approaches, coverage, or test architecture.
 mcp:
   path: mcp.jsonc
+references:
+- id: connectors
+  path: CONNECTORS.md

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-forgecat/skills/architecture/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-forgecat/skills/architecture/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<decision or system to design>"
 
 # /architecture
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Create an Architecture Decision Record (ADR) or evaluate a system design.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-forgecat/skills/code-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-forgecat/skills/code-review/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<PR URL, diff, or file path>"
 
 # /code-review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Review code changes with a structured lens on security, performance, correctness, and maintainability.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-forgecat/skills/debug/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-forgecat/skills/debug/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<error message or problem description>"
 
 # /debug
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Run a structured debugging session to find and fix issues systematically.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-forgecat/skills/deploy-checklist/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-forgecat/skills/deploy-checklist/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[service or release name]"
 
 # /deploy-checklist
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Generate a pre-deployment checklist to verify readiness before shipping.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-forgecat/skills/incident-response/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-forgecat/skills/incident-response/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<incident description or alert>"
 
 # /incident-response
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Manage an incident from detection through postmortem.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-forgecat/skills/standup/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_engineering/for-forgecat/skills/standup/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[yesterday | today | blockers]"
 
 # /standup
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Generate a standup update by pulling together recent activity across your tools.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/README.md
@@ -47,7 +47,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_enterprise-sear
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/enterprise-search |
-| Version | `0.0.8` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -61,6 +61,8 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_enterprise-sear
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-claude/.claude/skills/digest/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-claude/.claude/skills/digest/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: "[--daily | --weekly | --since <date>]"
 
 # Digest Command
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/CONNECTORS.md`).
 
 Scan recent activity across all connected sources and generate a structured digest highlighting what matters.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-claude/.claude/skills/search-strategy/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-claude/.claude/skills/search-strategy/SKILL.md
@@ -9,7 +9,7 @@ user-invocable: false
 
 # Search Strategy
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/CONNECTORS.md`).
 
 The core intelligence behind enterprise search. Transforms a single natural language question into parallel, source-specific searches and produces ranked, deduplicated results.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-claude/.claude/skills/search/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-claude/.claude/skills/search/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <query>
 
 # Search Command
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/CONNECTORS.md`).
 
 Search across all connected MCP sources in a single query. Decompose the user's question, run parallel searches, and synthesize results.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-claude/.claude/skills/source-management/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-claude/.claude/skills/source-management/SKILL.md
@@ -8,7 +8,7 @@ user-invocable: false
 
 # Source Management
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/CONNECTORS.md`).
 
 Knows what sources are available, helps connect new ones, and manages how sources are queried.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/CONNECTORS.md
@@ -1,0 +1,21 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~chat` might mean Slack, Microsoft Teams, or any other chat tool with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (chat, email, cloud storage, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+This plugin uses `~~category` references extensively as source labels in search output (e.g. `~~chat:`, `~~email:`). These are intentional — they represent dynamic category markers that resolve to whatever tool is connected.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Chat | `~~chat` | Slack | Microsoft Teams, Discord |
+| Email | `~~email` | Microsoft 365 | — |
+| Cloud storage | `~~cloud storage` | Microsoft 365 | Dropbox |
+| Knowledge base | `~~knowledge base` | Notion, Guru | Confluence, Slite |
+| Project tracker | `~~project tracker` | Atlassian (Jira/Confluence), Asana | Linear, monday.com |
+| CRM | `~~CRM` | *(not pre-configured)* | Salesforce, HubSpot |
+| Office suite | `~~office suite` | Microsoft 365 | Google Workspace |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Enterprise Search
@@ -49,7 +49,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_enterprise-sear
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/enterprise-search |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -61,8 +61,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_enterprise-sear
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-codex/.agents/skills/digest/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-codex/.agents/skills/digest/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: "[--daily | --weekly | --since <date>]"
 
 # Digest Command
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/CONNECTORS.md`).
 
 Scan recent activity across all connected sources and generate a structured digest highlighting what matters.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-codex/.agents/skills/search-strategy/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-codex/.agents/skills/search-strategy/SKILL.md
@@ -9,7 +9,7 @@ user-invocable: false
 
 # Search Strategy
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/CONNECTORS.md`).
 
 The core intelligence behind enterprise search. Transforms a single natural language question into parallel, source-specific searches and produces ranked, deduplicated results.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-codex/.agents/skills/search/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-codex/.agents/skills/search/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <query>
 
 # Search Command
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/CONNECTORS.md`).
 
 Search across all connected MCP sources in a single query. Decompose the user's question, run parallel searches, and synthesize results.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-codex/.agents/skills/source-management/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-codex/.agents/skills/source-management/SKILL.md
@@ -8,7 +8,7 @@ user-invocable: false
 
 # Source Management
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/CONNECTORS.md`).
 
 Knows what sources are available, helps connect new ones, and manages how sources are queried.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/CONNECTORS.md
@@ -1,0 +1,21 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~chat` might mean Slack, Microsoft Teams, or any other chat tool with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (chat, email, cloud storage, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+This plugin uses `~~category` references extensively as source labels in search output (e.g. `~~chat:`, `~~email:`). These are intentional — they represent dynamic category markers that resolve to whatever tool is connected.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Chat | `~~chat` | Slack | Microsoft Teams, Discord |
+| Email | `~~email` | Microsoft 365 | — |
+| Cloud storage | `~~cloud storage` | Microsoft 365 | Dropbox |
+| Knowledge base | `~~knowledge base` | Notion, Guru | Confluence, Slite |
+| Project tracker | `~~project tracker` | Atlassian (Jira/Confluence), Asana | Linear, monday.com |
+| CRM | `~~CRM` | *(not pre-configured)* | Salesforce, HubSpot |
+| Office suite | `~~office suite` | Microsoft 365 | Google Workspace |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Enterprise Search
@@ -49,7 +49,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_enterprise-sear
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/enterprise-search |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -61,8 +61,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_enterprise-sear
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-cursor/.cursor/skills/digest/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-cursor/.cursor/skills/digest/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: "[--daily | --weekly | --since <date>]"
 
 # Digest Command
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/CONNECTORS.md`).
 
 Scan recent activity across all connected sources and generate a structured digest highlighting what matters.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-cursor/.cursor/skills/search-strategy/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-cursor/.cursor/skills/search-strategy/SKILL.md
@@ -9,7 +9,7 @@ user-invocable: false
 
 # Search Strategy
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/CONNECTORS.md`).
 
 The core intelligence behind enterprise search. Transforms a single natural language question into parallel, source-specific searches and produces ranked, deduplicated results.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-cursor/.cursor/skills/search/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-cursor/.cursor/skills/search/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <query>
 
 # Search Command
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/CONNECTORS.md`).
 
 Search across all connected MCP sources in a single query. Decompose the user's question, run parallel searches, and synthesize results.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-cursor/.cursor/skills/source-management/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-cursor/.cursor/skills/source-management/SKILL.md
@@ -8,7 +8,7 @@ user-invocable: false
 
 # Source Management
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/CONNECTORS.md`).
 
 Knows what sources are available, helps connect new ones, and manages how sources are queried.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/CONNECTORS.md
@@ -1,0 +1,21 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~chat` might mean Slack, Microsoft Teams, or any other chat tool with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (chat, email, cloud storage, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+This plugin uses `~~category` references extensively as source labels in search output (e.g. `~~chat:`, `~~email:`). These are intentional — they represent dynamic category markers that resolve to whatever tool is connected.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Chat | `~~chat` | Slack | Microsoft Teams, Discord |
+| Email | `~~email` | Microsoft 365 | — |
+| Cloud storage | `~~cloud storage` | Microsoft 365 | Dropbox |
+| Knowledge base | `~~knowledge base` | Notion, Guru | Confluence, Slite |
+| Project tracker | `~~project tracker` | Atlassian (Jira/Confluence), Asana | Linear, monday.com |
+| CRM | `~~CRM` | *(not pre-configured)* | Salesforce, HubSpot |
+| Office suite | `~~office suite` | Microsoft 365 | Google Workspace |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_enterprise-search/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Enterprise Search
@@ -49,7 +49,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_enterprise-sear
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/enterprise-search |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -61,8 +61,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_enterprise-sear
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-forgecat/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-forgecat/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-forgecat/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-forgecat/README.md
@@ -49,7 +49,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_enterprise-sear
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/enterprise-search |
-| Version | `0.0.8` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -63,6 +63,8 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_enterprise-sear
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-forgecat/platforms/claude-code/.claude-plugin/plugin.json
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-forgecat/platforms/claude-code/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "enterprise-search",
+  "version": "1.2.0",
+  "description": "Search across all of your company's tools in one place. Find anything across email, chat, documents, and wikis without switching between apps.",
+  "author": {
+    "name": "Anthropic"
+  }
+}

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-forgecat/platforms/claude-code/.mcp.json
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-forgecat/platforms/claude-code/.mcp.json
@@ -1,0 +1,36 @@
+{
+  "mcpServers": {
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
+    },
+    "guru": {
+      "type": "http",
+      "url": "https://mcp.api.getguru.com/mcp"
+    },
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp"
+    },
+    "asana": {
+      "type": "http",
+      "url": "https://mcp.asana.com/v2/mcp"
+    },
+    "ms365": {
+      "type": "http",
+      "url": "https://microsoft365.mcp.claude.com/mcp"
+    },
+    "google-calendar": {
+      "type": "http",
+      "url": "https://gcal.mcp.claude.com/mcp"
+    },
+    "gmail": {
+      "type": "http",
+      "url": "https://gmail.mcp.claude.com/mcp"
+    }
+  }
+}

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-forgecat/profile.yml
@@ -1,48 +1,49 @@
-name: "@forgecat/anthropics_knowledge-work-plugins_enterprise-search"
-version: 0.0.8
-description: Search across all of your company's tools in one place. Find anything
-  across email, chat, documents, and wikis without switching between apps.
+name: '@forgecat/anthropics_knowledge-work-plugins_enterprise-search'
+description: Search across all of your company's tools in one place. Find anything across email, chat,
+  documents, and wikis without switching between apps.
+visibility: public
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/enterprise-search
 license: Apache-2.0
-visibility: public
 sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:
-      - claude-code
-      - cursor
-      - codex
+    - claude-code
+    - cursor
+    - codex
+    partial:
+    - openclaw
+    - hermes
   models:
     recommended: []
     minimum: []
 skills:
-- name: search
-  path: skills/search/SKILL.md
-  description: Search across all connected sources in one query. Trigger with "find
-    that doc about...", "what did we decide on...", "where was the conversation about...",
-    or when looking for a decision, document, or discussion that could live in chat,
-    email, cloud storage, or a project tracker.
 - name: digest
   path: skills/digest/SKILL.md
-  description: Generate a daily or weekly digest of activity across all connected
-    sources. Use when catching up after time away, starting the day and wanting a
-    summary of mentions and action items, or reviewing a week's decisions and document
-    updates grouped by project.
-- name: search-strategy
-  path: skills/search-strategy/SKILL.md
-  description: Query decomposition and multi-source search orchestration. Breaks natural
-    language questions into targeted searches per source, translates queries into
-    source-specific syntax, ranks results by relevance, and handles ambiguity and
-    fallback strategies.
+  description: Generate a daily or weekly digest of activity across all connected sources. Use when catching
+    up after time away, starting the day and wanting a summary of mentions and action items, or reviewing
+    a week's decisions and document updates grouped by project.
 - name: knowledge-synthesis
   path: skills/knowledge-synthesis/SKILL.md
-  description: Combines search results from multiple sources into coherent, deduplicated
-    answers with source attribution. Handles confidence scoring based on freshness
-    and authority, and summarizes large result sets effectively.
+  description: Combines search results from multiple sources into coherent, deduplicated answers with
+    source attribution. Handles confidence scoring based on freshness and authority, and summarizes large
+    result sets effectively.
+- name: search
+  path: skills/search/SKILL.md
+  description: Search across all connected sources in one query. Trigger with "find that doc about...",
+    "what did we decide on...", "where was the conversation about...", or when looking for a decision,
+    document, or discussion that could live in chat, email, cloud storage, or a project tracker.
+- name: search-strategy
+  path: skills/search-strategy/SKILL.md
+  description: Query decomposition and multi-source search orchestration. Breaks natural language questions
+    into targeted searches per source, translates queries into source-specific syntax, ranks results by
+    relevance, and handles ambiguity and fallback strategies.
 - name: source-management
   path: skills/source-management/SKILL.md
-  description: Manages connected MCP sources for enterprise search. Detects available
-    sources, guides users to connect new ones, handles source priority ordering, and
-    manages rate limiting awareness.
+  description: Manages connected MCP sources for enterprise search. Detects available sources, guides
+    users to connect new ones, handles source priority ordering, and manages rate limiting awareness.
 mcp:
   path: mcp.jsonc
+references:
+- id: connectors
+  path: CONNECTORS.md

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-forgecat/skills/digest/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-forgecat/skills/digest/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[--daily | --weekly | --since <date>]"
 
 # Digest Command
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Scan recent activity across all connected sources and generate a structured digest highlighting what matters.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-forgecat/skills/search-strategy/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-forgecat/skills/search-strategy/SKILL.md
@@ -6,7 +6,7 @@ user-invocable: false
 
 # Search Strategy
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 The core intelligence behind enterprise search. Transforms a single natural language question into parallel, source-specific searches and produces ranked, deduplicated results.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-forgecat/skills/search/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-forgecat/skills/search/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<query>"
 
 # Search Command
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Search across all connected MCP sources in a single query. Decompose the user's question, run parallel searches, and synthesize results.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-forgecat/skills/source-management/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_enterprise-search/for-forgecat/skills/source-management/SKILL.md
@@ -6,7 +6,7 @@ user-invocable: false
 
 # Source Management
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Knows what sources are available, helps connect new ones, and manages how sources are queried.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/README.md
@@ -50,7 +50,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_finance
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/finance |
-| Version | `0.0.8` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -64,6 +64,8 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_finance
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-claude/.claude/skills/financial-statements/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-claude/.claude/skills/financial-statements/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: <frequency> <period>
 
 # /financial-statements
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/CONNECTORS.md`).
 
 **Important**: This command assists with financial statement workflows but does not provide financial advice. All statements should be reviewed by qualified financial professionals before use in reporting or filings.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-claude/.claude/skills/journal-entry/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-claude/.claude/skills/journal-entry/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <entry type> [period]
 
 # Journal Entry Preparation
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/CONNECTORS.md`).
 
 **Important**: This command assists with journal entry workflows but does not provide financial advice. All entries should be reviewed by qualified financial professionals before posting.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-claude/.claude/skills/sox-testing/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-claude/.claude/skills/sox-testing/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <control area> [period]
 
 # SOX Compliance Testing
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/CONNECTORS.md`).
 
 **Important**: This command assists with SOX compliance workflows but does not provide audit or legal advice. All testing workpapers and assessments should be reviewed by qualified financial professionals before use in audit documentation.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/CONNECTORS.md
@@ -1,0 +1,20 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~data warehouse` might mean Snowflake, BigQuery, or any other warehouse with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (data warehouse, chat, project tracker, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Data warehouse | `~~data warehouse` | Snowflake\*, Databricks\*, BigQuery | Redshift, PostgreSQL |
+| Email | `~~email` | Microsoft 365 | — |
+| Office suite | `~~office suite` | Microsoft 365 | — |
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| ERP / Accounting | `~~erp` | — (no supported MCP servers yet) | NetSuite, SAP, QuickBooks, Xero |
+| Analytics / BI | `~~analytics` | — (no supported MCP servers yet) | Tableau, Looker, Power BI |
+
+\* Placeholder — MCP URL not yet configured

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Finance
@@ -52,7 +52,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_finance
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/finance |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -64,8 +64,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_finance
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-codex/.agents/skills/financial-statements/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-codex/.agents/skills/financial-statements/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: <frequency> <period>
 
 # /financial-statements
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/CONNECTORS.md`).
 
 **Important**: This command assists with financial statement workflows but does not provide financial advice. All statements should be reviewed by qualified financial professionals before use in reporting or filings.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-codex/.agents/skills/journal-entry/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-codex/.agents/skills/journal-entry/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <entry type> [period]
 
 # Journal Entry Preparation
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/CONNECTORS.md`).
 
 **Important**: This command assists with journal entry workflows but does not provide financial advice. All entries should be reviewed by qualified financial professionals before posting.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-codex/.agents/skills/sox-testing/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-codex/.agents/skills/sox-testing/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <control area> [period]
 
 # SOX Compliance Testing
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/CONNECTORS.md`).
 
 **Important**: This command assists with SOX compliance workflows but does not provide audit or legal advice. All testing workpapers and assessments should be reviewed by qualified financial professionals before use in audit documentation.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/CONNECTORS.md
@@ -1,0 +1,20 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~data warehouse` might mean Snowflake, BigQuery, or any other warehouse with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (data warehouse, chat, project tracker, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Data warehouse | `~~data warehouse` | Snowflake\*, Databricks\*, BigQuery | Redshift, PostgreSQL |
+| Email | `~~email` | Microsoft 365 | — |
+| Office suite | `~~office suite` | Microsoft 365 | — |
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| ERP / Accounting | `~~erp` | — (no supported MCP servers yet) | NetSuite, SAP, QuickBooks, Xero |
+| Analytics / BI | `~~analytics` | — (no supported MCP servers yet) | Tableau, Looker, Power BI |
+
+\* Placeholder — MCP URL not yet configured

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Finance
@@ -52,7 +52,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_finance
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/finance |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -64,8 +64,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_finance
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-cursor/.cursor/skills/financial-statements/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-cursor/.cursor/skills/financial-statements/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: <frequency> <period>
 
 # /financial-statements
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/CONNECTORS.md`).
 
 **Important**: This command assists with financial statement workflows but does not provide financial advice. All statements should be reviewed by qualified financial professionals before use in reporting or filings.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-cursor/.cursor/skills/journal-entry/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-cursor/.cursor/skills/journal-entry/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <entry type> [period]
 
 # Journal Entry Preparation
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/CONNECTORS.md`).
 
 **Important**: This command assists with journal entry workflows but does not provide financial advice. All entries should be reviewed by qualified financial professionals before posting.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-cursor/.cursor/skills/sox-testing/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-cursor/.cursor/skills/sox-testing/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <control area> [period]
 
 # SOX Compliance Testing
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/CONNECTORS.md`).
 
 **Important**: This command assists with SOX compliance workflows but does not provide audit or legal advice. All testing workpapers and assessments should be reviewed by qualified financial professionals before use in audit documentation.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/CONNECTORS.md
@@ -1,0 +1,20 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~data warehouse` might mean Snowflake, BigQuery, or any other warehouse with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (data warehouse, chat, project tracker, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Data warehouse | `~~data warehouse` | Snowflake\*, Databricks\*, BigQuery | Redshift, PostgreSQL |
+| Email | `~~email` | Microsoft 365 | — |
+| Office suite | `~~office suite` | Microsoft 365 | — |
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| ERP / Accounting | `~~erp` | — (no supported MCP servers yet) | NetSuite, SAP, QuickBooks, Xero |
+| Analytics / BI | `~~analytics` | — (no supported MCP servers yet) | Tableau, Looker, Power BI |
+
+\* Placeholder — MCP URL not yet configured

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_finance/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Finance
@@ -52,7 +52,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_finance
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/finance |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -64,8 +64,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_finance
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-forgecat/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-forgecat/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-forgecat/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-forgecat/README.md
@@ -52,7 +52,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_finance
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/finance |
-| Version | `0.0.8` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -66,6 +66,8 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_finance
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-forgecat/platforms/claude-code/.claude-plugin/plugin.json
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-forgecat/platforms/claude-code/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "finance",
+  "version": "1.2.0",
+  "description": "Streamline finance and accounting workflows, from journal entries and reconciliation to financial statements and variance analysis. Speed up audit prep, month-end close, and keeping your books clean.",
+  "author": {
+    "name": "Anthropic"
+  }
+}

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-forgecat/platforms/claude-code/.mcp.json
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-forgecat/platforms/claude-code/.mcp.json
@@ -1,0 +1,32 @@
+{
+  "mcpServers": {
+    "snowflake": {
+      "type": "http",
+      "url": ""
+    },
+    "databricks": {
+      "type": "http",
+      "url": ""
+    },
+    "bigquery": {
+      "type": "http",
+      "url": "https://bigquery.googleapis.com/mcp"
+    },
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
+    },
+    "ms365": {
+      "type": "http",
+      "url": "https://microsoft365.mcp.claude.com/mcp"
+    },
+    "google-calendar": {
+      "type": "http",
+      "url": "https://gcal.mcp.claude.com/mcp"
+    },
+    "gmail": {
+      "type": "http",
+      "url": "https://gmail.mcp.claude.com/mcp"
+    }
+  }
+}

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-forgecat/profile.yml
@@ -1,68 +1,66 @@
-name: "@forgecat/anthropics_knowledge-work-plugins_finance"
-version: 0.0.8
-description: Streamline finance and accounting workflows, from journal entries and
-  reconciliation to financial statements and variance analysis. Speed up audit prep,
-  month-end close, and keeping your books clean.
+name: '@forgecat/anthropics_knowledge-work-plugins_finance'
+description: Streamline finance and accounting workflows, from journal entries and reconciliation to financial
+  statements and variance analysis. Speed up audit prep, month-end close, and keeping your books clean.
+visibility: public
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/finance
 license: Apache-2.0
-visibility: public
 sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:
-      - claude-code
-      - cursor
-      - codex
+    - claude-code
+    - cursor
+    - codex
+    partial:
+    - openclaw
+    - hermes
   models:
     recommended: []
     minimum: []
 skills:
-- name: journal-entry
-  path: skills/journal-entry/SKILL.md
-  description: Prepare journal entries with proper debits, credits, and supporting
-    detail. Use when booking month-end accruals (AP, payroll, prepaid), recording
-    depreciation or amortization, posting revenue recognition or deferred revenue
-    adjustments, or documenting an entry for audit review.
-- name: reconciliation
-  path: skills/reconciliation/SKILL.md
-  description: Reconcile accounts by comparing GL balances to subledgers, bank statements,
-    or third-party data. Use when performing bank reconciliations, GL-to-subledger
-    recs, intercompany reconciliations, or identifying and categorizing reconciling
-    items.
-- name: financial-statements
-  path: skills/financial-statements/SKILL.md
-  description: Generate financial statements (income statement, balance sheet, cash
-    flow) with period-over-period comparison and variance analysis. Use when preparing
-    a monthly or quarterly P&L, closing the books and need to flag material variances,
-    comparing actuals to budget, building a financial summary for leadership review,
-    or looking up GAAP presentation requirements and period-end adjustments.
-- name: variance-analysis
-  path: skills/variance-analysis/SKILL.md
-  description: Decompose financial variances into drivers with narrative explanations
-    and waterfall analysis. Use when analyzing budget vs. actual, period-over-period
-    changes, revenue or expense variances, or preparing variance commentary for leadership.
-- name: sox-testing
-  path: skills/sox-testing/SKILL.md
-  description: Generate SOX sample selections, testing workpapers, and control assessments.
-    Use when planning quarterly or annual SOX 404 testing, pulling a sample for a
-    control (revenue, P2P, ITGC, close), building a testing workpaper template, or
-    evaluating and classifying a control deficiency.
-- name: close-management
-  path: skills/close-management/SKILL.md
-  description: Manage the month-end close process with task sequencing, dependencies,
-    and status tracking. Use when planning the close calendar, tracking close progress,
-    identifying blockers, or sequencing close activities by day.
-- name: journal-entry-prep
-  path: skills/journal-entry-prep/SKILL.md
-  description: Prepare journal entries with proper debits, credits, and supporting
-    documentation for month-end close. Use when booking accruals, prepaid amortization,
-    fixed asset depreciation, payroll entries, revenue recognition, or any manual
-    journal entry.
 - name: audit-support
   path: skills/audit-support/SKILL.md
-  description: Support SOX 404 compliance with control testing methodology, sample
-    selection, and documentation standards. Use when generating testing workpapers,
-    selecting audit samples, classifying control deficiencies, or preparing for internal
-    or external audits.
+  description: Support SOX 404 compliance with control testing methodology, sample selection, and documentation
+    standards. Use when generating testing workpapers, selecting audit samples, classifying control deficiencies,
+    or preparing for internal or external audits.
+- name: close-management
+  path: skills/close-management/SKILL.md
+  description: Manage the month-end close process with task sequencing, dependencies, and status tracking.
+    Use when planning the close calendar, tracking close progress, identifying blockers, or sequencing
+    close activities by day.
+- name: financial-statements
+  path: skills/financial-statements/SKILL.md
+  description: Generate financial statements (income statement, balance sheet, cash flow) with period-over-period
+    comparison and variance analysis. Use when preparing a monthly or quarterly P&L, closing the books
+    and need to flag material variances, comparing actuals to budget, building a financial summary for
+    leadership review, or looking up GAAP presentation requirements and period-end adjustments.
+- name: journal-entry
+  path: skills/journal-entry/SKILL.md
+  description: Prepare journal entries with proper debits, credits, and supporting detail. Use when booking
+    month-end accruals (AP, payroll, prepaid), recording depreciation or amortization, posting revenue
+    recognition or deferred revenue adjustments, or documenting an entry for audit review.
+- name: journal-entry-prep
+  path: skills/journal-entry-prep/SKILL.md
+  description: Prepare journal entries with proper debits, credits, and supporting documentation for month-end
+    close. Use when booking accruals, prepaid amortization, fixed asset depreciation, payroll entries,
+    revenue recognition, or any manual journal entry.
+- name: reconciliation
+  path: skills/reconciliation/SKILL.md
+  description: Reconcile accounts by comparing GL balances to subledgers, bank statements, or third-party
+    data. Use when performing bank reconciliations, GL-to-subledger recs, intercompany reconciliations,
+    or identifying and categorizing reconciling items.
+- name: sox-testing
+  path: skills/sox-testing/SKILL.md
+  description: Generate SOX sample selections, testing workpapers, and control assessments. Use when planning
+    quarterly or annual SOX 404 testing, pulling a sample for a control (revenue, P2P, ITGC, close), building
+    a testing workpaper template, or evaluating and classifying a control deficiency.
+- name: variance-analysis
+  path: skills/variance-analysis/SKILL.md
+  description: Decompose financial variances into drivers with narrative explanations and waterfall analysis.
+    Use when analyzing budget vs. actual, period-over-period changes, revenue or expense variances, or
+    preparing variance commentary for leadership.
 mcp:
   path: mcp.jsonc
+references:
+- id: connectors
+  path: CONNECTORS.md

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-forgecat/skills/financial-statements/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-forgecat/skills/financial-statements/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<frequency> <period>"
 
 # /financial-statements
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 **Important**: This command assists with financial statement workflows but does not provide financial advice. All statements should be reviewed by qualified financial professionals before use in reporting or filings.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-forgecat/skills/journal-entry/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-forgecat/skills/journal-entry/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<entry type> [period]"
 
 # Journal Entry Preparation
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 **Important**: This command assists with journal entry workflows but does not provide financial advice. All entries should be reviewed by qualified financial professionals before posting.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-forgecat/skills/sox-testing/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_finance/for-forgecat/skills/sox-testing/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<control area> [period]"
 
 # SOX Compliance Testing
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 **Important**: This command assists with SOX compliance workflows but does not provide audit or legal advice. All testing workpapers and assessments should be reviewed by qualified financial professionals before use in audit documentation.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/README.md
@@ -50,7 +50,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_human-resources
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/human-resources |
-| Version | `0.0.8` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -64,6 +64,8 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_human-resources
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-claude/.claude/skills/comp-analysis/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-claude/.claude/skills/comp-analysis/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <role, level, or dataset>
 
 # /comp-analysis
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/CONNECTORS.md`).
 
 Analyze compensation data for benchmarking, band placement, and planning. Helps benchmark compensation against market data for hiring, retention, and equity planning.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-claude/.claude/skills/draft-offer/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-claude/.claude/skills/draft-offer/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <role and level>
 
 # /draft-offer
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/CONNECTORS.md`).
 
 Draft a complete offer letter for a new hire.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-claude/.claude/skills/onboarding/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-claude/.claude/skills/onboarding/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <new hire name and role>
 
 # /onboarding
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/CONNECTORS.md`).
 
 Generate a comprehensive onboarding plan for a new team member.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-claude/.claude/skills/people-report/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-claude/.claude/skills/people-report/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <report type — headcount, attrition, diversity, org health>
 
 # /people-report
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/CONNECTORS.md`).
 
 Generate people analytics reports from your HR data. Analyze workforce data to surface trends, risks, and opportunities.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-claude/.claude/skills/performance-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-claude/.claude/skills/performance-review/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <employee name or review cycle>
 
 # /performance-review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/CONNECTORS.md`).
 
 Generate performance review templates and help structure feedback.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-claude/.claude/skills/policy-lookup/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-claude/.claude/skills/policy-lookup/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <policy topic — PTO, benefits, travel, expenses, etc.>
 
 # /policy-lookup
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/CONNECTORS.md`).
 
 Look up and explain company policies in plain language. Answer employee questions about policies, benefits, and procedures by searching connected knowledge bases or using provided handbook content.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/CONNECTORS.md
@@ -1,0 +1,19 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~HRIS` might mean Workday, BambooHR, or any other HRIS with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (HRIS, ATS, email, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| ATS | `~~ATS` | — | Greenhouse, Lever, Ashby, Workable |
+| Calendar | `~~calendar` | Google Calendar | Microsoft 365 |
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Email | `~~email` | Gmail, Microsoft 365 | — |
+| HRIS | `~~HRIS` | — | Workday, BambooHR, Rippling, Gusto |
+| Knowledge base | `~~knowledge base` | Notion, Atlassian (Confluence) | Guru, Coda |
+| Compensation data | `~~compensation data` | — | Pave, Radford, Levels.fyi |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Human Resources
@@ -52,7 +52,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_human-resources
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/human-resources |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -64,8 +64,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_human-resources
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-codex/.agents/skills/comp-analysis/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-codex/.agents/skills/comp-analysis/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <role, level, or dataset>
 
 # /comp-analysis
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/CONNECTORS.md`).
 
 Analyze compensation data for benchmarking, band placement, and planning. Helps benchmark compensation against market data for hiring, retention, and equity planning.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-codex/.agents/skills/draft-offer/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-codex/.agents/skills/draft-offer/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <role and level>
 
 # /draft-offer
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/CONNECTORS.md`).
 
 Draft a complete offer letter for a new hire.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-codex/.agents/skills/onboarding/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-codex/.agents/skills/onboarding/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <new hire name and role>
 
 # /onboarding
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/CONNECTORS.md`).
 
 Generate a comprehensive onboarding plan for a new team member.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-codex/.agents/skills/people-report/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-codex/.agents/skills/people-report/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <report type — headcount, attrition, diversity, org health>
 
 # /people-report
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/CONNECTORS.md`).
 
 Generate people analytics reports from your HR data. Analyze workforce data to surface trends, risks, and opportunities.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-codex/.agents/skills/performance-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-codex/.agents/skills/performance-review/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <employee name or review cycle>
 
 # /performance-review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/CONNECTORS.md`).
 
 Generate performance review templates and help structure feedback.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-codex/.agents/skills/policy-lookup/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-codex/.agents/skills/policy-lookup/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <policy topic — PTO, benefits, travel, expenses, etc.>
 
 # /policy-lookup
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/CONNECTORS.md`).
 
 Look up and explain company policies in plain language. Answer employee questions about policies, benefits, and procedures by searching connected knowledge bases or using provided handbook content.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/CONNECTORS.md
@@ -1,0 +1,19 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~HRIS` might mean Workday, BambooHR, or any other HRIS with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (HRIS, ATS, email, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| ATS | `~~ATS` | — | Greenhouse, Lever, Ashby, Workable |
+| Calendar | `~~calendar` | Google Calendar | Microsoft 365 |
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Email | `~~email` | Gmail, Microsoft 365 | — |
+| HRIS | `~~HRIS` | — | Workday, BambooHR, Rippling, Gusto |
+| Knowledge base | `~~knowledge base` | Notion, Atlassian (Confluence) | Guru, Coda |
+| Compensation data | `~~compensation data` | — | Pave, Radford, Levels.fyi |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Human Resources
@@ -52,7 +52,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_human-resources
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/human-resources |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -64,8 +64,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_human-resources
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-cursor/.cursor/skills/comp-analysis/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-cursor/.cursor/skills/comp-analysis/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <role, level, or dataset>
 
 # /comp-analysis
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/CONNECTORS.md`).
 
 Analyze compensation data for benchmarking, band placement, and planning. Helps benchmark compensation against market data for hiring, retention, and equity planning.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-cursor/.cursor/skills/draft-offer/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-cursor/.cursor/skills/draft-offer/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <role and level>
 
 # /draft-offer
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/CONNECTORS.md`).
 
 Draft a complete offer letter for a new hire.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-cursor/.cursor/skills/onboarding/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-cursor/.cursor/skills/onboarding/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <new hire name and role>
 
 # /onboarding
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/CONNECTORS.md`).
 
 Generate a comprehensive onboarding plan for a new team member.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-cursor/.cursor/skills/people-report/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-cursor/.cursor/skills/people-report/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <report type — headcount, attrition, diversity, org health>
 
 # /people-report
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/CONNECTORS.md`).
 
 Generate people analytics reports from your HR data. Analyze workforce data to surface trends, risks, and opportunities.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-cursor/.cursor/skills/performance-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-cursor/.cursor/skills/performance-review/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <employee name or review cycle>
 
 # /performance-review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/CONNECTORS.md`).
 
 Generate performance review templates and help structure feedback.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-cursor/.cursor/skills/policy-lookup/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-cursor/.cursor/skills/policy-lookup/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <policy topic — PTO, benefits, travel, expenses, etc.>
 
 # /policy-lookup
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/CONNECTORS.md`).
 
 Look up and explain company policies in plain language. Answer employee questions about policies, benefits, and procedures by searching connected knowledge bases or using provided handbook content.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/CONNECTORS.md
@@ -1,0 +1,19 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~HRIS` might mean Workday, BambooHR, or any other HRIS with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (HRIS, ATS, email, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| ATS | `~~ATS` | — | Greenhouse, Lever, Ashby, Workable |
+| Calendar | `~~calendar` | Google Calendar | Microsoft 365 |
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Email | `~~email` | Gmail, Microsoft 365 | — |
+| HRIS | `~~HRIS` | — | Workday, BambooHR, Rippling, Gusto |
+| Knowledge base | `~~knowledge base` | Notion, Atlassian (Confluence) | Guru, Coda |
+| Compensation data | `~~compensation data` | — | Pave, Radford, Levels.fyi |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_human-resources/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Human Resources
@@ -52,7 +52,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_human-resources
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/human-resources |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -64,8 +64,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_human-resources
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-forgecat/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-forgecat/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-forgecat/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-forgecat/README.md
@@ -52,7 +52,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_human-resources
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/human-resources |
-| Version | `0.0.8` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -66,6 +66,8 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_human-resources
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-forgecat/platforms/claude-code/.claude-plugin/plugin.json
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-forgecat/platforms/claude-code/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "human-resources",
+  "version": "1.2.0",
+  "description": "Streamline people operations — recruiting, onboarding, performance reviews, compensation analysis, and policy guidance. Maintain compliance and keep your team running smoothly.",
+  "author": {
+    "name": "Anthropic"
+  }
+}

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-forgecat/platforms/claude-code/.mcp.json
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-forgecat/platforms/claude-code/.mcp.json
@@ -1,0 +1,28 @@
+{
+  "mcpServers": {
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
+    },
+    "google-calendar": {
+      "type": "http",
+      "url": "https://gcal.mcp.claude.com/mcp"
+    },
+    "gmail": {
+      "type": "http",
+      "url": "https://gmail.mcp.claude.com/mcp"
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
+    },
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp"
+    },
+    "ms365": {
+      "type": "http",
+      "url": "https://microsoft365.mcp.claude.com/mcp"
+    }
+  }
+}

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-forgecat/profile.yml
@@ -1,75 +1,71 @@
-name: "@forgecat/anthropics_knowledge-work-plugins_human-resources"
-version: 0.0.8
-description: Streamline people operations — recruiting, onboarding, performance reviews,
-  compensation analysis, and policy guidance. Maintain compliance and keep your team
-  running smoothly.
+name: '@forgecat/anthropics_knowledge-work-plugins_human-resources'
+description: Streamline people operations — recruiting, onboarding, performance reviews, compensation
+  analysis, and policy guidance. Maintain compliance and keep your team running smoothly.
+visibility: public
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/human-resources
 license: Apache-2.0
-visibility: public
 sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:
-      - claude-code
-      - cursor
-      - codex
+    - claude-code
+    - cursor
+    - codex
+    partial:
+    - openclaw
+    - hermes
   models:
     recommended: []
     minimum: []
 skills:
-- name: recruiting-pipeline
-  path: skills/recruiting-pipeline/SKILL.md
-  description: Track and manage recruiting pipeline stages. Trigger with "recruiting
-    update", "candidate pipeline", "how many candidates", "hiring status", or when
-    the user discusses sourcing, screening, interviewing, or extending offers.
-- name: interview-prep
-  path: skills/interview-prep/SKILL.md
-  description: Create structured interview plans with competency-based questions and
-    scorecards. Trigger with "interview plan for", "interview questions for", "how
-    should we interview", "scorecard for", or when the user is preparing to interview
-    candidates.
-- name: draft-offer
-  path: skills/draft-offer/SKILL.md
-  description: Draft an offer letter with comp details and terms. Use when a candidate
-    is ready for an offer, assembling a total comp package (base, equity, signing
-    bonus), writing the offer letter text itself, or prepping negotiation guidance
-    for the hiring manager.
-- name: onboarding
-  path: skills/onboarding/SKILL.md
-  description: Generate an onboarding checklist and first-week plan for a new hire.
-    Use when someone has a start date coming up, building the pre-start task list
-    (accounts, equipment, buddy), scheduling Day 1 and Week 1, or setting 30/60/90-day
-    goals for a new team member.
-- name: performance-review
-  path: skills/performance-review/SKILL.md
-  description: Structure a performance review with self-assessment, manager template,
-    and calibration prep. Use when review season kicks off and you need a self-assessment
-    template, writing a manager review for a direct report, prepping rating distributions
-    and promotion cases for calibration, or turning vague feedback into specific behavioral
-    examples.
 - name: comp-analysis
   path: skills/comp-analysis/SKILL.md
-  description: Analyze compensation — benchmarking, band placement, and equity modeling.
-    Trigger with "what should we pay a [role]", "is this offer competitive", "model
-    this equity grant", or when uploading comp data to find outliers and retention
-    risks.
-- name: people-report
-  path: skills/people-report/SKILL.md
-  description: Generate headcount, attrition, diversity, or org health reports. Use
-    when pulling a headcount snapshot for leadership, analyzing turnover trends by
-    team, preparing diversity representation metrics, or assessing span of control
-    and flight risk across the org.
+  description: Analyze compensation — benchmarking, band placement, and equity modeling. Trigger with
+    "what should we pay a [role]", "is this offer competitive", "model this equity grant", or when uploading
+    comp data to find outliers and retention risks.
+- name: draft-offer
+  path: skills/draft-offer/SKILL.md
+  description: Draft an offer letter with comp details and terms. Use when a candidate is ready for an
+    offer, assembling a total comp package (base, equity, signing bonus), writing the offer letter text
+    itself, or prepping negotiation guidance for the hiring manager.
+- name: interview-prep
+  path: skills/interview-prep/SKILL.md
+  description: Create structured interview plans with competency-based questions and scorecards. Trigger
+    with "interview plan for", "interview questions for", "how should we interview", "scorecard for",
+    or when the user is preparing to interview candidates.
+- name: onboarding
+  path: skills/onboarding/SKILL.md
+  description: Generate an onboarding checklist and first-week plan for a new hire. Use when someone has
+    a start date coming up, building the pre-start task list (accounts, equipment, buddy), scheduling
+    Day 1 and Week 1, or setting 30/60/90-day goals for a new team member.
 - name: org-planning
   path: skills/org-planning/SKILL.md
-  description: Headcount planning, org design, and team structure optimization. Trigger
-    with "org planning", "headcount plan", "team structure", "reorg", "who should
-    we hire next", or when the user is thinking about team size, reporting structure,
-    or organizational design.
+  description: Headcount planning, org design, and team structure optimization. Trigger with "org planning",
+    "headcount plan", "team structure", "reorg", "who should we hire next", or when the user is thinking
+    about team size, reporting structure, or organizational design.
+- name: people-report
+  path: skills/people-report/SKILL.md
+  description: Generate headcount, attrition, diversity, or org health reports. Use when pulling a headcount
+    snapshot for leadership, analyzing turnover trends by team, preparing diversity representation metrics,
+    or assessing span of control and flight risk across the org.
+- name: performance-review
+  path: skills/performance-review/SKILL.md
+  description: Structure a performance review with self-assessment, manager template, and calibration
+    prep. Use when review season kicks off and you need a self-assessment template, writing a manager
+    review for a direct report, prepping rating distributions and promotion cases for calibration, or
+    turning vague feedback into specific behavioral examples.
 - name: policy-lookup
   path: skills/policy-lookup/SKILL.md
-  description: Find and explain company policies in plain language. Trigger with "what's
-    our PTO policy", "can I work remotely from another country", "how do expenses
-    work", or any plain-language question about benefits, travel, leave, or handbook
-    rules.
+  description: Find and explain company policies in plain language. Trigger with "what's our PTO policy",
+    "can I work remotely from another country", "how do expenses work", or any plain-language question
+    about benefits, travel, leave, or handbook rules.
+- name: recruiting-pipeline
+  path: skills/recruiting-pipeline/SKILL.md
+  description: Track and manage recruiting pipeline stages. Trigger with "recruiting update", "candidate
+    pipeline", "how many candidates", "hiring status", or when the user discusses sourcing, screening,
+    interviewing, or extending offers.
 mcp:
   path: mcp.jsonc
+references:
+- id: connectors
+  path: CONNECTORS.md

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-forgecat/skills/comp-analysis/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-forgecat/skills/comp-analysis/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<role, level, or dataset>"
 
 # /comp-analysis
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Analyze compensation data for benchmarking, band placement, and planning. Helps benchmark compensation against market data for hiring, retention, and equity planning.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-forgecat/skills/draft-offer/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-forgecat/skills/draft-offer/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<role and level>"
 
 # /draft-offer
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Draft a complete offer letter for a new hire.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-forgecat/skills/onboarding/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-forgecat/skills/onboarding/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<new hire name and role>"
 
 # /onboarding
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Generate a comprehensive onboarding plan for a new team member.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-forgecat/skills/people-report/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-forgecat/skills/people-report/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<report type — headcount, attrition, diversity, org health>"
 
 # /people-report
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Generate people analytics reports from your HR data. Analyze workforce data to surface trends, risks, and opportunities.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-forgecat/skills/performance-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-forgecat/skills/performance-review/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<employee name or review cycle>"
 
 # /performance-review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Generate performance review templates and help structure feedback.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-forgecat/skills/policy-lookup/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_human-resources/for-forgecat/skills/policy-lookup/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<policy topic — PTO, benefits, travel, expenses, etc.>"
 
 # /policy-lookup
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Look up and explain company policies in plain language. Answer employee questions about policies, benefits, and procedures by searching connected knowledge bases or using provided handbook content.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/README.md
@@ -52,7 +52,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_legal
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/legal |
-| Version | `0.0.8` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -66,6 +66,8 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_legal
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-claude/.claude/skills/brief/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-claude/.claude/skills/brief/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: "[daily | topic <query> | incident]"
 
 # /brief -- Legal Team Briefing
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md`).
 
 Generate contextual briefings for legal work. Supports three modes: daily brief, topic brief, and incident brief.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-claude/.claude/skills/compliance-check/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-claude/.claude/skills/compliance-check/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: <action or initiative to check>
 
 # /compliance-check -- Compliance Review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md`).
 
 Run a compliance check on a proposed action, product feature, marketing campaign, or business initiative.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-claude/.claude/skills/legal-response/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-claude/.claude/skills/legal-response/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: "[inquiry-type]"
 
 # /legal-response -- Generate Response from Templates
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md`).
 
 Generate a response to a common legal inquiry using configured templates. Customizes the response with specific details and includes escalation triggers for situations that should not use a templated response.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-claude/.claude/skills/review-contract/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-claude/.claude/skills/review-contract/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <contract file or text>
 
 # /review-contract -- Contract Review Against Playbook
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md`).
 
 Review a contract against your organization's negotiation playbook. Analyze each clause, flag deviations, generate redline suggestions, and provide business impact analysis.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-claude/.claude/skills/signature-request/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-claude/.claude/skills/signature-request/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <document or contract to send>
 
 # /signature-request -- E-Signature Routing
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md`).
 
 Prepare a document for electronic signature — verify completeness, set signing order, and route for execution.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-claude/.claude/skills/triage-nda/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-claude/.claude/skills/triage-nda/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <NDA file or text>
 
 # /triage-nda -- NDA Pre-Screening
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md`).
 
 Triage the NDA: @$1
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-claude/.claude/skills/vendor-check/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-claude/.claude/skills/vendor-check/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: "[vendor name]"
 
 # /vendor-check -- Vendor Agreement Status
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md`).
 
 Check the status of existing agreements with a vendor across all connected systems. Provides a consolidated view of the legal relationship.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md
@@ -1,0 +1,21 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~cloud storage` might mean Box, Egnyte, or any other storage provider with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (cloud storage, chat, office suite, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Calendar | `~~calendar` | Google Calendar | Microsoft 365 |
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Cloud storage | `~~cloud storage` | Box, Egnyte | Dropbox, SharePoint, Google Drive |
+| CLM | `~~CLM` | — | Ironclad, Agiloft |
+| CRM | `~~CRM` | — | Salesforce, HubSpot |
+| Email | `~~email` | Gmail | Microsoft 365 |
+| E-signature | `~~e-signature` | DocuSign | Adobe Sign |
+| Office suite | `~~office suite` | Microsoft 365 | Google Workspace |
+| Project tracker | `~~project tracker` | Atlassian (Jira/Confluence) | Linear, Asana |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Legal
@@ -54,7 +54,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_legal
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/legal |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -66,8 +66,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_legal
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-codex/.agents/skills/brief/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-codex/.agents/skills/brief/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: "[daily | topic <query> | incident]"
 
 # /brief -- Legal Team Briefing
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md`).
 
 Generate contextual briefings for legal work. Supports three modes: daily brief, topic brief, and incident brief.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-codex/.agents/skills/compliance-check/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-codex/.agents/skills/compliance-check/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: <action or initiative to check>
 
 # /compliance-check -- Compliance Review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md`).
 
 Run a compliance check on a proposed action, product feature, marketing campaign, or business initiative.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-codex/.agents/skills/legal-response/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-codex/.agents/skills/legal-response/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: "[inquiry-type]"
 
 # /legal-response -- Generate Response from Templates
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md`).
 
 Generate a response to a common legal inquiry using configured templates. Customizes the response with specific details and includes escalation triggers for situations that should not use a templated response.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-codex/.agents/skills/review-contract/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-codex/.agents/skills/review-contract/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <contract file or text>
 
 # /review-contract -- Contract Review Against Playbook
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md`).
 
 Review a contract against your organization's negotiation playbook. Analyze each clause, flag deviations, generate redline suggestions, and provide business impact analysis.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-codex/.agents/skills/signature-request/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-codex/.agents/skills/signature-request/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <document or contract to send>
 
 # /signature-request -- E-Signature Routing
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md`).
 
 Prepare a document for electronic signature — verify completeness, set signing order, and route for execution.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-codex/.agents/skills/triage-nda/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-codex/.agents/skills/triage-nda/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <NDA file or text>
 
 # /triage-nda -- NDA Pre-Screening
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md`).
 
 Triage the NDA: @$1
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-codex/.agents/skills/vendor-check/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-codex/.agents/skills/vendor-check/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: "[vendor name]"
 
 # /vendor-check -- Vendor Agreement Status
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md`).
 
 Check the status of existing agreements with a vendor across all connected systems. Provides a consolidated view of the legal relationship.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md
@@ -1,0 +1,21 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~cloud storage` might mean Box, Egnyte, or any other storage provider with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (cloud storage, chat, office suite, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Calendar | `~~calendar` | Google Calendar | Microsoft 365 |
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Cloud storage | `~~cloud storage` | Box, Egnyte | Dropbox, SharePoint, Google Drive |
+| CLM | `~~CLM` | — | Ironclad, Agiloft |
+| CRM | `~~CRM` | — | Salesforce, HubSpot |
+| Email | `~~email` | Gmail | Microsoft 365 |
+| E-signature | `~~e-signature` | DocuSign | Adobe Sign |
+| Office suite | `~~office suite` | Microsoft 365 | Google Workspace |
+| Project tracker | `~~project tracker` | Atlassian (Jira/Confluence) | Linear, Asana |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Legal
@@ -54,7 +54,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_legal
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/legal |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -66,8 +66,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_legal
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-cursor/.cursor/skills/brief/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-cursor/.cursor/skills/brief/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: "[daily | topic <query> | incident]"
 
 # /brief -- Legal Team Briefing
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md`).
 
 Generate contextual briefings for legal work. Supports three modes: daily brief, topic brief, and incident brief.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-cursor/.cursor/skills/compliance-check/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-cursor/.cursor/skills/compliance-check/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: <action or initiative to check>
 
 # /compliance-check -- Compliance Review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md`).
 
 Run a compliance check on a proposed action, product feature, marketing campaign, or business initiative.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-cursor/.cursor/skills/legal-response/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-cursor/.cursor/skills/legal-response/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: "[inquiry-type]"
 
 # /legal-response -- Generate Response from Templates
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md`).
 
 Generate a response to a common legal inquiry using configured templates. Customizes the response with specific details and includes escalation triggers for situations that should not use a templated response.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-cursor/.cursor/skills/review-contract/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-cursor/.cursor/skills/review-contract/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <contract file or text>
 
 # /review-contract -- Contract Review Against Playbook
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md`).
 
 Review a contract against your organization's negotiation playbook. Analyze each clause, flag deviations, generate redline suggestions, and provide business impact analysis.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-cursor/.cursor/skills/signature-request/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-cursor/.cursor/skills/signature-request/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <document or contract to send>
 
 # /signature-request -- E-Signature Routing
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md`).
 
 Prepare a document for electronic signature — verify completeness, set signing order, and route for execution.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-cursor/.cursor/skills/triage-nda/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-cursor/.cursor/skills/triage-nda/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <NDA file or text>
 
 # /triage-nda -- NDA Pre-Screening
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md`).
 
 Triage the NDA: @$1
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-cursor/.cursor/skills/vendor-check/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-cursor/.cursor/skills/vendor-check/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: "[vendor name]"
 
 # /vendor-check -- Vendor Agreement Status
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md`).
 
 Check the status of existing agreements with a vendor across all connected systems. Provides a consolidated view of the legal relationship.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/CONNECTORS.md
@@ -1,0 +1,21 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~cloud storage` might mean Box, Egnyte, or any other storage provider with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (cloud storage, chat, office suite, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Calendar | `~~calendar` | Google Calendar | Microsoft 365 |
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Cloud storage | `~~cloud storage` | Box, Egnyte | Dropbox, SharePoint, Google Drive |
+| CLM | `~~CLM` | — | Ironclad, Agiloft |
+| CRM | `~~CRM` | — | Salesforce, HubSpot |
+| Email | `~~email` | Gmail | Microsoft 365 |
+| E-signature | `~~e-signature` | DocuSign | Adobe Sign |
+| Office suite | `~~office suite` | Microsoft 365 | Google Workspace |
+| Project tracker | `~~project tracker` | Atlassian (Jira/Confluence) | Linear, Asana |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_legal/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Legal
@@ -54,7 +54,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_legal
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/legal |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -66,8 +66,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_legal
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/README.md
@@ -54,7 +54,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_legal
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/legal |
-| Version | `0.0.8` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -68,6 +68,8 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_legal
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/platforms/claude-code/.claude-plugin/plugin.json
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/platforms/claude-code/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "legal",
+  "version": "1.2.0",
+  "description": "Speed up contract review, NDA triage, and compliance workflows for in-house legal teams. Draft legal briefs, organize precedent research, and manage institutional knowledge.",
+  "author": {
+    "name": "Anthropic"
+  }
+}

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/platforms/claude-code/.mcp.json
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/platforms/claude-code/.mcp.json
@@ -1,0 +1,36 @@
+{
+  "mcpServers": {
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
+    },
+    "box": {
+      "type": "http",
+      "url": "https://mcp.box.com"
+    },
+    "egnyte": {
+      "type": "http",
+      "url": "https://mcp-server.egnyte.com/mcp"
+    },
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp"
+    },
+    "ms365": {
+      "type": "http",
+      "url": "https://microsoft365.mcp.claude.com/mcp"
+    },
+    "docusign": {
+      "type": "http",
+      "url": "https://mcp.docusign.com/mcp"
+    },
+    "google-calendar": {
+      "type": "http",
+      "url": "https://gcal.mcp.claude.com/mcp"
+    },
+    "gmail": {
+      "type": "http",
+      "url": "https://gmail.mcp.claude.com/mcp"
+    }
+  }
+}

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/profile.yml
@@ -1,81 +1,77 @@
-name: "@forgecat/anthropics_knowledge-work-plugins_legal"
-version: 0.0.8
-description: Speed up contract review, NDA triage, and compliance workflows for in-house
-  legal teams. Draft legal briefs, organize precedent research, and manage institutional
-  knowledge.
+name: '@forgecat/anthropics_knowledge-work-plugins_legal'
+description: Speed up contract review, NDA triage, and compliance workflows for in-house legal teams.
+  Draft legal briefs, organize precedent research, and manage institutional knowledge.
+visibility: public
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/legal
 license: Apache-2.0
-visibility: public
 sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:
-      - claude-code
-      - cursor
-      - codex
+    - claude-code
+    - cursor
+    - codex
+    partial:
+    - openclaw
+    - hermes
   models:
     recommended: []
     minimum: []
 skills:
-- name: review-contract
-  path: skills/review-contract/SKILL.md
-  description: Review a contract against your organization's negotiation playbook
-    — flag deviations, generate redlines, provide business impact analysis. Use when
-    reviewing vendor or customer agreements, when you need clause-by-clause analysis
-    against standard positions, or when preparing a negotiation strategy with prioritized
-    redlines and fallback positions.
-- name: triage-nda
-  path: skills/triage-nda/SKILL.md
-  description: Rapidly triage an incoming NDA and classify it as GREEN (standard approval),
-    YELLOW (counsel review), or RED (full legal review). Use when a new NDA arrives
-    from sales or business development, when screening for embedded non-solicits,
-    non-competes, or missing carveouts, or when deciding whether an NDA can be signed
-    under standard delegation.
-- name: compliance-check
-  path: skills/compliance-check/SKILL.md
-  description: Run a compliance check on a proposed action, product feature, or business
-    initiative, surfacing applicable regulations, required approvals, and risk areas.
-    Use when launching a feature that touches personal data, when marketing or product
-    proposes something with regulatory implications, or when you need to know which
-    approvals and jurisdictional requirements apply before proceeding.
-- name: legal-risk-assessment
-  path: skills/legal-risk-assessment/SKILL.md
-  description: Assess and classify legal risks using a severity-by-likelihood framework
-    with escalation criteria. Use when evaluating contract risk, assessing deal exposure,
-    classifying issues by severity, or determining whether a matter needs senior counsel
-    or outside legal review.
 - name: brief
   path: skills/brief/SKILL.md
-  description: Generate contextual briefings for legal work — daily summary, topic
-    research, or incident response. Use when starting your day and need a scan of
-    legal-relevant items across email, calendar, and contracts, when researching a
-    specific legal question across internal sources, or when a developing situation
-    (data breach, litigation threat, regulatory inquiry) needs rapid context.
-- name: meeting-briefing
-  path: skills/meeting-briefing/SKILL.md
-  description: Prepare structured briefings for meetings with legal relevance and
-    track resulting action items. Use when preparing for contract negotiations, board
-    meetings, compliance reviews, or any meeting where legal context, background research,
-    or action tracking is needed.
+  description: Generate contextual briefings for legal work — daily summary, topic research, or incident
+    response. Use when starting your day and need a scan of legal-relevant items across email, calendar,
+    and contracts, when researching a specific legal question across internal sources, or when a developing
+    situation (data breach, litigation threat, regulatory inquiry) needs rapid context.
+- name: compliance-check
+  path: skills/compliance-check/SKILL.md
+  description: Run a compliance check on a proposed action, product feature, or business initiative, surfacing
+    applicable regulations, required approvals, and risk areas. Use when launching a feature that touches
+    personal data, when marketing or product proposes something with regulatory implications, or when
+    you need to know which approvals and jurisdictional requirements apply before proceeding.
 - name: legal-response
   path: skills/legal-response/SKILL.md
-  description: Generate a response to a common legal inquiry using configured templates,
-    with built-in escalation checks for situations that shouldn't use a templated
-    reply. Use when responding to data subject requests, litigation hold notices,
-    vendor legal questions, NDA requests from business teams, or subpoenas.
+  description: Generate a response to a common legal inquiry using configured templates, with built-in
+    escalation checks for situations that shouldn't use a templated reply. Use when responding to data
+    subject requests, litigation hold notices, vendor legal questions, NDA requests from business teams,
+    or subpoenas.
+- name: legal-risk-assessment
+  path: skills/legal-risk-assessment/SKILL.md
+  description: Assess and classify legal risks using a severity-by-likelihood framework with escalation
+    criteria. Use when evaluating contract risk, assessing deal exposure, classifying issues by severity,
+    or determining whether a matter needs senior counsel or outside legal review.
+- name: meeting-briefing
+  path: skills/meeting-briefing/SKILL.md
+  description: Prepare structured briefings for meetings with legal relevance and track resulting action
+    items. Use when preparing for contract negotiations, board meetings, compliance reviews, or any meeting
+    where legal context, background research, or action tracking is needed.
+- name: review-contract
+  path: skills/review-contract/SKILL.md
+  description: Review a contract against your organization's negotiation playbook — flag deviations, generate
+    redlines, provide business impact analysis. Use when reviewing vendor or customer agreements, when
+    you need clause-by-clause analysis against standard positions, or when preparing a negotiation strategy
+    with prioritized redlines and fallback positions.
 - name: signature-request
   path: skills/signature-request/SKILL.md
-  description: Prepare and route a document for e-signature — run a pre-signature
-    checklist, configure signing order, and send for execution. Use when a contract
-    is finalized and ready to sign, when verifying entity names, exhibits, and signature
-    blocks before sending, or when setting up an envelope with sequential or parallel
-    signers.
+  description: Prepare and route a document for e-signature — run a pre-signature checklist, configure
+    signing order, and send for execution. Use when a contract is finalized and ready to sign, when verifying
+    entity names, exhibits, and signature blocks before sending, or when setting up an envelope with sequential
+    or parallel signers.
+- name: triage-nda
+  path: skills/triage-nda/SKILL.md
+  description: Rapidly triage an incoming NDA and classify it as GREEN (standard approval), YELLOW (counsel
+    review), or RED (full legal review). Use when a new NDA arrives from sales or business development,
+    when screening for embedded non-solicits, non-competes, or missing carveouts, or when deciding whether
+    an NDA can be signed under standard delegation.
 - name: vendor-check
   path: skills/vendor-check/SKILL.md
-  description: Check the status of existing agreements with a vendor across all connected
-    systems — CLM, CRM, email, and document storage — with gap analysis and upcoming
-    deadlines. Use when onboarding or renewing a vendor, when you need a consolidated
-    view of what's signed and what's missing (MSA, DPA, SOW), or when checking for
-    approaching expirations and surviving obligations.
+  description: Check the status of existing agreements with a vendor across all connected systems — CLM,
+    CRM, email, and document storage — with gap analysis and upcoming deadlines. Use when onboarding or
+    renewing a vendor, when you need a consolidated view of what's signed and what's missing (MSA, DPA,
+    SOW), or when checking for approaching expirations and surviving obligations.
 mcp:
   path: mcp.jsonc
+references:
+- id: connectors
+  path: CONNECTORS.md

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/skills/brief/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/skills/brief/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[daily | topic <query> | incident]"
 
 # /brief -- Legal Team Briefing
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Generate contextual briefings for legal work. Supports three modes: daily brief, topic brief, and incident brief.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/skills/compliance-check/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/skills/compliance-check/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<action or initiative to check>"
 
 # /compliance-check -- Compliance Review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Run a compliance check on a proposed action, product feature, marketing campaign, or business initiative.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/skills/legal-response/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/skills/legal-response/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[inquiry-type]"
 
 # /legal-response -- Generate Response from Templates
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Generate a response to a common legal inquiry using configured templates. Customizes the response with specific details and includes escalation triggers for situations that should not use a templated response.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/skills/review-contract/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/skills/review-contract/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<contract file or text>"
 
 # /review-contract -- Contract Review Against Playbook
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Review a contract against your organization's negotiation playbook. Analyze each clause, flag deviations, generate redline suggestions, and provide business impact analysis.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/skills/signature-request/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/skills/signature-request/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<document or contract to send>"
 
 # /signature-request -- E-Signature Routing
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Prepare a document for electronic signature — verify completeness, set signing order, and route for execution.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/skills/triage-nda/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/skills/triage-nda/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<NDA file or text>"
 
 # /triage-nda -- NDA Pre-Screening
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Triage the NDA: @$1
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/skills/vendor-check/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_legal/for-forgecat/skills/vendor-check/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[vendor name]"
 
 # /vendor-check -- Vendor Agreement Status
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Check the status of existing agreements with a vendor across all connected systems. Provides a consolidated view of the legal relationship.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/README.md
@@ -56,7 +56,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_marketing
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/marketing |
-| Version | `0.0.8` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -70,6 +70,8 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_marketing
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-claude/.claude/skills/brand-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-claude/.claude/skills/brand-review/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <content to review>
 
 # Brand Review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md`).
 
 Review marketing content against brand voice, style guidelines, and messaging standards. Flag deviations and provide specific improvement suggestions.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-claude/.claude/skills/campaign-plan/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-claude/.claude/skills/campaign-plan/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <campaign objective or product>
 
 # Campaign Plan
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md`).
 
 Generate a comprehensive marketing campaign brief with objectives, audience, messaging, channel strategy, content calendar, and success metrics.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-claude/.claude/skills/competitive-brief/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-claude/.claude/skills/competitive-brief/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <competitor or market segment>
 
 # Competitive Brief
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md`).
 
 Research competitors and generate a structured competitive analysis comparing positioning, messaging, content strategy, and market presence.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-claude/.claude/skills/draft-content/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-claude/.claude/skills/draft-content/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <content type and topic>
 
 # Draft Content
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md`).
 
 Generate marketing content drafts tailored to a specific content type, audience, and brand voice.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-claude/.claude/skills/email-sequence/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-claude/.claude/skills/email-sequence/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: "[sequence type]"
 
 # Email Sequence
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md`).
 
 Design and draft complete email sequences with full copy, timing, branching logic, and performance benchmarks for any lifecycle or campaign use case.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-claude/.claude/skills/performance-report/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-claude/.claude/skills/performance-report/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <time period or campaign>
 
 # Performance Report
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md`).
 
 Generate a marketing performance report with key metrics, trend analysis, insights, and optimization recommendations.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-claude/.claude/skills/seo-audit/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-claude/.claude/skills/seo-audit/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <url or topic> [audit type]
 
 # /seo-audit
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md`).
 
 Audit a website's SEO health, research keyword opportunities, identify content gaps, and benchmark against competitors. Produces a prioritized action plan a marketer can execute immediately.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md
@@ -1,0 +1,20 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~marketing automation` might mean HubSpot, Marketo, or any other marketing platform with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (design, SEO, email marketing, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Design | `~~design` | Canva, Figma | Adobe Creative Cloud |
+| Marketing automation | `~~marketing automation` | HubSpot | Marketo, Pardot, Mailchimp |
+| Product analytics | `~~product analytics` | Amplitude | Mixpanel, Google Analytics |
+| Knowledge base | `~~knowledge base` | Notion | Confluence, Guru |
+| SEO | `~~SEO` | Ahrefs, Similarweb | Semrush, Moz |
+| Email marketing | `~~email marketing` | Klaviyo | Mailchimp, Brevo, Customer.io |
+| Marketing analytics | `~~marketing analytics` | Supermetrics | Google Analytics, Mailchimp, Semrush |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Marketing
@@ -58,7 +58,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_marketing
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/marketing |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -70,8 +70,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_marketing
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-codex/.agents/skills/brand-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-codex/.agents/skills/brand-review/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <content to review>
 
 # Brand Review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md`).
 
 Review marketing content against brand voice, style guidelines, and messaging standards. Flag deviations and provide specific improvement suggestions.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-codex/.agents/skills/campaign-plan/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-codex/.agents/skills/campaign-plan/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <campaign objective or product>
 
 # Campaign Plan
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md`).
 
 Generate a comprehensive marketing campaign brief with objectives, audience, messaging, channel strategy, content calendar, and success metrics.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-codex/.agents/skills/competitive-brief/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-codex/.agents/skills/competitive-brief/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <competitor or market segment>
 
 # Competitive Brief
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md`).
 
 Research competitors and generate a structured competitive analysis comparing positioning, messaging, content strategy, and market presence.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-codex/.agents/skills/draft-content/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-codex/.agents/skills/draft-content/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <content type and topic>
 
 # Draft Content
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md`).
 
 Generate marketing content drafts tailored to a specific content type, audience, and brand voice.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-codex/.agents/skills/email-sequence/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-codex/.agents/skills/email-sequence/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: "[sequence type]"
 
 # Email Sequence
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md`).
 
 Design and draft complete email sequences with full copy, timing, branching logic, and performance benchmarks for any lifecycle or campaign use case.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-codex/.agents/skills/performance-report/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-codex/.agents/skills/performance-report/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <time period or campaign>
 
 # Performance Report
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md`).
 
 Generate a marketing performance report with key metrics, trend analysis, insights, and optimization recommendations.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-codex/.agents/skills/seo-audit/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-codex/.agents/skills/seo-audit/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <url or topic> [audit type]
 
 # /seo-audit
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md`).
 
 Audit a website's SEO health, research keyword opportunities, identify content gaps, and benchmark against competitors. Produces a prioritized action plan a marketer can execute immediately.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md
@@ -1,0 +1,20 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~marketing automation` might mean HubSpot, Marketo, or any other marketing platform with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (design, SEO, email marketing, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Design | `~~design` | Canva, Figma | Adobe Creative Cloud |
+| Marketing automation | `~~marketing automation` | HubSpot | Marketo, Pardot, Mailchimp |
+| Product analytics | `~~product analytics` | Amplitude | Mixpanel, Google Analytics |
+| Knowledge base | `~~knowledge base` | Notion | Confluence, Guru |
+| SEO | `~~SEO` | Ahrefs, Similarweb | Semrush, Moz |
+| Email marketing | `~~email marketing` | Klaviyo | Mailchimp, Brevo, Customer.io |
+| Marketing analytics | `~~marketing analytics` | Supermetrics | Google Analytics, Mailchimp, Semrush |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Marketing
@@ -58,7 +58,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_marketing
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/marketing |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -70,8 +70,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_marketing
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-cursor/.cursor/skills/brand-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-cursor/.cursor/skills/brand-review/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <content to review>
 
 # Brand Review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md`).
 
 Review marketing content against brand voice, style guidelines, and messaging standards. Flag deviations and provide specific improvement suggestions.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-cursor/.cursor/skills/campaign-plan/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-cursor/.cursor/skills/campaign-plan/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <campaign objective or product>
 
 # Campaign Plan
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md`).
 
 Generate a comprehensive marketing campaign brief with objectives, audience, messaging, channel strategy, content calendar, and success metrics.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-cursor/.cursor/skills/competitive-brief/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-cursor/.cursor/skills/competitive-brief/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <competitor or market segment>
 
 # Competitive Brief
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md`).
 
 Research competitors and generate a structured competitive analysis comparing positioning, messaging, content strategy, and market presence.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-cursor/.cursor/skills/draft-content/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-cursor/.cursor/skills/draft-content/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <content type and topic>
 
 # Draft Content
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md`).
 
 Generate marketing content drafts tailored to a specific content type, audience, and brand voice.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-cursor/.cursor/skills/email-sequence/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-cursor/.cursor/skills/email-sequence/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: "[sequence type]"
 
 # Email Sequence
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md`).
 
 Design and draft complete email sequences with full copy, timing, branching logic, and performance benchmarks for any lifecycle or campaign use case.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-cursor/.cursor/skills/performance-report/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-cursor/.cursor/skills/performance-report/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <time period or campaign>
 
 # Performance Report
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md`).
 
 Generate a marketing performance report with key metrics, trend analysis, insights, and optimization recommendations.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-cursor/.cursor/skills/seo-audit/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-cursor/.cursor/skills/seo-audit/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <url or topic> [audit type]
 
 # /seo-audit
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md`).
 
 Audit a website's SEO health, research keyword opportunities, identify content gaps, and benchmark against competitors. Produces a prioritized action plan a marketer can execute immediately.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/CONNECTORS.md
@@ -1,0 +1,20 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~marketing automation` might mean HubSpot, Marketo, or any other marketing platform with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (design, SEO, email marketing, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Design | `~~design` | Canva, Figma | Adobe Creative Cloud |
+| Marketing automation | `~~marketing automation` | HubSpot | Marketo, Pardot, Mailchimp |
+| Product analytics | `~~product analytics` | Amplitude | Mixpanel, Google Analytics |
+| Knowledge base | `~~knowledge base` | Notion | Confluence, Guru |
+| SEO | `~~SEO` | Ahrefs, Similarweb | Semrush, Moz |
+| Email marketing | `~~email marketing` | Klaviyo | Mailchimp, Brevo, Customer.io |
+| Marketing analytics | `~~marketing analytics` | Supermetrics | Google Analytics, Mailchimp, Semrush |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_marketing/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Marketing
@@ -58,7 +58,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_marketing
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/marketing |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -70,8 +70,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_marketing
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/README.md
@@ -58,7 +58,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_marketing
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/marketing |
-| Version | `0.0.8` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -72,6 +72,8 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_marketing
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/platforms/claude-code/.claude-plugin/plugin.json
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/platforms/claude-code/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "marketing",
+  "version": "1.2.0",
+  "description": "Create content, plan campaigns, and analyze performance across marketing channels. Maintain brand voice consistency, track competitors, and report on what's working.",
+  "author": {
+    "name": "Anthropic"
+  }
+}

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/platforms/claude-code/.mcp.json
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/platforms/claude-code/.mcp.json
@@ -1,0 +1,56 @@
+{
+  "mcpServers": {
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
+    },
+    "canva": {
+      "type": "http",
+      "url": "https://mcp.canva.com/mcp"
+    },
+    "figma": {
+      "type": "http",
+      "url": "https://mcp.figma.com/mcp"
+    },
+    "hubspot": {
+      "type": "http",
+      "url": "https://mcp.hubspot.com/anthropic"
+    },
+    "amplitude": {
+      "type": "http",
+      "url": "https://mcp.amplitude.com/mcp"
+    },
+    "amplitude-eu": {
+      "type": "http",
+      "url": "https://mcp.eu.amplitude.com/mcp"
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
+    },
+    "ahrefs": {
+      "type": "http",
+      "url": "https://api.ahrefs.com/mcp/mcp"
+    },
+    "similarweb": {
+      "type": "http",
+      "url": "https://mcp.similarweb.com"
+    },
+    "klaviyo": {
+      "type": "http",
+      "url": "https://mcp.klaviyo.com/mcp"
+    },
+    "supermetrics": {
+      "type": "http",
+      "url": "https://mcp.supermetrics.com/mcp"
+    },
+    "google-calendar": {
+      "type": "http",
+      "url": "https://gcal.mcp.claude.com/mcp"
+    },
+    "gmail": {
+      "type": "http",
+      "url": "https://gmail.mcp.claude.com/mcp"
+    }
+  }
+}

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/profile.yml
@@ -1,75 +1,72 @@
-name: "@forgecat/anthropics_knowledge-work-plugins_marketing"
-version: 0.0.8
-description: Create content, plan campaigns, and analyze performance across marketing
-  channels. Maintain brand voice consistency, track competitors, and report on what's
-  working.
+name: '@forgecat/anthropics_knowledge-work-plugins_marketing'
+description: Create content, plan campaigns, and analyze performance across marketing channels. Maintain
+  brand voice consistency, track competitors, and report on what's working.
+visibility: public
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/marketing
 license: Apache-2.0
-visibility: public
 sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:
-      - claude-code
-      - cursor
-      - codex
+    - claude-code
+    - cursor
+    - codex
+    partial:
+    - openclaw
+    - hermes
   models:
     recommended: []
     minimum: []
 skills:
-- name: draft-content
-  path: skills/draft-content/SKILL.md
-  description: Draft blog posts, social media, email newsletters, landing pages, press
-    releases, and case studies with channel-specific formatting and SEO recommendations.
-    Use when writing any marketing content, when you need headline or subject line
-    options, or when adapting a message for a specific platform, audience, and brand
-    voice.
-- name: campaign-plan
-  path: skills/campaign-plan/SKILL.md
-  description: Generate a full campaign brief with objectives, audience, messaging,
-    channel strategy, content calendar, and success metrics. Use when planning a product
-    launch, lead-gen push, or awareness campaign, when you need a week-by-week content
-    calendar with dependencies, or when translating a marketing goal into a structured,
-    executable plan.
 - name: brand-review
   path: skills/brand-review/SKILL.md
-  description: Review content against your brand voice, style guide, and messaging
-    pillars, flagging deviations by severity with specific before/after fixes. Use
-    when checking a draft before it ships, when auditing copy for voice consistency
-    and terminology, or when screening for unsubstantiated claims, missing disclaimers,
-    and other legal flags.
+  description: Review content against your brand voice, style guide, and messaging pillars, flagging deviations
+    by severity with specific before/after fixes. Use when checking a draft before it ships, when auditing
+    copy for voice consistency and terminology, or when screening for unsubstantiated claims, missing
+    disclaimers, and other legal flags.
+- name: campaign-plan
+  path: skills/campaign-plan/SKILL.md
+  description: Generate a full campaign brief with objectives, audience, messaging, channel strategy,
+    content calendar, and success metrics. Use when planning a product launch, lead-gen push, or awareness
+    campaign, when you need a week-by-week content calendar with dependencies, or when translating a marketing
+    goal into a structured, executable plan.
 - name: competitive-brief
   path: skills/competitive-brief/SKILL.md
-  description: Research competitors and generate a positioning and messaging comparison
-    with content gaps, opportunities, and threats. Use when building sales battlecards,
-    when finding positioning gaps and messaging angles competitors haven't claimed,
-    or when a competitor makes a move and you need to assess the impact.
-- name: seo-audit
-  path: skills/seo-audit/SKILL.md
-  description: Run a comprehensive SEO audit — keyword research, on-page analysis,
-    content gaps, technical checks, and competitor comparison. Use when assessing
-    a site's SEO health, when finding keyword opportunities and content gaps competitors
-    own, or when you need a prioritized action plan split into quick wins and strategic
-    investments.
-- name: email-sequence
-  path: skills/email-sequence/SKILL.md
-  description: Design and draft multi-email sequences with full copy, timing, branching
-    logic, exit conditions, and performance benchmarks. Use when building onboarding,
-    lead nurture, re-engagement, win-back, or product launch flows, when you need
-    a complete drip campaign with A/B test suggestions, or when mapping a sequence
-    end-to-end with a flow diagram.
-- name: performance-report
-  path: skills/performance-report/SKILL.md
-  description: Build a marketing performance report with key metrics, trend analysis,
-    wins and misses, and prioritized optimization recommendations. Use when wrapping
-    a campaign, when preparing weekly, monthly, or quarterly channel summaries for
-    stakeholders, or when you need data translated into an executive summary with
-    next-period priorities.
+  description: Research competitors and generate a positioning and messaging comparison with content gaps,
+    opportunities, and threats. Use when building sales battlecards, when finding positioning gaps and
+    messaging angles competitors haven't claimed, or when a competitor makes a move and you need to assess
+    the impact.
 - name: content-creation
   path: skills/content-creation/SKILL.md
-  description: Draft marketing content across channels — blog posts, social media,
-    email newsletters, landing pages, press releases, and case studies. Use when writing
-    any marketing content, when you need channel-specific formatting, SEO-optimized
-    copy, headline options, or calls to action.
+  description: Draft marketing content across channels — blog posts, social media, email newsletters,
+    landing pages, press releases, and case studies. Use when writing any marketing content, when you
+    need channel-specific formatting, SEO-optimized copy, headline options, or calls to action.
+- name: draft-content
+  path: skills/draft-content/SKILL.md
+  description: Draft blog posts, social media, email newsletters, landing pages, press releases, and case
+    studies with channel-specific formatting and SEO recommendations. Use when writing any marketing content,
+    when you need headline or subject line options, or when adapting a message for a specific platform,
+    audience, and brand voice.
+- name: email-sequence
+  path: skills/email-sequence/SKILL.md
+  description: Design and draft multi-email sequences with full copy, timing, branching logic, exit conditions,
+    and performance benchmarks. Use when building onboarding, lead nurture, re-engagement, win-back, or
+    product launch flows, when you need a complete drip campaign with A/B test suggestions, or when mapping
+    a sequence end-to-end with a flow diagram.
+- name: performance-report
+  path: skills/performance-report/SKILL.md
+  description: Build a marketing performance report with key metrics, trend analysis, wins and misses,
+    and prioritized optimization recommendations. Use when wrapping a campaign, when preparing weekly,
+    monthly, or quarterly channel summaries for stakeholders, or when you need data translated into an
+    executive summary with next-period priorities.
+- name: seo-audit
+  path: skills/seo-audit/SKILL.md
+  description: Run a comprehensive SEO audit — keyword research, on-page analysis, content gaps, technical
+    checks, and competitor comparison. Use when assessing a site's SEO health, when finding keyword opportunities
+    and content gaps competitors own, or when you need a prioritized action plan split into quick wins
+    and strategic investments.
 mcp:
   path: mcp.jsonc
+references:
+- id: connectors
+  path: CONNECTORS.md

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/skills/brand-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/skills/brand-review/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<content to review>"
 
 # Brand Review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Review marketing content against brand voice, style guidelines, and messaging standards. Flag deviations and provide specific improvement suggestions.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/skills/campaign-plan/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/skills/campaign-plan/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<campaign objective or product>"
 
 # Campaign Plan
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Generate a comprehensive marketing campaign brief with objectives, audience, messaging, channel strategy, content calendar, and success metrics.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/skills/competitive-brief/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/skills/competitive-brief/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<competitor or market segment>"
 
 # Competitive Brief
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Research competitors and generate a structured competitive analysis comparing positioning, messaging, content strategy, and market presence.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/skills/draft-content/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/skills/draft-content/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<content type and topic>"
 
 # Draft Content
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Generate marketing content drafts tailored to a specific content type, audience, and brand voice.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/skills/email-sequence/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/skills/email-sequence/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[sequence type]"
 
 # Email Sequence
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Design and draft complete email sequences with full copy, timing, branching logic, and performance benchmarks for any lifecycle or campaign use case.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/skills/performance-report/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/skills/performance-report/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<time period or campaign>"
 
 # Performance Report
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Generate a marketing performance report with key metrics, trend analysis, insights, and optimization recommendations.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/skills/seo-audit/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_marketing/for-forgecat/skills/seo-audit/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<url or topic> [audit type]"
 
 # /seo-audit
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Audit a website's SEO health, research keyword opportunities, identify content gaps, and benchmark against competitors. Produces a prioritized action plan a marketer can execute immediately.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/README.md
@@ -52,7 +52,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_operations
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/operations |
-| Version | `0.0.8` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -66,6 +66,8 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_operations
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-claude/.claude/skills/capacity-plan/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-claude/.claude/skills/capacity-plan/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <team or project scope>
 
 # /capacity-plan
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/CONNECTORS.md`).
 
 Analyze team capacity and plan resource allocation.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-claude/.claude/skills/change-request/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-claude/.claude/skills/change-request/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <change description>
 
 # /change-request
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/CONNECTORS.md`).
 
 Create a structured change request with impact analysis, risk assessment, and rollback plan.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-claude/.claude/skills/process-doc/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-claude/.claude/skills/process-doc/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <process name or description>
 
 # /process-doc
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/CONNECTORS.md`).
 
 Document a business process as a complete standard operating procedure (SOP).
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-claude/.claude/skills/runbook/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-claude/.claude/skills/runbook/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <process or task name>
 
 # /runbook
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/CONNECTORS.md`).
 
 Create a step-by-step operational runbook for a recurring task or procedure.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-claude/.claude/skills/status-report/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-claude/.claude/skills/status-report/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: "[weekly | monthly | quarterly] [project or team]"
 
 # /status-report
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/CONNECTORS.md`).
 
 Generate a polished status report for leadership or stakeholders. See the **risk-assessment** skill for risk matrix frameworks and severity definitions.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-claude/.claude/skills/vendor-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-claude/.claude/skills/vendor-review/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <vendor name or proposal>
 
 # /vendor-review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/CONNECTORS.md`).
 
 Evaluate a vendor with structured analysis covering cost, risk, performance, and fit.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/CONNECTORS.md
@@ -1,0 +1,20 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~ITSM` might mean ServiceNow, Zendesk, or any other service management tool with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (ITSM, project tracker, knowledge base, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Calendar | `~~calendar` | Google Calendar | Microsoft 365 |
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Email | `~~email` | Gmail, Microsoft 365 | — |
+| ITSM | `~~ITSM` | ServiceNow | Zendesk, Freshservice, Jira Service Management |
+| Knowledge base | `~~knowledge base` | Notion, Atlassian (Confluence) | Guru, Coda |
+| Project tracker | `~~project tracker` | Asana, Atlassian (Jira) | Linear, monday.com, ClickUp |
+| Procurement | `~~procurement` | — | Coupa, SAP Ariba, Zip |
+| Office suite | `~~office suite` | Microsoft 365 | Google Workspace |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Operations
@@ -54,7 +54,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_operations
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/operations |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -66,8 +66,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_operations
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-codex/.agents/skills/capacity-plan/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-codex/.agents/skills/capacity-plan/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <team or project scope>
 
 # /capacity-plan
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/CONNECTORS.md`).
 
 Analyze team capacity and plan resource allocation.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-codex/.agents/skills/change-request/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-codex/.agents/skills/change-request/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <change description>
 
 # /change-request
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/CONNECTORS.md`).
 
 Create a structured change request with impact analysis, risk assessment, and rollback plan.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-codex/.agents/skills/process-doc/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-codex/.agents/skills/process-doc/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <process name or description>
 
 # /process-doc
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/CONNECTORS.md`).
 
 Document a business process as a complete standard operating procedure (SOP).
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-codex/.agents/skills/runbook/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-codex/.agents/skills/runbook/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <process or task name>
 
 # /runbook
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/CONNECTORS.md`).
 
 Create a step-by-step operational runbook for a recurring task or procedure.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-codex/.agents/skills/status-report/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-codex/.agents/skills/status-report/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: "[weekly | monthly | quarterly] [project or team]"
 
 # /status-report
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/CONNECTORS.md`).
 
 Generate a polished status report for leadership or stakeholders. See the **risk-assessment** skill for risk matrix frameworks and severity definitions.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-codex/.agents/skills/vendor-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-codex/.agents/skills/vendor-review/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <vendor name or proposal>
 
 # /vendor-review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/CONNECTORS.md`).
 
 Evaluate a vendor with structured analysis covering cost, risk, performance, and fit.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/CONNECTORS.md
@@ -1,0 +1,20 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~ITSM` might mean ServiceNow, Zendesk, or any other service management tool with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (ITSM, project tracker, knowledge base, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Calendar | `~~calendar` | Google Calendar | Microsoft 365 |
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Email | `~~email` | Gmail, Microsoft 365 | — |
+| ITSM | `~~ITSM` | ServiceNow | Zendesk, Freshservice, Jira Service Management |
+| Knowledge base | `~~knowledge base` | Notion, Atlassian (Confluence) | Guru, Coda |
+| Project tracker | `~~project tracker` | Asana, Atlassian (Jira) | Linear, monday.com, ClickUp |
+| Procurement | `~~procurement` | — | Coupa, SAP Ariba, Zip |
+| Office suite | `~~office suite` | Microsoft 365 | Google Workspace |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Operations
@@ -54,7 +54,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_operations
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/operations |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -66,8 +66,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_operations
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-cursor/.cursor/skills/capacity-plan/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-cursor/.cursor/skills/capacity-plan/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <team or project scope>
 
 # /capacity-plan
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/CONNECTORS.md`).
 
 Analyze team capacity and plan resource allocation.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-cursor/.cursor/skills/change-request/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-cursor/.cursor/skills/change-request/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <change description>
 
 # /change-request
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/CONNECTORS.md`).
 
 Create a structured change request with impact analysis, risk assessment, and rollback plan.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-cursor/.cursor/skills/process-doc/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-cursor/.cursor/skills/process-doc/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <process name or description>
 
 # /process-doc
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/CONNECTORS.md`).
 
 Document a business process as a complete standard operating procedure (SOP).
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-cursor/.cursor/skills/runbook/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-cursor/.cursor/skills/runbook/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <process or task name>
 
 # /runbook
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/CONNECTORS.md`).
 
 Create a step-by-step operational runbook for a recurring task or procedure.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-cursor/.cursor/skills/status-report/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-cursor/.cursor/skills/status-report/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: "[weekly | monthly | quarterly] [project or team]"
 
 # /status-report
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/CONNECTORS.md`).
 
 Generate a polished status report for leadership or stakeholders. See the **risk-assessment** skill for risk matrix frameworks and severity definitions.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-cursor/.cursor/skills/vendor-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-cursor/.cursor/skills/vendor-review/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <vendor name or proposal>
 
 # /vendor-review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/CONNECTORS.md`).
 
 Evaluate a vendor with structured analysis covering cost, risk, performance, and fit.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/CONNECTORS.md
@@ -1,0 +1,20 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~ITSM` might mean ServiceNow, Zendesk, or any other service management tool with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (ITSM, project tracker, knowledge base, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Calendar | `~~calendar` | Google Calendar | Microsoft 365 |
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Email | `~~email` | Gmail, Microsoft 365 | — |
+| ITSM | `~~ITSM` | ServiceNow | Zendesk, Freshservice, Jira Service Management |
+| Knowledge base | `~~knowledge base` | Notion, Atlassian (Confluence) | Guru, Coda |
+| Project tracker | `~~project tracker` | Asana, Atlassian (Jira) | Linear, monday.com, ClickUp |
+| Procurement | `~~procurement` | — | Coupa, SAP Ariba, Zip |
+| Office suite | `~~office suite` | Microsoft 365 | Google Workspace |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_operations/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Operations
@@ -54,7 +54,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_operations
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/operations |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -66,8 +66,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_operations
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-forgecat/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-forgecat/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-forgecat/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-forgecat/README.md
@@ -54,7 +54,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_operations
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/operations |
-| Version | `0.0.8` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -68,6 +68,8 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_operations
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-forgecat/platforms/claude-code/.claude-plugin/plugin.json
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-forgecat/platforms/claude-code/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "operations",
+  "version": "1.2.0",
+  "description": "Optimize business operations — vendor management, process documentation, change management, capacity planning, and compliance tracking. Keep your organization running efficiently.",
+  "author": {
+    "name": "Anthropic"
+  }
+}

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-forgecat/platforms/claude-code/.mcp.json
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-forgecat/platforms/claude-code/.mcp.json
@@ -1,0 +1,36 @@
+{
+  "mcpServers": {
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
+    },
+    "google-calendar": {
+      "type": "http",
+      "url": "https://gcal.mcp.claude.com/mcp"
+    },
+    "gmail": {
+      "type": "http",
+      "url": "https://gmail.mcp.claude.com/mcp"
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
+    },
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp"
+    },
+    "asana": {
+      "type": "http",
+      "url": "https://mcp.asana.com/v2/mcp"
+    },
+    "servicenow": {
+      "type": "http",
+      "url": "https://mcp.servicenow.com/mcp"
+    },
+    "ms365": {
+      "type": "http",
+      "url": "https://microsoft365.mcp.claude.com/mcp"
+    }
+  }
+}

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-forgecat/profile.yml
@@ -1,74 +1,72 @@
-name: "@forgecat/anthropics_knowledge-work-plugins_operations"
-version: 0.0.8
-description: Optimize business operations — vendor management, process documentation,
-  change management, capacity planning, and compliance tracking. Keep your organization
-  running efficiently.
+name: '@forgecat/anthropics_knowledge-work-plugins_operations'
+description: Optimize business operations — vendor management, process documentation, change management,
+  capacity planning, and compliance tracking. Keep your organization running efficiently.
+visibility: public
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/operations
 license: Apache-2.0
-visibility: public
 sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:
-      - claude-code
-      - cursor
-      - codex
+    - claude-code
+    - cursor
+    - codex
+    partial:
+    - openclaw
+    - hermes
   models:
     recommended: []
     minimum: []
 skills:
-- name: process-doc
-  path: skills/process-doc/SKILL.md
-  description: Document a business process — flowcharts, RACI, and SOPs. Use when
-    formalizing a process that lives in someone's head, building a RACI to clarify
-    who owns what, writing an SOP for a handoff or audit, or capturing the exceptions
-    and edge cases of how work actually gets done.
-- name: process-optimization
-  path: skills/process-optimization/SKILL.md
-  description: Analyze and improve business processes. Trigger with "this process
-    is slow", "how can we improve", "streamline this workflow", "too many steps",
-    "bottleneck", or when the user describes an inefficient process they want to fix.
-- name: runbook
-  path: skills/runbook/SKILL.md
-  description: Create or update an operational runbook for a recurring task or procedure.
-    Use when documenting a task that on-call or ops needs to run repeatably, turning
-    tribal knowledge into exact step-by-step commands, adding troubleshooting and
-    rollback steps to an existing procedure, or writing escalation paths for when
-    things go wrong.
-- name: change-request
-  path: skills/change-request/SKILL.md
-  description: Create a change management request with impact analysis and rollback
-    plan. Use when proposing a system or process change that needs approval, preparing
-    a change record for CAB review, documenting risk and rollback steps before a deployment,
-    or planning stakeholder communications for a rollout.
-- name: vendor-review
-  path: skills/vendor-review/SKILL.md
-  description: Evaluate a vendor — cost analysis, risk assessment, and recommendation.
-    Use when reviewing a new vendor proposal, deciding whether to renew or replace
-    a contract, comparing two vendors side-by-side, or building a TCO breakdown and
-    negotiation points before procurement sign-off.
 - name: capacity-plan
   path: skills/capacity-plan/SKILL.md
-  description: Plan resource capacity — workload analysis and utilization forecasting.
-    Use when heading into quarterly planning, the team feels overallocated and you
-    need the numbers, deciding whether to hire or deprioritize, or stress-testing
-    whether upcoming projects fit the people you have.
-- name: risk-assessment
-  path: skills/risk-assessment/SKILL.md
-  description: Identify, assess, and mitigate operational risks. Trigger with "what
-    are the risks", "risk assessment", "risk register", "what could go wrong", or
-    when the user is evaluating risks associated with a project, vendor, process,
-    or decision.
-- name: status-report
-  path: skills/status-report/SKILL.md
-  description: Generate a status report with KPIs, risks, and action items. Use when
-    writing a weekly or monthly update for leadership, summarizing project health
-    with green/yellow/red status, surfacing risks and decisions that need stakeholder
-    attention, or turning a pile of project tracker activity into a readable narrative.
+  description: Plan resource capacity — workload analysis and utilization forecasting. Use when heading
+    into quarterly planning, the team feels overallocated and you need the numbers, deciding whether to
+    hire or deprioritize, or stress-testing whether upcoming projects fit the people you have.
+- name: change-request
+  path: skills/change-request/SKILL.md
+  description: Create a change management request with impact analysis and rollback plan. Use when proposing
+    a system or process change that needs approval, preparing a change record for CAB review, documenting
+    risk and rollback steps before a deployment, or planning stakeholder communications for a rollout.
 - name: compliance-tracking
   path: skills/compliance-tracking/SKILL.md
-  description: Track compliance requirements and audit readiness. Trigger with "compliance",
-    "audit prep", "SOC 2", "ISO 27001", "GDPR", "regulatory requirement", or when
-    the user needs help tracking, preparing for, or documenting compliance activities.
+  description: Track compliance requirements and audit readiness. Trigger with "compliance", "audit prep",
+    "SOC 2", "ISO 27001", "GDPR", "regulatory requirement", or when the user needs help tracking, preparing
+    for, or documenting compliance activities.
+- name: process-doc
+  path: skills/process-doc/SKILL.md
+  description: Document a business process — flowcharts, RACI, and SOPs. Use when formalizing a process
+    that lives in someone's head, building a RACI to clarify who owns what, writing an SOP for a handoff
+    or audit, or capturing the exceptions and edge cases of how work actually gets done.
+- name: process-optimization
+  path: skills/process-optimization/SKILL.md
+  description: Analyze and improve business processes. Trigger with "this process is slow", "how can we
+    improve", "streamline this workflow", "too many steps", "bottleneck", or when the user describes an
+    inefficient process they want to fix.
+- name: risk-assessment
+  path: skills/risk-assessment/SKILL.md
+  description: Identify, assess, and mitigate operational risks. Trigger with "what are the risks", "risk
+    assessment", "risk register", "what could go wrong", or when the user is evaluating risks associated
+    with a project, vendor, process, or decision.
+- name: runbook
+  path: skills/runbook/SKILL.md
+  description: Create or update an operational runbook for a recurring task or procedure. Use when documenting
+    a task that on-call or ops needs to run repeatably, turning tribal knowledge into exact step-by-step
+    commands, adding troubleshooting and rollback steps to an existing procedure, or writing escalation
+    paths for when things go wrong.
+- name: status-report
+  path: skills/status-report/SKILL.md
+  description: Generate a status report with KPIs, risks, and action items. Use when writing a weekly
+    or monthly update for leadership, summarizing project health with green/yellow/red status, surfacing
+    risks and decisions that need stakeholder attention, or turning a pile of project tracker activity
+    into a readable narrative.
+- name: vendor-review
+  path: skills/vendor-review/SKILL.md
+  description: Evaluate a vendor — cost analysis, risk assessment, and recommendation. Use when reviewing
+    a new vendor proposal, deciding whether to renew or replace a contract, comparing two vendors side-by-side,
+    or building a TCO breakdown and negotiation points before procurement sign-off.
 mcp:
   path: mcp.jsonc
+references:
+- id: connectors
+  path: CONNECTORS.md

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-forgecat/skills/capacity-plan/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-forgecat/skills/capacity-plan/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<team or project scope>"
 
 # /capacity-plan
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Analyze team capacity and plan resource allocation.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-forgecat/skills/change-request/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-forgecat/skills/change-request/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<change description>"
 
 # /change-request
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Create a structured change request with impact analysis, risk assessment, and rollback plan.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-forgecat/skills/process-doc/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-forgecat/skills/process-doc/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<process name or description>"
 
 # /process-doc
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Document a business process as a complete standard operating procedure (SOP).
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-forgecat/skills/runbook/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-forgecat/skills/runbook/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<process or task name>"
 
 # /runbook
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Create a step-by-step operational runbook for a recurring task or procedure.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-forgecat/skills/status-report/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-forgecat/skills/status-report/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[weekly | monthly | quarterly] [project or team]"
 
 # /status-report
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Generate a polished status report for leadership or stakeholders. See the **risk-assessment** skill for risk matrix frameworks and severity definitions.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-forgecat/skills/vendor-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_operations/for-forgecat/skills/vendor-review/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<vendor name or proposal>"
 
 # /vendor-review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Evaluate a vendor with structured analysis covering cost, risk, performance, and fit.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/README.md
@@ -65,7 +65,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_product-managem
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/product-management |
-| Version | `0.0.7` |
+| Version | `0.0.9` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -79,6 +79,8 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_product-managem
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Partial |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-claude/.claude/commands/brainstorm.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-claude/.claude/commands/brainstorm.md
@@ -1,6 +1,6 @@
 # /brainstorm
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md`).
 
 Brainstorm a product topic with a sharp, opinionated thinking partner. This is a conversation, not a deliverable — the goal is to push thinking further than the PM would get alone.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-claude/.claude/skills/competitive-brief/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-claude/.claude/skills/competitive-brief/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <competitor or feature area>
 
 # Competitive Brief
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md`).
 
 Create a competitive analysis brief for one or more competitors or a feature area.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-claude/.claude/skills/metrics-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-claude/.claude/skills/metrics-review/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <time period or metric focus>
 
 # Metrics Review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md`).
 
 Review and analyze product metrics, identify trends, and surface actionable insights.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-claude/.claude/skills/roadmap-update/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-claude/.claude/skills/roadmap-update/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <update description>
 
 # Roadmap Update
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md`).
 
 Update, create, or reprioritize a product roadmap.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-claude/.claude/skills/sprint-planning/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-claude/.claude/skills/sprint-planning/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: "[sprint name or date range]"
 
 # /sprint-planning
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md`).
 
 Plan a sprint by scoping work, estimating capacity, and setting clear goals.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-claude/.claude/skills/stakeholder-update/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-claude/.claude/skills/stakeholder-update/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <update type and audience>
 
 # Stakeholder Update
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md`).
 
 Generate a stakeholder update tailored to the audience and cadence.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-claude/.claude/skills/synthesize-research/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-claude/.claude/skills/synthesize-research/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <research topic or question>
 
 # Synthesize Research
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md`).
 
 Synthesize user research from multiple sources into structured insights and recommendations.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-claude/.claude/skills/write-spec/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-claude/.claude/skills/write-spec/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <feature or problem statement>
 
 # Write Spec
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md`).
 
 Write a feature specification or product requirements document (PRD).
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md
@@ -1,0 +1,22 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~project tracker` might mean Linear, Asana, Jira, or any other tracker with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (project tracker, design, product analytics, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Calendar | `~~calendar` | Google Calendar | Microsoft 365 |
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Competitive intelligence | `~~competitive intelligence` | Similarweb | Crayon, Klue |
+| Design | `~~design` | Figma | Sketch, Adobe XD |
+| Email | `~~email` | Gmail | Microsoft 365 |
+| Knowledge base | `~~knowledge base` | Notion | Confluence, Guru, Coda |
+| Meeting transcription | `~~meeting transcription` | Fireflies | Gong, Dovetail, Otter.ai |
+| Product analytics | `~~product analytics` | Amplitude, Pendo | Mixpanel, Heap, FullStory |
+| Project tracker | `~~project tracker` | Linear, Asana, monday.com, ClickUp, Atlassian (Jira/Confluence) | Shortcut, Basecamp |
+| User feedback | `~~user feedback` | Intercom | Productboard, Canny, UserVoice |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Product Management
@@ -67,7 +67,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_product-managem
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/product-management |
-| Version | `0.0.4` |
+| Version | `0.0.9` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -79,8 +79,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_product-managem
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Cursor | Tested |
 | Codex | Partial |
-| Cursor | Partial |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-codex/.agents/skills/competitive-brief/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-codex/.agents/skills/competitive-brief/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <competitor or feature area>
 
 # Competitive Brief
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md`).
 
 Create a competitive analysis brief for one or more competitors or a feature area.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-codex/.agents/skills/metrics-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-codex/.agents/skills/metrics-review/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <time period or metric focus>
 
 # Metrics Review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md`).
 
 Review and analyze product metrics, identify trends, and surface actionable insights.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-codex/.agents/skills/roadmap-update/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-codex/.agents/skills/roadmap-update/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <update description>
 
 # Roadmap Update
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md`).
 
 Update, create, or reprioritize a product roadmap.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-codex/.agents/skills/sprint-planning/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-codex/.agents/skills/sprint-planning/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: "[sprint name or date range]"
 
 # /sprint-planning
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md`).
 
 Plan a sprint by scoping work, estimating capacity, and setting clear goals.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-codex/.agents/skills/stakeholder-update/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-codex/.agents/skills/stakeholder-update/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <update type and audience>
 
 # Stakeholder Update
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md`).
 
 Generate a stakeholder update tailored to the audience and cadence.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-codex/.agents/skills/synthesize-research/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-codex/.agents/skills/synthesize-research/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <research topic or question>
 
 # Synthesize Research
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md`).
 
 Synthesize user research from multiple sources into structured insights and recommendations.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-codex/.agents/skills/write-spec/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-codex/.agents/skills/write-spec/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <feature or problem statement>
 
 # Write Spec
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md`).
 
 Write a feature specification or product requirements document (PRD).
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md
@@ -1,0 +1,22 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~project tracker` might mean Linear, Asana, Jira, or any other tracker with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (project tracker, design, product analytics, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Calendar | `~~calendar` | Google Calendar | Microsoft 365 |
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Competitive intelligence | `~~competitive intelligence` | Similarweb | Crayon, Klue |
+| Design | `~~design` | Figma | Sketch, Adobe XD |
+| Email | `~~email` | Gmail | Microsoft 365 |
+| Knowledge base | `~~knowledge base` | Notion | Confluence, Guru, Coda |
+| Meeting transcription | `~~meeting transcription` | Fireflies | Gong, Dovetail, Otter.ai |
+| Product analytics | `~~product analytics` | Amplitude, Pendo | Mixpanel, Heap, FullStory |
+| Project tracker | `~~project tracker` | Linear, Asana, monday.com, ClickUp, Atlassian (Jira/Confluence) | Shortcut, Basecamp |
+| User feedback | `~~user feedback` | Intercom | Productboard, Canny, UserVoice |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Product Management
@@ -67,7 +67,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_product-managem
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/product-management |
-| Version | `0.0.4` |
+| Version | `0.0.9` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -79,8 +79,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_product-managem
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Cursor | Tested |
 | Codex | Partial |
-| Cursor | Partial |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-cursor/.cursor/rules/cmd-brainstorm.mdc
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-cursor/.cursor/rules/cmd-brainstorm.mdc
@@ -6,7 +6,7 @@ alwaysApply: true
 
 # /brainstorm
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md`).
 
 Brainstorm a product topic with a sharp, opinionated thinking partner. This is a conversation, not a deliverable — the goal is to push thinking further than the PM would get alone.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-cursor/.cursor/skills/competitive-brief/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-cursor/.cursor/skills/competitive-brief/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <competitor or feature area>
 
 # Competitive Brief
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md`).
 
 Create a competitive analysis brief for one or more competitors or a feature area.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-cursor/.cursor/skills/metrics-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-cursor/.cursor/skills/metrics-review/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <time period or metric focus>
 
 # Metrics Review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md`).
 
 Review and analyze product metrics, identify trends, and surface actionable insights.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-cursor/.cursor/skills/roadmap-update/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-cursor/.cursor/skills/roadmap-update/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <update description>
 
 # Roadmap Update
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md`).
 
 Update, create, or reprioritize a product roadmap.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-cursor/.cursor/skills/sprint-planning/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-cursor/.cursor/skills/sprint-planning/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: "[sprint name or date range]"
 
 # /sprint-planning
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md`).
 
 Plan a sprint by scoping work, estimating capacity, and setting clear goals.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-cursor/.cursor/skills/stakeholder-update/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-cursor/.cursor/skills/stakeholder-update/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <update type and audience>
 
 # Stakeholder Update
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md`).
 
 Generate a stakeholder update tailored to the audience and cadence.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-cursor/.cursor/skills/synthesize-research/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-cursor/.cursor/skills/synthesize-research/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <research topic or question>
 
 # Synthesize Research
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md`).
 
 Synthesize user research from multiple sources into structured insights and recommendations.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-cursor/.cursor/skills/write-spec/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-cursor/.cursor/skills/write-spec/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <feature or problem statement>
 
 # Write Spec
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md`).
 
 Write a feature specification or product requirements document (PRD).
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/CONNECTORS.md
@@ -1,0 +1,22 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~project tracker` might mean Linear, Asana, Jira, or any other tracker with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (project tracker, design, product analytics, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Calendar | `~~calendar` | Google Calendar | Microsoft 365 |
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Competitive intelligence | `~~competitive intelligence` | Similarweb | Crayon, Klue |
+| Design | `~~design` | Figma | Sketch, Adobe XD |
+| Email | `~~email` | Gmail | Microsoft 365 |
+| Knowledge base | `~~knowledge base` | Notion | Confluence, Guru, Coda |
+| Meeting transcription | `~~meeting transcription` | Fireflies | Gong, Dovetail, Otter.ai |
+| Product analytics | `~~product analytics` | Amplitude, Pendo | Mixpanel, Heap, FullStory |
+| Project tracker | `~~project tracker` | Linear, Asana, monday.com, ClickUp, Atlassian (Jira/Confluence) | Shortcut, Basecamp |
+| User feedback | `~~user feedback` | Intercom | Productboard, Canny, UserVoice |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_product-management/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Product Management
@@ -67,7 +67,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_product-managem
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/product-management |
-| Version | `0.0.4` |
+| Version | `0.0.9` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -79,8 +79,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_product-managem
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
+| Cursor | Tested |
 | Codex | Partial |
-| Cursor | Partial |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/README.md
@@ -67,7 +67,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_product-managem
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/product-management |
-| Version | `0.0.7` |
+| Version | `0.0.9` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -81,6 +81,8 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_product-managem
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Partial |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/commands/brainstorm.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/commands/brainstorm.md
@@ -5,7 +5,7 @@ argument-hint: "<topic, problem, or idea to explore>"
 
 # /brainstorm
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Brainstorm a product topic with a sharp, opinionated thinking partner. This is a conversation, not a deliverable — the goal is to push thinking further than the PM would get alone.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/platforms/claude-code/.claude-plugin/plugin.json
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/platforms/claude-code/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "product-management",
+  "version": "1.2.0",
+  "description": "Write feature specs, plan roadmaps, and synthesize user research faster. Keep stakeholders updated and stay ahead of the competitive landscape.",
+  "author": {
+    "name": "Anthropic"
+  }
+}

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/platforms/claude-code/.mcp.json
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/platforms/claude-code/.mcp.json
@@ -1,0 +1,68 @@
+{
+  "mcpServers": {
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
+    },
+    "linear": {
+      "type": "http",
+      "url": "https://mcp.linear.app/mcp"
+    },
+    "asana": {
+      "type": "http",
+      "url": "https://mcp.asana.com/v2/mcp"
+    },
+    "monday": {
+      "type": "http",
+      "url": "https://mcp.monday.com/mcp"
+    },
+    "clickup": {
+      "type": "http",
+      "url": "https://mcp.clickup.com/mcp"
+    },
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp"
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
+    },
+    "figma": {
+      "type": "http",
+      "url": "https://mcp.figma.com/mcp"
+    },
+    "amplitude": {
+      "type": "http",
+      "url": "https://mcp.amplitude.com/mcp"
+    },
+    "amplitude-eu": {
+      "type": "http",
+      "url": "https://mcp.eu.amplitude.com/mcp"
+    },
+    "pendo": {
+      "type": "http",
+      "url": "https://app.pendo.io/mcp/v0/shttp"
+    },
+    "intercom": {
+      "type": "http",
+      "url": "https://mcp.intercom.com/mcp"
+    },
+    "fireflies": {
+      "type": "http",
+      "url": "https://api.fireflies.ai/mcp"
+    },
+    "google-calendar": {
+      "type": "http",
+      "url": "https://gcal.mcp.claude.com/mcp"
+    },
+    "gmail": {
+      "type": "http",
+      "url": "https://gmail.mcp.claude.com/mcp"
+    },
+    "similarweb": {
+      "type": "http",
+      "url": "https://mcp.similarweb.com/mcp"
+    }
+  }
+}

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/profile.yml
@@ -1,74 +1,71 @@
-name: "@forgecat/anthropics_knowledge-work-plugins_product-management"
-version: 0.0.7
-description: Write feature specs, plan roadmaps, and synthesize user research faster.
-  Keep stakeholders updated and stay ahead of the competitive landscape.
+name: '@forgecat/anthropics_knowledge-work-plugins_product-management'
+description: Write feature specs, plan roadmaps, and synthesize user research faster. Keep stakeholders
+  updated and stay ahead of the competitive landscape.
+visibility: public
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/product-management
 license: Apache-2.0
-visibility: public
 sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:
-      - claude-code
-      - cursor
+    - claude-code
+    - cursor
     partial:
-      - codex
+    - codex
+    - openclaw
+    - hermes
   models:
     recommended: []
     minimum: []
 skills:
-- name: write-spec
-  path: skills/write-spec/SKILL.md
-  description: Write a feature spec or PRD from a problem statement or feature idea.
-    Use when turning a vague idea or user request into a structured document, scoping
-    a feature with goals and non-goals, defining success metrics and acceptance criteria,
-    or breaking a big ask into a phased spec.
-- name: roadmap-update
-  path: skills/roadmap-update/SKILL.md
-  description: Update, create, or reprioritize your product roadmap. Use when adding
-    a new initiative and deciding what moves to make room, shifting priorities after
-    new information comes in, moving timelines due to a dependency slip, or building
-    a Now/Next/Later view from scratch.
-- name: synthesize-research
-  path: skills/synthesize-research/SKILL.md
-  description: Synthesize user research from interviews, surveys, and feedback into
-    structured insights. Use when you have a pile of interview notes, survey responses,
-    or support tickets to make sense of, need to extract themes and rank findings
-    by frequency and impact, or want to turn raw feedback into roadmap recommendations.
-- name: stakeholder-update
-  path: skills/stakeholder-update/SKILL.md
-  description: Generate a stakeholder update tailored to audience and cadence. Use
-    when writing a weekly or monthly status for leadership, announcing a launch, escalating
-    a risk or blocker, or translating the same progress into exec-brief, engineering-detail,
-    or customer-facing versions.
 - name: competitive-brief
   path: skills/competitive-brief/SKILL.md
-  description: Create a competitive analysis brief for one or more competitors or
-    a feature area. Use when informing product strategy or feature prioritization,
-    building sales battle cards, prepping board or investor materials, or deciding
-    where to differentiate vs. achieve parity.
+  description: Create a competitive analysis brief for one or more competitors or a feature area. Use
+    when informing product strategy or feature prioritization, building sales battle cards, prepping board
+    or investor materials, or deciding where to differentiate vs. achieve parity.
 - name: metrics-review
   path: skills/metrics-review/SKILL.md
-  description: Review and analyze product metrics with trend analysis and actionable
-    insights. Use when running a weekly, monthly, or quarterly metrics review, investigating
-    a sudden spike or drop, comparing performance against targets, or turning raw
-    numbers into a scorecard with recommended actions.
-- name: sprint-planning
-  path: skills/sprint-planning/SKILL.md
-  description: Plan a sprint — scope work, estimate capacity, set goals, and draft
-    a sprint plan. Use when kicking off a new sprint, sizing a backlog against team
-    availability (accounting for PTO and meetings), deciding what's P0 vs. stretch,
-    or handling carryover from the last sprint.
+  description: Review and analyze product metrics with trend analysis and actionable insights. Use when
+    running a weekly, monthly, or quarterly metrics review, investigating a sudden spike or drop, comparing
+    performance against targets, or turning raw numbers into a scorecard with recommended actions.
 - name: product-brainstorming
   path: skills/product-brainstorming/SKILL.md
-  description: Brainstorm product ideas, explore problem spaces, and challenge assumptions
-    as a thinking partner. Use when exploring a new opportunity, generating solutions
-    to a product problem, stress-testing an idea, or when a PM needs to think out
-    loud with a sharp sparring partner before converging on a direction.
+  description: Brainstorm product ideas, explore problem spaces, and challenge assumptions as a thinking
+    partner. Use when exploring a new opportunity, generating solutions to a product problem, stress-testing
+    an idea, or when a PM needs to think out loud with a sharp sparring partner before converging on a
+    direction.
+- name: roadmap-update
+  path: skills/roadmap-update/SKILL.md
+  description: Update, create, or reprioritize your product roadmap. Use when adding a new initiative
+    and deciding what moves to make room, shifting priorities after new information comes in, moving timelines
+    due to a dependency slip, or building a Now/Next/Later view from scratch.
+- name: sprint-planning
+  path: skills/sprint-planning/SKILL.md
+  description: Plan a sprint — scope work, estimate capacity, set goals, and draft a sprint plan. Use
+    when kicking off a new sprint, sizing a backlog against team availability (accounting for PTO and
+    meetings), deciding what's P0 vs. stretch, or handling carryover from the last sprint.
+- name: stakeholder-update
+  path: skills/stakeholder-update/SKILL.md
+  description: Generate a stakeholder update tailored to audience and cadence. Use when writing a weekly
+    or monthly status for leadership, announcing a launch, escalating a risk or blocker, or translating
+    the same progress into exec-brief, engineering-detail, or customer-facing versions.
+- name: synthesize-research
+  path: skills/synthesize-research/SKILL.md
+  description: Synthesize user research from interviews, surveys, and feedback into structured insights.
+    Use when you have a pile of interview notes, survey responses, or support tickets to make sense of,
+    need to extract themes and rank findings by frequency and impact, or want to turn raw feedback into
+    roadmap recommendations.
+- name: write-spec
+  path: skills/write-spec/SKILL.md
+  description: Write a feature spec or PRD from a problem statement or feature idea. Use when turning
+    a vague idea or user request into a structured document, scoping a feature with goals and non-goals,
+    defining success metrics and acceptance criteria, or breaking a big ask into a phased spec.
 commands:
 - name: brainstorm
   path: commands/brainstorm.md
-  description: Brainstorm a product idea, problem space, or strategic question with
-    a sharp thinking partner
+  description: Brainstorm a product idea, problem space, or strategic question with a sharp thinking partner
 mcp:
   path: mcp.jsonc
+references:
+- id: connectors
+  path: CONNECTORS.md

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/skills/competitive-brief/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/skills/competitive-brief/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<competitor or feature area>"
 
 # Competitive Brief
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Create a competitive analysis brief for one or more competitors or a feature area.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/skills/metrics-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/skills/metrics-review/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<time period or metric focus>"
 
 # Metrics Review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Review and analyze product metrics, identify trends, and surface actionable insights.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/skills/roadmap-update/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/skills/roadmap-update/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<update description>"
 
 # Roadmap Update
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Update, create, or reprioritize a product roadmap.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/skills/sprint-planning/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/skills/sprint-planning/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[sprint name or date range]"
 
 # /sprint-planning
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Plan a sprint by scoping work, estimating capacity, and setting clear goals.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/skills/stakeholder-update/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/skills/stakeholder-update/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<update type and audience>"
 
 # Stakeholder Update
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Generate a stakeholder update tailored to the audience and cadence.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/skills/synthesize-research/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/skills/synthesize-research/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<research topic or question>"
 
 # Synthesize Research
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Synthesize user research from multiple sources into structured insights and recommendations.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/skills/write-spec/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_product-management/for-forgecat/skills/write-spec/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<feature or problem statement>"
 
 # Write Spec
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Write a feature specification or product requirements document (PRD).
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/README.md
@@ -58,7 +58,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_sales
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/sales |
-| Version | `0.0.8` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -72,6 +72,8 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_sales
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-claude/.claude/skills/call-summary/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-claude/.claude/skills/call-summary/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <call notes or transcript>
 
 # /call-summary
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/CONNECTORS.md`).
 
 Process call notes or a transcript to extract action items, draft follow-up communications, and update records.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-claude/.claude/skills/forecast/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-claude/.claude/skills/forecast/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <period>
 
 # /forecast
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/CONNECTORS.md`).
 
 Generate a weighted sales forecast with risk analysis and commit recommendations.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-claude/.claude/skills/pipeline-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-claude/.claude/skills/pipeline-review/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <segment or rep>
 
 # /pipeline-review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/CONNECTORS.md`).
 
 Analyze your pipeline health, prioritize deals, and get actionable recommendations for where to focus.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/CONNECTORS.md
@@ -1,0 +1,22 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~CRM` might mean Salesforce, HubSpot, or any other CRM with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (CRM, chat, email, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Calendar | `~~calendar` | Google Calendar, Microsoft 365 | — |
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Competitive intelligence | `~~competitive intelligence` | Similarweb | Crayon, Klue |
+| CRM | `~~CRM` | HubSpot, Close | Salesforce, Pipedrive, Copper |
+| Data enrichment | `~~data enrichment` | Clay, ZoomInfo, Apollo | Clearbit, Lusha |
+| Email | `~~email` | Gmail, Microsoft 365 | — |
+| Knowledge base | `~~knowledge base` | Notion | Confluence, Guru |
+| Meeting transcription | `~~conversation intelligence` | Fireflies | Gong, Chorus, Otter.ai |
+| Project tracker | `~~project tracker` | Atlassian (Jira/Confluence) | Linear, Asana |
+| Sales engagement | `~~sales engagement` | Outreach | Salesloft, Apollo |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Sales
@@ -60,7 +60,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_sales
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/sales |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -72,8 +72,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_sales
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-codex/.agents/skills/call-summary/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-codex/.agents/skills/call-summary/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <call notes or transcript>
 
 # /call-summary
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/CONNECTORS.md`).
 
 Process call notes or a transcript to extract action items, draft follow-up communications, and update records.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-codex/.agents/skills/forecast/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-codex/.agents/skills/forecast/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <period>
 
 # /forecast
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/CONNECTORS.md`).
 
 Generate a weighted sales forecast with risk analysis and commit recommendations.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-codex/.agents/skills/pipeline-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-codex/.agents/skills/pipeline-review/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <segment or rep>
 
 # /pipeline-review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/CONNECTORS.md`).
 
 Analyze your pipeline health, prioritize deals, and get actionable recommendations for where to focus.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/CONNECTORS.md
@@ -1,0 +1,22 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~CRM` might mean Salesforce, HubSpot, or any other CRM with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (CRM, chat, email, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Calendar | `~~calendar` | Google Calendar, Microsoft 365 | — |
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Competitive intelligence | `~~competitive intelligence` | Similarweb | Crayon, Klue |
+| CRM | `~~CRM` | HubSpot, Close | Salesforce, Pipedrive, Copper |
+| Data enrichment | `~~data enrichment` | Clay, ZoomInfo, Apollo | Clearbit, Lusha |
+| Email | `~~email` | Gmail, Microsoft 365 | — |
+| Knowledge base | `~~knowledge base` | Notion | Confluence, Guru |
+| Meeting transcription | `~~conversation intelligence` | Fireflies | Gong, Chorus, Otter.ai |
+| Project tracker | `~~project tracker` | Atlassian (Jira/Confluence) | Linear, Asana |
+| Sales engagement | `~~sales engagement` | Outreach | Salesloft, Apollo |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Sales
@@ -60,7 +60,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_sales
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/sales |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -72,8 +72,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_sales
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-cursor/.cursor/skills/call-summary/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-cursor/.cursor/skills/call-summary/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <call notes or transcript>
 
 # /call-summary
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/CONNECTORS.md`).
 
 Process call notes or a transcript to extract action items, draft follow-up communications, and update records.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-cursor/.cursor/skills/forecast/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-cursor/.cursor/skills/forecast/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: <period>
 
 # /forecast
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/CONNECTORS.md`).
 
 Generate a weighted sales forecast with risk analysis and commit recommendations.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-cursor/.cursor/skills/pipeline-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-cursor/.cursor/skills/pipeline-review/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: <segment or rep>
 
 # /pipeline-review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/CONNECTORS.md`).
 
 Analyze your pipeline health, prioritize deals, and get actionable recommendations for where to focus.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/CONNECTORS.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/CONNECTORS.md
@@ -1,0 +1,22 @@
+# Connectors
+
+## How tool references work
+
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~CRM` might mean Salesforce, HubSpot, or any other CRM with an MCP server.
+
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (CRM, chat, email, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+
+## Connectors for this plugin
+
+| Category | Placeholder | Included servers | Other options |
+|----------|-------------|-----------------|---------------|
+| Calendar | `~~calendar` | Google Calendar, Microsoft 365 | — |
+| Chat | `~~chat` | Slack | Microsoft Teams |
+| Competitive intelligence | `~~competitive intelligence` | Similarweb | Crayon, Klue |
+| CRM | `~~CRM` | HubSpot, Close | Salesforce, Pipedrive, Copper |
+| Data enrichment | `~~data enrichment` | Clay, ZoomInfo, Apollo | Clearbit, Lusha |
+| Email | `~~email` | Gmail, Microsoft 365 | — |
+| Knowledge base | `~~knowledge base` | Notion | Confluence, Guru |
+| Meeting transcription | `~~conversation intelligence` | Fireflies | Gong, Chorus, Otter.ai |
+| Project tracker | `~~project tracker` | Atlassian (Jira/Confluence) | Linear, Asana |
+| Sales engagement | `~~sales engagement` | Outreach | Salesloft, Apollo |

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-cursor/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_sales/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 
 # Sales
@@ -60,7 +60,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_sales
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/sales |
-| Version | `0.0.4` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -72,8 +72,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_sales
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-forgecat/LICENSE
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-forgecat/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-forgecat/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-forgecat/README.md
@@ -60,7 +60,7 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_sales
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/knowledge-work-plugins/tree/main/sales |
-| Version | `0.0.8` |
+| Version | `0.0.10` |
 | Original commit | d2ba7f6 |
 | License | Apache-2.0 |
 | Source platform | Claude Code plugin (Cowork) |
@@ -74,6 +74,8 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_sales
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-forgecat/platforms/claude-code/.claude-plugin/plugin.json
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-forgecat/platforms/claude-code/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "sales",
+  "version": "1.2.0",
+  "description": "Prospect, craft outreach, and build deal strategy faster. Prep for calls, manage your pipeline, and write personalized messaging that moves deals forward.",
+  "author": {
+    "name": "Anthropic"
+  }
+}

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-forgecat/platforms/claude-code/.mcp.json
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-forgecat/platforms/claude-code/.mcp.json
@@ -1,0 +1,60 @@
+{
+  "mcpServers": {
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
+    },
+    "hubspot": {
+      "type": "http",
+      "url": "https://mcp.hubspot.com/anthropic"
+    },
+    "close": {
+      "type": "http",
+      "url": "https://mcp.close.com/mcp"
+    },
+    "clay": {
+      "type": "http",
+      "url": "https://api.clay.com/v3/mcp"
+    },
+    "zoominfo": {
+      "type": "http",
+      "url": "https://mcp.zoominfo.com/mcp"
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
+    },
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp"
+    },
+    "fireflies": {
+      "type": "http",
+      "url": "https://api.fireflies.ai/mcp"
+    },
+    "ms365": {
+      "type": "http",
+      "url": "https://microsoft365.mcp.claude.com/mcp"
+    },
+    "apollo": {
+      "type": "http",
+      "url": "https://api.apollo.io/mcp"
+    },
+    "outreach": {
+      "type": "http",
+      "url": "https://mcp.outreach.io/mcp"
+    },
+    "google-calendar": {
+      "type": "http",
+      "url": "https://gcal.mcp.claude.com/mcp"
+    },
+    "gmail": {
+      "type": "http",
+      "url": "https://gmail.mcp.claude.com/mcp"
+    },
+    "similarweb": {
+      "type": "http",
+      "url": "https://mcp.similarweb.com/mcp"
+    }
+  }
+}

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-forgecat/profile.yml
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-forgecat/profile.yml
@@ -1,73 +1,74 @@
-name: "@forgecat/anthropics_knowledge-work-plugins_sales"
-version: 0.0.8
-description: Prospect, craft outreach, and build deal strategy faster. Prep for calls,
-  manage your pipeline, and write personalized messaging that moves deals forward.
+name: '@forgecat/anthropics_knowledge-work-plugins_sales'
+description: Prospect, craft outreach, and build deal strategy faster. Prep for calls, manage your pipeline,
+  and write personalized messaging that moves deals forward.
+visibility: public
 repository: https://github.com/anthropics/knowledge-work-plugins/tree/main/sales
 license: Apache-2.0
-visibility: public
 sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:
-      - claude-code
-      - cursor
-      - codex
+    - claude-code
+    - cursor
+    - codex
+    partial:
+    - openclaw
+    - hermes
   models:
     recommended: []
     minimum: []
 skills:
 - name: account-research
   path: skills/account-research/SKILL.md
-  description: Research a company or person and get actionable sales intel. Works
-    standalone with web search, supercharged when you connect enrichment tools or
-    your CRM. Trigger with "research [company]", "look up [person]", "intel on [prospect]",
-    "who is [name] at [company]", or "tell me about [company]".
+  description: Research a company or person and get actionable sales intel. Works standalone with web
+    search, supercharged when you connect enrichment tools or your CRM. Trigger with "research [company]",
+    "look up [person]", "intel on [prospect]", "who is [name] at [company]", or "tell me about [company]".
 - name: call-prep
   path: skills/call-prep/SKILL.md
-  description: Prepare for a sales call with account context, attendee research, and
-    suggested agenda. Works standalone with user input and web research, supercharged
-    when you connect your CRM, email, chat, or transcripts. Trigger with "prep me
-    for my call with [company]", "I'm meeting with [company] prep me", "call prep
-    [company]", or "get me ready for [meeting]".
+  description: Prepare for a sales call with account context, attendee research, and suggested agenda.
+    Works standalone with user input and web research, supercharged when you connect your CRM, email,
+    chat, or transcripts. Trigger with "prep me for my call with [company]", "I'm meeting with [company]
+    prep me", "call prep [company]", or "get me ready for [meeting]".
 - name: call-summary
   path: skills/call-summary/SKILL.md
-  description: Process call notes or a transcript — extract action items, draft follow-up
-    email, generate internal summary. Use when pasting rough notes or a transcript
-    after a discovery, demo, or negotiation call, drafting a customer follow-up, logging
-    the activity for your CRM, or capturing objections and next steps for your team.
-- name: draft-outreach
-  path: skills/draft-outreach/SKILL.md
-  description: Research a prospect then draft personalized outreach. Uses web research
-    by default, supercharged with enrichment and CRM. Trigger with "draft outreach
-    to [person/company]", "write cold email to [prospect]", "reach out to [name]".
-- name: daily-briefing
-  path: skills/daily-briefing/SKILL.md
-  description: Start your day with a prioritized sales briefing. Works standalone
-    when you tell me your meetings and priorities, supercharged when you connect your
-    calendar, CRM, and email. Trigger with "morning briefing", "daily brief", "what's
-    on my plate today", "prep my day", or "start my day".
-- name: pipeline-review
-  path: skills/pipeline-review/SKILL.md
-  description: Analyze pipeline health — prioritize deals, flag risks, get a weekly
-    action plan. Use when running a weekly pipeline review, deciding which deals to
-    focus on this week, spotting stale or stuck opportunities, auditing for hygiene
-    issues like bad close dates, or identifying single-threaded deals.
+  description: Process call notes or a transcript — extract action items, draft follow-up email, generate
+    internal summary. Use when pasting rough notes or a transcript after a discovery, demo, or negotiation
+    call, drafting a customer follow-up, logging the activity for your CRM, or capturing objections and
+    next steps for your team.
 - name: competitive-intelligence
   path: skills/competitive-intelligence/SKILL.md
-  description: Research your competitors and build an interactive battlecard. Outputs
-    an HTML artifact with clickable competitor cards and a comparison matrix. Trigger
-    with "competitive intel", "research competitors", "how do we compare to [competitor]",
-    "battlecard for [competitor]", or "what's new with [competitor]".
+  description: Research your competitors and build an interactive battlecard. Outputs an HTML artifact
+    with clickable competitor cards and a comparison matrix. Trigger with "competitive intel", "research
+    competitors", "how do we compare to [competitor]", "battlecard for [competitor]", or "what's new with
+    [competitor]".
 - name: create-an-asset
   path: skills/create-an-asset/SKILL.md
-  description: Generate tailored sales assets (landing pages, decks, one-pagers, workflow
-    demos) from your deal context. Describe your prospect, audience, and goal — get
-    a polished, branded asset ready to share with customers.
+  description: Generate tailored sales assets (landing pages, decks, one-pagers, workflow demos) from
+    your deal context. Describe your prospect, audience, and goal — get a polished, branded asset ready
+    to share with customers.
+- name: daily-briefing
+  path: skills/daily-briefing/SKILL.md
+  description: Start your day with a prioritized sales briefing. Works standalone when you tell me your
+    meetings and priorities, supercharged when you connect your calendar, CRM, and email. Trigger with
+    "morning briefing", "daily brief", "what's on my plate today", "prep my day", or "start my day".
+- name: draft-outreach
+  path: skills/draft-outreach/SKILL.md
+  description: Research a prospect then draft personalized outreach. Uses web research by default, supercharged
+    with enrichment and CRM. Trigger with "draft outreach to [person/company]", "write cold email to [prospect]",
+    "reach out to [name]".
 - name: forecast
   path: skills/forecast/SKILL.md
-  description: Generate a weighted sales forecast with best/likely/worst scenarios,
-    commit vs. upside breakdown, and gap analysis. Use when preparing a quarterly
-    forecast call, assessing gap-to-quota from a pipeline CSV, deciding which deals
-    to commit vs. call upside, or checking pipeline coverage against your number.
+  description: Generate a weighted sales forecast with best/likely/worst scenarios, commit vs. upside
+    breakdown, and gap analysis. Use when preparing a quarterly forecast call, assessing gap-to-quota
+    from a pipeline CSV, deciding which deals to commit vs. call upside, or checking pipeline coverage
+    against your number.
+- name: pipeline-review
+  path: skills/pipeline-review/SKILL.md
+  description: Analyze pipeline health — prioritize deals, flag risks, get a weekly action plan. Use when
+    running a weekly pipeline review, deciding which deals to focus on this week, spotting stale or stuck
+    opportunities, auditing for hygiene issues like bad close dates, or identifying single-threaded deals.
 mcp:
   path: mcp.jsonc
+references:
+- id: connectors
+  path: CONNECTORS.md

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-forgecat/skills/call-summary/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-forgecat/skills/call-summary/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<call notes or transcript>"
 
 # /call-summary
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Process call notes or a transcript to extract action items, draft follow-up communications, and update records.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-forgecat/skills/forecast/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-forgecat/skills/forecast/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<period>"
 
 # /forecast
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Generate a weighted sales forecast with risk analysis and commit recommendations.
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-forgecat/skills/pipeline-review/SKILL.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_sales/for-forgecat/skills/pipeline-review/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<segment or rep>"
 
 # /pipeline-review
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> If you see unfamiliar placeholders or need to check which tools are connected, see CONNECTORS.md (`{{ref:connectors}}`).
 
 Analyze your pipeline health, prioritize deals, and get actionable recommendations for where to focus.
 


### PR DESCRIPTION
## Summary

This updates eleven Anthropic Knowledge Work profiles from the exact candidates verified as private Registry versions. It adds or refreshes Claude Code, Cursor, and Codex native artifacts, installs `CONNECTORS.md` as a functional reference, and aligns every README with the verified compatibility result.

Ten profiles are tested on Claude Code, Cursor, and Codex, with OpenClaw and Hermes partial because ForgeCat does not deliver project MCP to home targets. Product Management is tested on Claude Code and Cursor; Codex, OpenClaw, and Hermes remain partial because the source `brainstorm` command is not delivered there.

## Profiles

| Profile | Version | Tested | Partial |
|---|---:|---|---|
| customer-support | `0.0.11` | Claude Code, Cursor, Codex | OpenClaw, Hermes |
| design | `0.0.10` | Claude Code, Cursor, Codex | OpenClaw, Hermes |
| engineering | `0.0.10` | Claude Code, Cursor, Codex | OpenClaw, Hermes |
| enterprise-search | `0.0.10` | Claude Code, Cursor, Codex | OpenClaw, Hermes |
| finance | `0.0.10` | Claude Code, Cursor, Codex | OpenClaw, Hermes |
| human-resources | `0.0.10` | Claude Code, Cursor, Codex | OpenClaw, Hermes |
| legal | `0.0.10` | Claude Code, Cursor, Codex | OpenClaw, Hermes |
| marketing | `0.0.10` | Claude Code, Cursor, Codex | OpenClaw, Hermes |
| operations | `0.0.10` | Claude Code, Cursor, Codex | OpenClaw, Hermes |
| product-management | `0.0.9` | Claude Code, Cursor | Codex, OpenClaw, Hermes |
| sales | `0.0.10` | Claude Code, Cursor, Codex | OpenClaw, Hermes |

## Source and license

- Source: `https://github.com/anthropics/knowledge-work-plugins`
- Commit: `d2ba7f65cec6502f048286b432dfee2ae59bfdff`
- License: Apache-2.0, preserved from the pinned source in every profile
- Source coverage: missing 0 for all eleven scopes

## Runtime evidence

- All eleven exact private versions passed their reviewed converter release gate.
- Every final audit has zero base failures and zero missing platforms.
- Project MCP checks used exact installed configuration and the unauthenticated OAuth `401 Bearer` boundary. No SaaS account was connected for release testing.
- Every delivered component has direct or byte-identical equivalent evidence.
- All five ForgeCat uninstalls and both temporary home-object deletions passed for every profile.
- The corresponding private History PR records the exact Registry integrity and shipping SHA for each version.

## Checks

- `forgecat validate --strict --json`: 11/11
- `ruby scripts/check-readme-catalog.rb`
- `ruby scripts/check-profile-artifacts.rb --changed-only origin/main...HEAD`
- `ruby scripts/test-license-evidence.rb`
- `bash scripts/test-license-gate.sh`
- `bash scripts/test-license-audit.sh`
- `ruby scripts/check-license-evidence.rb --changed-only origin/main...HEAD`

## Release boundary

The Registry profiles remain private. Merging this PR does not publish them. Failed-canary unpublish and profile-wide public visibility remain separate approval gates after both official PRs merge.

History PR: [forgecat-profile-converter-history #19](https://github.com/nota-america/forgecat-profile-converter-history/pull/19)
