### PR TITLE
fix: sync four public native receipts

### DIFF
--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_pr-review-toolkit/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_pr-review-toolkit/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_pr-review-toolkit/for-claude/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_pr-review-toolkit/README.md
@@ -51,6 +51,8 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_pr-review-tool
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Partial |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ---
 *written by original source*

--- a/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_pr-review-toolkit/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_pr-review-toolkit/README.md
+++ b/profiles/anthropics/claude-plugins-official/anthropics_claude-plugins-official_pr-review-toolkit/for-cursor/.forgecat/profiles/@forgecat/anthropics_claude-plugins-official_pr-review-toolkit/README.md
@@ -49,8 +49,10 @@ npx forgecat install @forgecat/anthropics_claude-plugins-official_pr-review-tool
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
+| Cursor | Tested |
 | Codex | Partial |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ---
 *written by original source*

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_bio-research/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_bio-research/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_bio-research/for-claude/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_bio-research/README.md
@@ -67,6 +67,8 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_bio-research
 | Claude Code | Tested |
 | Cursor | Partial |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_bio-research/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_bio-research/README.md
+++ b/profiles/anthropics/knowledge-work-plugins/anthropics_knowledge-work-plugins_bio-research/for-codex/.forgecat/profiles/@forgecat/anthropics_knowledge-work-plugins_bio-research/README.md
@@ -65,8 +65,10 @@ npx forgecat install @forgecat/anthropics_knowledge-work-plugins_bio-research
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
 | Cursor | Partial |
+| Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-specialized/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-specialized/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-specialized/for-claude/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-specialized/README.md
@@ -62,6 +62,8 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-specialized
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-specialized/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-specialized/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-specialized/for-codex/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-specialized/README.md
@@ -56,11 +56,14 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-specialized
 
 ## Compatibility
 ### Platforms
+
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-specialized/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-specialized/README.md
+++ b/profiles/msitarzewski/agency-agents/msitarzewski_agency-agents_agency-specialized/for-cursor/.forgecat/profiles/@forgecat/msitarzewski_agency-agents_agency-specialized/README.md
@@ -56,11 +56,14 @@ npx forgecat install @forgecat/msitarzewski_agency-agents_agency-specialized
 
 ## Compatibility
 ### Platforms
+
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Codex | Partial |
-| Cursor | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Unsupported |
+| Hermes | Unsupported |
 
 ### Models
 | Model | Role |

--- a/profiles/upstash/context7/for-claude/.forgecat/profiles/@forgecat/upstash_context7/README.md
+++ b/profiles/upstash/context7/for-claude/.forgecat/profiles/@forgecat/upstash_context7/README.md
@@ -45,6 +45,8 @@ npx forgecat install @forgecat/upstash_context7
 | Claude Code | Tested |
 | Cursor | Partial |
 | Codex | Partial |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ### Models
 | Model | Role |


### PR DESCRIPTION
## Summary

Synchronize eight existing native receipt READMEs with the four public claims-only releases.

The public Registry packages, compatibility claims, functional files, and exact installs are correct. This PR changes only the repo-native ForgeCat receipt tables that missed the new OpenClaw and Hermes rows.

## Scope

| Profile | Native receipts corrected |
|---|---:|
| `pr-review-toolkit` | Claude Code, Cursor |
| `bio-research` | Claude Code, Codex |
| `agency-specialized` | Claude Code, Codex, Cursor |
| `upstash_context7` | Claude Code |

```text
8 README files changed
0 for-forgecat files changed
0 functional files changed
0 Registry writes
```

The complete four-profile tree is byte-identical to a fresh replay produced by the paired Converter fix.

## Validation

```text
changed-profile artifact check: pass
changed-profile license check: pass
README catalog check: pass
git diff --check: pass
public Claude install and cleanup: 4/4 pass
deterministic replay equality: 4/4 pass
independent QA: pass / ready
```

## Exact candidate

- Base: `f1ab02b616369243acdabc62a69a1947e74c71f8`
- Head: `bd7c910ee10a4fcb4ddfb80e17847ebb00228055`
- Operator approval: Echo message `a823466f-545f-4217-92ec-4308827e4687`

Paired Converter PR: https://github.com/nota-america/forgecat-profile-converter/pull/6

Paired final History PR: https://github.com/nota-america/forgecat-profile-converter-history/pull/22
