### PR TITLE
feat: verify Anthropic Frontend Design on five platforms

### DIFF
--- a/profiles/anthropics/skills/anthropics_skills_frontend-design/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_frontend-design/README.md
@@ -1,4 +1,6 @@
-![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+*written by ForgeCat*
+
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Anthropic Skills — Frontend Design
 
@@ -18,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 
 ## Skills
 
-- **frontend-design** — Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics. `skill`
+- **frontend-design** — Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
 
 ## Details
 
@@ -26,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.4` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -40,7 +42,9 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_frontend-design/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_frontend-design/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_frontend-design/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_frontend-design/README.md
@@ -20,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 
 ## Skills
 
-- **frontend-design** — Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics. `skill`
+- **frontend-design** — Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
 
 ## Details
 
@@ -28,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.0` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -40,9 +40,11 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
-| Codex | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_frontend-design/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_frontend-design/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_frontend-design/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_frontend-design/README.md
@@ -20,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 
 ## Skills
 
-- **frontend-design** — Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics. `skill`
+- **frontend-design** — Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
 
 ## Details
 
@@ -28,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.0` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -40,9 +40,11 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
-| Codex | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_frontend-design/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_frontend-design/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_frontend-design/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_frontend-design/README.md
@@ -20,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 
 ## Skills
 
-- **frontend-design** — Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics. `skill`
+- **frontend-design** — Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
 
 ## Details
 
@@ -28,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.0` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -40,9 +40,11 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
-| Codex | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_frontend-design/for-forgecat/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_frontend-design/for-forgecat/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Anthropic Skills — Frontend Design
 
@@ -20,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 
 ## Skills
 
-- **frontend-design** — Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics. `skill`
+- **frontend-design** — Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
 
 ## Details
 
@@ -28,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.4` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -42,7 +42,9 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_frontend-design/for-forgecat/profile.yml
+++ b/profiles/anthropics/skills/anthropics_skills_frontend-design/for-forgecat/profile.yml
@@ -1,29 +1,30 @@
-name: "@forgecat/anthropics_skills_frontend-design"
-version: 0.0.4
-description: Create distinctive, production-grade frontend interfaces with high design
-  quality. Use this skill when the user asks to build web components, pages, artifacts,
-  posters, or applications (examples include websites, landing pages, dashboards,
-  React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates
-  creative, polished code and UI design that avoids generic AI aesthetics.
+name: '@forgecat/anthropics_skills_frontend-design'
+description: Create distinctive, production-grade frontend interfaces with high design quality. Use
+  this skill when the user asks to build web components, pages, artifacts, posters, or applications
+  (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when
+  styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic
+  AI aesthetics.
+visibility: public
 repository: https://github.com/anthropics/skills
 license: Apache-2.0
-visibility: public
 sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:
-      - claude-code
-      - cursor
-      - codex
+    - claude-code
+    - cursor
+    - codex
+    - openclaw
+    - hermes
+    partial: []
   models:
     recommended: []
     minimum: []
 skills:
 - name: frontend-design
   path: skills/frontend-design/SKILL.md
-  description: Create distinctive, production-grade frontend interfaces with high
-    design quality. Use this skill when the user asks to build web components, pages,
-    artifacts, posters, or applications (examples include websites, landing pages,
-    dashboards, React components, HTML/CSS layouts, or when styling/beautifying any
-    web UI). Generates creative, polished code and UI design that avoids generic AI
-    aesthetics.
+  description: Create distinctive, production-grade frontend interfaces with high design quality. Use
+    this skill when the user asks to build web components, pages, artifacts, posters, or applications
+    (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when
+    styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic
+    AI aesthetics.


### PR DESCRIPTION
## Converter Agent Checklist

### At a glance

| Field | Value |
|---|---|
| Profile | `@forgecat/anthropics_skills_frontend-design` |
| Source repo | `https://github.com/anthropics/skills` at `5128e1865d670f5d6c9cef000e6dfc4e951fb5b9` (`skills/frontend-design`) |
| Profile PR | Closed: https://github.com/nota-america/forgecat-agent-profiles/pull/200 |
| History PR | Closed: https://github.com/nota-america/forgecat-profile-converter-history/pull/33 |
| Registry version | Private `0.0.5`, preserved as failed evidence; integrity `sha256-2e25449259612124f6af6cb11ead6ca33b8022e35da186bb8b97a1405a33badb` |
| Overall status | Blocked |
| Main caveat | Generated README banner alt text uses `Forgecat`; the product name must be `ForgeCat`. |
| Operator next action | Keep both PRs closed, merge the converter casing fix, and build a fresh `0.0.6` candidate. |

### Review checklist

| Area | Human review question | Status | Evidence | Risk / next action | Notes / special cases |
|---|---|---|---|---|---|
| PR scope | Does the PR contain only profile artifacts, the required root README catalog update, and any explicitly justified validation compatibility fix, with no source snapshots, history docs, scratch reports, or generated CSVs? | Blocked | Profile PR #200 and History PR #33 were closed after the generated casing defect was found. | Replace both PRs after a new private canary. | The History PR reuses the Anthropic source snapshot already merged by Brand Guidelines. |
| Profile identity | Do `profile.yml` name, profile folder, source owner, collection, source URL, and source commit line up? | Pass | `profiles/anthropics/skills/anthropics_skills_frontend-design/for-forgecat/profile.yml`; source `anthropics/skills`, scope `skills/frontend-design`, commit `5128e1865d670f5d6c9cef000e6dfc4e951fb5b9`. | None. | Registry name is unchanged. |
| Source inventory | Were all source runtime surfaces inventoried: skills, agents, commands, hooks, MCP, rules/instructions, docs, runtime helpers, assets/templates, and platform-native files? | Pass | Scoped inventory contains `SKILL.md` and `LICENSE.txt`; coverage is relocated 2, excluded 0, missing 0. | None. | This scope has no agents, commands, hooks, MCP, rules, helpers, assets, or native source files. |
| Converted components | Are required source surfaces present in the forgecat profile, or explicitly classified as intentional exclusion / unsupported limitation? | Pass | One skill and its scoped Apache-2.0 license are present in `for-forgecat/skills/frontend-design/`. | None. | No exclusions. |
| Internal file edits | Were any file contents changed beyond relocation, such as hook/script path rewrites, wrapper changes, config rewrites, or internal file-reference updates caused by forgecat install paths? | Pass | Functional `SKILL.md` and `LICENSE.txt` bytes match the source and prior Registry payload. Only generated manifest and README receipts changed. | Review metadata only. | No runtime file edits or path rewrites. |
| Behavior parity risk | Is there any known chance that the converted profile behaves differently from the original repo because of runtime support gaps, path rewrites, platform conversion, missing host features, or intentional exclusions? | Pass | The installed skill returned its specific tone, font, palette, motion, composition, texture, and complexity guidance on all five platforms. | None. | No unsupported surface. |
| Manifest/schema | Does `for-forgecat/profile.yml` pass current forgecat schema rules, including visibility, compatibility, models.minimum, no comments, and no source-derived version for new profiles? | Pass | Converter validation and `forgecat validate --strict` passed. License is `Apache-2.0`, source platform is `claude-code`, and all five verified platforms are Tested. | None. | The deprecated manifest version key was removed; README receipts carry `0.0.5`. |
| README/docs | Do root and `for-forgecat/README.md` follow the current README rules and preserve source docs or path rewrites needed by installed skills? | Blocked | The generated banner alt text says `Forgecat` instead of `ForgeCat`. | Regenerate every receipt with the corrected converter. | Functional source docs are unchanged. |
| QA findings | Did an independent QA pass run, and are all blocker / fix-before-merge findings fixed or explicitly classified? | Blocked | Independent conversion QA passed before the product-casing defect was reported. The converter had no casing regression check. | Rerun QA on the corrected candidate. | Converter commit `310e0bcebad0e0384f5ab5ba50805f23eb1f0cfe` adds the missing assertion locally. |
| Validation gates | Did post-conversion validation and forgecat validate/plan/scan pass, and did Admin-Local bind the private-canary preview to the frozen candidate? | Blocked | Existing mechanical gates passed at shipping SHA `4fd9a28efaa71b404da7e611745a0156805d39f90c64fb4abb6403e34352868a`, but none checked product-name casing. | Run the corrected converter and a fresh `0.0.6` canary. | Private `0.0.5` remains immutable failure evidence. |
| Registry/version | Is the exact private-canary version and integrity bound to the frozen candidate, while public visibility remains pending until both PRs merge? | Blocked | Private `0.0.5`; integrity `sha256-2e25449259612124f6af6cb11ead6ca33b8022e35da186bb8b97a1405a33badb`; 4 shipping files; shipping SHA `4fd9a28efaa71b404da7e611745a0156805d39f90c64fb4abb6403e34352868a`. | Keep private as failed evidence and replace it with a fresh version. | Source, Agent Intent, Permissions, and MCP security ratings are Low. |
| Platform install/runtime | Are install and component-aware runtime results recorded separately for all five ForgeCat platforms, with unsupported home-target surfaces explicit and every unverified platform kept out of `tested`? | Pass | `claude-code`: exact install, direct skill probe, cleanup; `cursor`: workspace trust, exact install, direct skill probe, cleanup; `codex`: exact install, direct skill probe, cleanup; `openclaw`: exact interactive install, direct local skill probe, ForgeCat and native cleanup; `hermes`: exact interactive install, direct skill probe, ForgeCat and native cleanup. | None. | Each platform used an isolated target. The prompt requested the installed skill's named industrial/utilitarian direction and its specific frontend-design rules. |
| Native artifacts | Do `for-claude/`, `for-codex/`, `for-cursor/`, or other native artifacts exist only when intentionally generated and component-runtime-tested? | Pass | Claude Code, Cursor, and Codex native artifacts match their exact private install receipts. | None. | OpenClaw and Hermes temporary native objects were removed through their confirmation flows. |
| License/security | Are upstream license/notices preserved, and does the forgecat CLI's built-in secret/content scan (`forgecat validate` / publish gate) pass for the shipping file set? | Pass | Scoped `LICENSE.txt` is byte-exact to upstream Apache-2.0; strict validation and scan passed without findings. | None. | The manifest replaces the legacy Registry label with the source-backed SPDX identifier. |
| Archive/history | Does the history PR contain the exact same source pin, candidate hash, private version/integrity, runtime evidence, and caveats as the profile PR? | Blocked | Closed History commit `8a28a47cc2e67bd7ca8b796fc762b1053cfae394` records the source pin and private canary, but classifies `0.0.5` as successful. | Replace it with a history record that preserves `0.0.5` as failed and records the corrected version separately. | No new source snapshot is needed. |
| Operator decision | Based on the rows above, should the operator merge both PRs, request fixes, or approve the later public-registry gate? | Blocked | Profile PR #200 and History PR #33 are closed. Private `0.0.5` remains unpublished to users. | Merge the converter fix first, then create a fresh candidate and private canary. | Public visibility was not changed. |
