### PR TITLE
Reconcile Ponytail 0.1.8 home claims

### DIFF
--- a/profiles/dietrichgebert/ponytail/README.md
+++ b/profiles/dietrichgebert/ponytail/README.md
@@ -37,7 +37,7 @@ npx forgecat install @forgecat/dietrichgebert_ponytail
 |---|---|
 | Author | Dietrich Gebert |
 | Original repository | https://github.com/DietrichGebert/ponytail |
-| Version | `0.1.7` |
+| Version | `0.1.8` |
 | Original commit | `1c420ad2f306b2a096dd1e7c1b8c5ebbb4cdf3d4` |
 | License | MIT |
 | Source platform | Multi-platform: Claude Code plugin, Codex plugin, Cursor rule, OpenCode plugin, Gemini extension, pi extension, and generic AGENTS.md/skills adapters |
@@ -51,6 +51,8 @@ npx forgecat install @forgecat/dietrichgebert_ponytail
 | Claude Code | Tested |
 | Cursor | Partial |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/dietrichgebert/ponytail/for-claude/.forgecat/profiles/@forgecat/dietrichgebert_ponytail/README.md
+++ b/profiles/dietrichgebert/ponytail/for-claude/.forgecat/profiles/@forgecat/dietrichgebert_ponytail/README.md
@@ -39,7 +39,7 @@ npx forgecat install @forgecat/dietrichgebert_ponytail
 |---|---|
 | Author | Dietrich Gebert |
 | Original repository | https://github.com/DietrichGebert/ponytail |
-| Version | `0.1.6` |
+| Version | `0.1.8` |
 | Original commit | `1c420ad2f306b2a096dd1e7c1b8c5ebbb4cdf3d4` |
 | License | MIT |
 | Source platform | Multi-platform: Claude Code plugin, Codex plugin, Cursor rule, OpenCode plugin, Gemini extension, pi extension, and generic AGENTS.md/skills adapters |
@@ -53,6 +53,8 @@ npx forgecat install @forgecat/dietrichgebert_ponytail
 | Claude Code | Tested |
 | Cursor | Partial |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/dietrichgebert/ponytail/for-codex/.forgecat/profiles/@forgecat/dietrichgebert_ponytail/README.md
+++ b/profiles/dietrichgebert/ponytail/for-codex/.forgecat/profiles/@forgecat/dietrichgebert_ponytail/README.md
@@ -39,7 +39,7 @@ npx forgecat install @forgecat/dietrichgebert_ponytail
 |---|---|
 | Author | Dietrich Gebert |
 | Original repository | https://github.com/DietrichGebert/ponytail |
-| Version | `0.1.6` |
+| Version | `0.1.8` |
 | Original commit | `1c420ad2f306b2a096dd1e7c1b8c5ebbb4cdf3d4` |
 | License | MIT |
 | Source platform | Multi-platform: Claude Code plugin, Codex plugin, Cursor rule, OpenCode plugin, Gemini extension, pi extension, and generic AGENTS.md/skills adapters |
@@ -53,6 +53,8 @@ npx forgecat install @forgecat/dietrichgebert_ponytail
 | Claude Code | Tested |
 | Cursor | Partial |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/dietrichgebert/ponytail/for-cursor/.forgecat/profiles/@forgecat/dietrichgebert_ponytail/README.md
+++ b/profiles/dietrichgebert/ponytail/for-cursor/.forgecat/profiles/@forgecat/dietrichgebert_ponytail/README.md
@@ -39,7 +39,7 @@ npx forgecat install @forgecat/dietrichgebert_ponytail
 |---|---|
 | Author | Dietrich Gebert |
 | Original repository | https://github.com/DietrichGebert/ponytail |
-| Version | `0.1.6` |
+| Version | `0.1.8` |
 | Original commit | `1c420ad2f306b2a096dd1e7c1b8c5ebbb4cdf3d4` |
 | License | MIT |
 | Source platform | Multi-platform: Claude Code plugin, Codex plugin, Cursor rule, OpenCode plugin, Gemini extension, pi extension, and generic AGENTS.md/skills adapters |
@@ -53,6 +53,8 @@ npx forgecat install @forgecat/dietrichgebert_ponytail
 | Claude Code | Tested |
 | Cursor | Partial |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/dietrichgebert/ponytail/for-forgecat/README.md
+++ b/profiles/dietrichgebert/ponytail/for-forgecat/README.md
@@ -39,7 +39,7 @@ npx forgecat install @forgecat/dietrichgebert_ponytail
 |---|---|
 | Author | Dietrich Gebert |
 | Original repository | https://github.com/DietrichGebert/ponytail |
-| Version | `0.1.6` |
+| Version | `0.1.8` |
 | Original commit | `1c420ad2f306b2a096dd1e7c1b8c5ebbb4cdf3d4` |
 | License | MIT |
 | Source platform | Multi-platform: Claude Code plugin, Codex plugin, Cursor rule, OpenCode plugin, Gemini extension, pi extension, and generic AGENTS.md/skills adapters |
@@ -53,6 +53,8 @@ npx forgecat install @forgecat/dietrichgebert_ponytail
 | Claude Code | Tested |
 | Cursor | Partial |
 | Codex | Tested |
+| OpenClaw | Partial |
+| Hermes | Partial |
 
 ## Dependencies
 

--- a/profiles/dietrichgebert/ponytail/for-forgecat/profile.yml
+++ b/profiles/dietrichgebert/ponytail/for-forgecat/profile.yml
@@ -11,6 +11,8 @@ compatibility:
       - codex
     partial:
       - cursor
+      - openclaw
+      - hermes
   models:
     recommended: []
     minimum: []


### PR DESCRIPTION
## Summary

- Reconcile the public `@forgecat/dietrichgebert_ponytail@0.1.8` release with the profile repository.
- Add the reviewed OpenClaw and Hermes `Partial` claims.
- Synchronize ForgeCat-authored README version and compatibility receipts.
- Keep all functional files, manifest behavior, generated source prose, file modes, and the install plan unchanged.

## Verification

- Public Registry integrity: `sha256-63e823a8bb5290720c58f0d8a30f1d4b1f23caeb7db6e8c7c3779cf588eb24e5`
- Shipping SHA-256: `04a3383e4a7f6bd962a7a4e6547771246d7a3ae1a49b84ec3fde41633830d557`
- Functional equivalence: 21 files byte-identical with matching modes and install plan
- Strict validation: 0 errors and 2 reviewed hook-platform warnings
- Exact Codex install: 12 clean managed files; hooks remained untrusted and unexecuted
- Profile-managed cleanup: all profile-owned files, hook entries, wrappers, and the lock entry removed
- Independent conversion QA: `pass / ready`, findings 0

## Scope

No Tested claim is added, no profile component was executed, and no Registry mutation is part of this PR.

History counterpart: https://github.com/nota-america/forgecat-profile-converter-history/pull/25