### PR TITLE
feat: verify Anthropic Brand Guidelines on five platforms

### DIFF
--- a/profiles/anthropics/skills/anthropics_skills_brand-guidelines/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_brand-guidelines/README.md
@@ -1,4 +1,6 @@
-![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+*written by ForgeCat*
+
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Anthropic Skills — Brand Guidelines
 
@@ -18,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_brand-guidelines
 
 ## Skills
 
-- **brand-guidelines** — Applies Anthropic's official brand colors and typography to any sort of artifact that may benefit from having Anthropic's look-and-feel. Use it when brand colors or style guidelines, visual formatting, or company design standards apply. `skill`
+- **brand-guidelines** — Applies Anthropic's official brand colors and typography to any sort of artifact that may benefit from having Anthropic's look-and-feel. Use it when brand colors or style guidelines, visual formatting, or company design standards apply.
 
 ## Details
 
@@ -26,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_brand-guidelines
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.4` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -40,7 +42,9 @@ npx forgecat install @forgecat/anthropics_skills_brand-guidelines
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_brand-guidelines/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_brand-guidelines/README.md
@@ -20,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_brand-guidelines
 
 ## Skills
 
-- **brand-guidelines** — Applies Anthropic's official brand colors and typography to any sort of artifact that may benefit from having Anthropic's look-and-feel. Use it when brand colors or style guidelines, visual formatting, or company design standards apply. `skill`
+- **brand-guidelines** — Applies Anthropic's official brand colors and typography to any sort of artifact that may benefit from having Anthropic's look-and-feel. Use it when brand colors or style guidelines, visual formatting, or company design standards apply.
 
 ## Details
 
@@ -28,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_brand-guidelines
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.0` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -40,9 +40,11 @@ npx forgecat install @forgecat/anthropics_skills_brand-guidelines
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
-| Codex | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_brand-guidelines/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_brand-guidelines/README.md
@@ -20,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_brand-guidelines
 
 ## Skills
 
-- **brand-guidelines** — Applies Anthropic's official brand colors and typography to any sort of artifact that may benefit from having Anthropic's look-and-feel. Use it when brand colors or style guidelines, visual formatting, or company design standards apply. `skill`
+- **brand-guidelines** — Applies Anthropic's official brand colors and typography to any sort of artifact that may benefit from having Anthropic's look-and-feel. Use it when brand colors or style guidelines, visual formatting, or company design standards apply.
 
 ## Details
 
@@ -28,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_brand-guidelines
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.0` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -40,9 +40,11 @@ npx forgecat install @forgecat/anthropics_skills_brand-guidelines
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
-| Codex | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_brand-guidelines/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_brand-guidelines/README.md
@@ -20,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_brand-guidelines
 
 ## Skills
 
-- **brand-guidelines** — Applies Anthropic's official brand colors and typography to any sort of artifact that may benefit from having Anthropic's look-and-feel. Use it when brand colors or style guidelines, visual formatting, or company design standards apply. `skill`
+- **brand-guidelines** — Applies Anthropic's official brand colors and typography to any sort of artifact that may benefit from having Anthropic's look-and-feel. Use it when brand colors or style guidelines, visual formatting, or company design standards apply.
 
 ## Details
 
@@ -28,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_brand-guidelines
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.0` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -40,9 +40,11 @@ npx forgecat install @forgecat/anthropics_skills_brand-guidelines
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
-| Codex | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-forgecat/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-forgecat/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Anthropic Skills — Brand Guidelines
 
@@ -20,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_brand-guidelines
 
 ## Skills
 
-- **brand-guidelines** — Applies Anthropic's official brand colors and typography to any sort of artifact that may benefit from having Anthropic's look-and-feel. Use it when brand colors or style guidelines, visual formatting, or company design standards apply. `skill`
+- **brand-guidelines** — Applies Anthropic's official brand colors and typography to any sort of artifact that may benefit from having Anthropic's look-and-feel. Use it when brand colors or style guidelines, visual formatting, or company design standards apply.
 
 ## Details
 
@@ -28,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_brand-guidelines
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.4` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -42,7 +42,9 @@ npx forgecat install @forgecat/anthropics_skills_brand-guidelines
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-forgecat/profile.yml
+++ b/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-forgecat/profile.yml
@@ -1,26 +1,26 @@
-name: "@forgecat/anthropics_skills_brand-guidelines"
-version: 0.0.4
-description: Applies Anthropic's official brand colors and typography to any sort
-  of artifact that may benefit from having Anthropic's look-and-feel. Use it when
-  brand colors or style guidelines, visual formatting, or company design standards
-  apply.
+name: '@forgecat/anthropics_skills_brand-guidelines'
+description: Applies Anthropic's official brand colors and typography to any sort of artifact that may
+  benefit from having Anthropic's look-and-feel. Use it when brand colors or style guidelines, visual
+  formatting, or company design standards apply.
+visibility: public
 repository: https://github.com/anthropics/skills
 license: Apache-2.0
-visibility: public
 sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:
-      - claude-code
-      - cursor
-      - codex
+    - claude-code
+    - cursor
+    - codex
+    - openclaw
+    - hermes
+    partial: []
   models:
     recommended: []
     minimum: []
 skills:
 - name: brand-guidelines
   path: skills/brand-guidelines/SKILL.md
-  description: Applies Anthropic's official brand colors and typography to any sort
-    of artifact that may benefit from having Anthropic's look-and-feel. Use it when
-    brand colors or style guidelines, visual formatting, or company design standards
-    apply.
+  description: Applies Anthropic's official brand colors and typography to any sort of artifact that may
+    benefit from having Anthropic's look-and-feel. Use it when brand colors or style guidelines, visual
+    formatting, or company design standards apply.


### PR DESCRIPTION
## Converter Agent Checklist

> Post-merge correction: the generated banner alt text says `Forgecat`; the product name must be `ForgeCat`. Public `0.0.5` remains functionally verified, but it needs a corrective release after the converter casing fix.

### At a glance

| Field | Value |
|---|---|
| Profile | `@forgecat/anthropics_skills_brand-guidelines` |
| Source repo | `https://github.com/anthropics/skills` @ `5128e1865d670f5d6c9cef000e6dfc4e951fb5b9` (`skills/brand-guidelines`) |
| Profile PR | Merged as `357d574c61c5645d1297844748db5eb9107bc584`: https://github.com/nota-america/forgecat-agent-profiles/pull/199 |
| History PR | Merged as `0505734cf18f1c058e8b27e416d727db9069a2a9`: https://github.com/nota-america/forgecat-profile-converter-history/pull/32 |
| Registry version | Public `0.0.5`; integrity `sha256-56acfdca4de3d73dfa8a46c5959185ef3ca68a2e0af70f88f74c662cc34cca2e` |
| Overall status | Partial |
| Main caveat | The generated banner alt text has incorrect product casing. The history PR also preserves upstream whitespace byte-for-byte. |
| Operator next action | Publish a corrective version after the converter casing fix is merged. |

### Review checklist

| Area | Human review question | Status | Evidence | Risk / next action | Notes / special cases |
|---|---|---|---|---|---|
| PR scope | Does the PR contain only profile artifacts, the required root README catalog update, and any explicitly justified validation compatibility fix, with no source snapshots, history docs, scratch reports, or generated CSVs? | Pass | Profile PR #199 merged 6 metadata/receipt files. History PR #32 merged 396 archival files: 6 Brand Guidelines records plus a 390-file shared Anthropic source snapshot. | Complete. | The source snapshot is history-only and will be reused by the remaining Anthropic profiles. |
| Profile identity | Do `profile.yml` name, profile folder, source owner, collection, source URL, and source commit line up? | Pass | `profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-forgecat/profile.yml`; source `anthropics/skills`, scope `skills/brand-guidelines`, commit `5128e1865d670f5d6c9cef000e6dfc4e951fb5b9`. | None. | Registry name remains unchanged. |
| Source inventory | Were all source runtime surfaces inventoried: skills, agents, commands, hooks, MCP, rules/instructions, docs, runtime helpers, assets/templates, and platform-native files? | Pass | Scoped inventory contains `SKILL.md` and `LICENSE.txt`; coverage is relocated 2, excluded 0, missing 0. | None. | No agents, commands, hooks, MCP, rules, helpers, assets, or native source files in this scope. |
| Converted components | Are required source surfaces present in the forgecat profile, or explicitly classified as intentional exclusion / unsupported limitation? | Pass | One skill plus its scoped Apache-2.0 license are present in `for-forgecat/skills/brand-guidelines/`. | None. | No exclusions. |
| Internal file edits | Were any file contents changed beyond relocation, such as hook/script path rewrites, wrapper changes, config rewrites, or internal file-reference updates caused by forgecat install paths? | Pass | Functional `SKILL.md` and `LICENSE.txt` bytes match source and the prior Registry payload. Only generated manifest and README receipts changed. | Review metadata only. | No runtime file edits or path rewrites. |
| Behavior parity risk | Is there any known chance that the converted profile behaves differently from the original repo because of runtime support gaps, path rewrites, platform conversion, missing host features, or intentional exclusions? | Pass | The same installed skill answered the component-specific brand-spec probe on all five platforms. | None. | No unsupported surface. |
| Manifest/schema | Does `for-forgecat/profile.yml` pass current forgecat schema rules, including visibility, compatibility, models.minimum, no comments, and no source-derived version for new profiles? | Pass | Converter validation and `forgecat validate --strict` passed. License is `Apache-2.0`, source platform is `claude-code`, and all five verified platforms are Tested. | None. | This is an existing profile; version receipt is `0.0.5`. |
| README/docs | Do root and `for-forgecat/README.md` follow the current README rules and preserve source docs or path rewrites needed by installed skills? | Blocked | All five merged README receipts say `Forgecat` in the banner alt text. | Regenerate them with the corrected converter. | Functional source docs are unchanged. |
| QA findings | Did an independent QA pass run, and are all blocker / fix-before-merge findings fixed or explicitly classified? | Partial | Independent conversion QA returned ready/pass before the casing defect was reported. The converter had no product-casing assertion. | Rerun QA for the corrective version. | Converter commit `310e0bcebad0e0384f5ab5ba50805f23eb1f0cfe` adds the missing assertion locally. |
| Validation gates | Did post-conversion validation and forgecat validate/plan/scan pass, and did Admin-Local bind the private-canary preview to the frozen candidate? | Partial | The original gates passed at shipping SHA `6438007d6bb5c834e6eb7d15efc49c8b2b631b14b6c4684505c7a4ea6869d0a3`. They did not check product-name casing. | Run the corrected converter and a fresh canary for the replacement version. | Functional canary evidence remains valid for `0.0.5`. |
| Registry/version | Is the exact private-canary version and integrity bound to the frozen candidate, while public visibility remains pending until both PRs merge? | Partial | Public `0.0.5`; integrity `sha256-56acfdca4de3d73dfa8a46c5959185ef3ca68a2e0af70f88f74c662cc34cca2e`; 4 shipping files; shipping SHA `6438007d6bb5c834e6eb7d15efc49c8b2b631b14b6c4684505c7a4ea6869d0a3`. | Replace with a corrected version. | Security evaluation: Source, Agent Intent, Permissions, and MCP all Low. |
| Platform install/runtime | Are install and component-aware runtime results recorded separately for all five ForgeCat platforms, with unsupported home-target surfaces explicit and every unverified platform kept out of `tested`? | Pass | `claude-code`: exact install + direct `/brand-guidelines` probe + cleanup; `cursor`: exact install + direct skill probe + cleanup; `codex`: exact install + direct skill probe + cleanup; `openclaw`: exact install + direct skill probe + native cleanup; `hermes`: exact install + direct skill probe + native cleanup. | None. | Each platform used an isolated target. The prompt requested exact typography, color, fallback-font, and heading-threshold values from the installed skill. |
| Native artifacts | Do `for-claude/`, `for-codex/`, `for-cursor/`, or other native artifacts exist only when intentionally generated and component-runtime-tested? | Pass | Three native README receipts were generated from exact `0.0.5` installations; no functional native artifact is committed. | None. | OpenClaw and Hermes temporary native objects were removed through their confirmation flows. |
| License/security | Are upstream license/notices preserved, and does the forgecat CLI's built-in secret/content scan (`forgecat validate` / publish gate) pass for the shipping file set? | Pass | Scoped `LICENSE.txt` is byte-exact to upstream Apache-2.0; strict validation and security scan passed with no findings. | None. | Manifest license spelling is normalized from the legacy Registry label. |
| Archive/history | Does the history PR contain the exact same source pin, candidate hash, private version/integrity, runtime evidence, and caveats as the profile PR? | Pass | Merged History main records source commit `5128e1865d670f5d6c9cef000e6dfc4e951fb5b9`, private `0.0.5`, integrity, shipping SHA, five-platform evidence, and cleanup. | Complete. | The 390-file source snapshot preserves upstream trailing whitespace exactly; it is not reformatted. |
| Operator decision | Based on the rows above, should the operator merge both PRs, request fixes, or approve the later public-registry gate? | Partial | Profile merge `357d574c61c5645d1297844748db5eb9107bc584`; History merge `0505734cf18f1c058e8b27e416d727db9069a2a9`; Registry is public exact `0.0.5`; non-owner exact Codex install and cleanup passed. | Keep `0.0.5` public until a corrected version completes the full release sequence. | Do not unpublish the currently usable public version first. |
