### PR TITLE
fix: correct ForgeCat casing in Anthropic profiles

### DIFF
--- a/profiles/anthropics/skills/anthropics_skills_brand-guidelines/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_brand-guidelines/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Anthropic Skills — Brand Guidelines
 
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_skills_brand-guidelines
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.5` |
+| Version | `0.0.7` |
 | Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
 | License | Apache-2.0 |
 | Source platform | claude-code |

--- a/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_brand-guidelines/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_brand-guidelines/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Anthropic Skills — Brand Guidelines
 
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_skills_brand-guidelines
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.5` |
+| Version | `0.0.7` |
 | Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
 | License | Apache-2.0 |
 | Source platform | claude-code |

--- a/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_brand-guidelines/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_brand-guidelines/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Anthropic Skills — Brand Guidelines
 
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_skills_brand-guidelines
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.5` |
+| Version | `0.0.7` |
 | Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
 | License | Apache-2.0 |
 | Source platform | claude-code |

--- a/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_brand-guidelines/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_brand-guidelines/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Anthropic Skills — Brand Guidelines
 
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_skills_brand-guidelines
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.5` |
+| Version | `0.0.7` |
 | Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
 | License | Apache-2.0 |
 | Source platform | claude-code |

--- a/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-forgecat/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_brand-guidelines/for-forgecat/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Anthropic Skills — Brand Guidelines
 
@@ -28,7 +28,7 @@ npx forgecat install @forgecat/anthropics_skills_brand-guidelines
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.5` |
+| Version | `0.0.7` |
 | Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
 | License | Apache-2.0 |
 | Source platform | claude-code |

--- a/profiles/anthropics/skills/anthropics_skills_frontend-design/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_frontend-design/README.md
@@ -1,3 +1,5 @@
+*written by ForgeCat*
+
 ![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Anthropic Skills — Frontend Design
@@ -18,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 
 ## Skills
 
-- **frontend-design** — Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics. `skill`
+- **frontend-design** — Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
 
 ## Details
 
@@ -26,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.4` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.6` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -40,7 +42,9 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_frontend-design/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_frontend-design/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_frontend-design/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_frontend-design/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Anthropic Skills — Frontend Design
 
@@ -20,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 
 ## Skills
 
-- **frontend-design** — Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics. `skill`
+- **frontend-design** — Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
 
 ## Details
 
@@ -28,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.0` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.6` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -40,9 +40,11 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
-| Codex | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_frontend-design/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_frontend-design/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_frontend-design/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_frontend-design/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Anthropic Skills — Frontend Design
 
@@ -20,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 
 ## Skills
 
-- **frontend-design** — Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics. `skill`
+- **frontend-design** — Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
 
 ## Details
 
@@ -28,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.0` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.6` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -40,9 +40,11 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
-| Codex | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_frontend-design/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_frontend-design/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_frontend-design/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_frontend-design/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Anthropic Skills — Frontend Design
 
@@ -20,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 
 ## Skills
 
-- **frontend-design** — Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics. `skill`
+- **frontend-design** — Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
 
 ## Details
 
@@ -28,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.0` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.6` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -40,9 +40,11 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
-| Codex | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_frontend-design/for-forgecat/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_frontend-design/for-forgecat/README.md
@@ -20,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 
 ## Skills
 
-- **frontend-design** — Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics. `skill`
+- **frontend-design** — Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
 
 ## Details
 
@@ -28,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.4` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.6` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -42,7 +42,9 @@ npx forgecat install @forgecat/anthropics_skills_frontend-design
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_frontend-design/for-forgecat/profile.yml
+++ b/profiles/anthropics/skills/anthropics_skills_frontend-design/for-forgecat/profile.yml
@@ -1,29 +1,30 @@
-name: "@forgecat/anthropics_skills_frontend-design"
-version: 0.0.4
-description: Create distinctive, production-grade frontend interfaces with high design
-  quality. Use this skill when the user asks to build web components, pages, artifacts,
-  posters, or applications (examples include websites, landing pages, dashboards,
-  React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates
-  creative, polished code and UI design that avoids generic AI aesthetics.
+name: '@forgecat/anthropics_skills_frontend-design'
+description: Create distinctive, production-grade frontend interfaces with high design quality. Use
+  this skill when the user asks to build web components, pages, artifacts, posters, or applications
+  (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when
+  styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic
+  AI aesthetics.
+visibility: public
 repository: https://github.com/anthropics/skills
 license: Apache-2.0
-visibility: public
 sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:
-      - claude-code
-      - cursor
-      - codex
+    - claude-code
+    - cursor
+    - codex
+    - openclaw
+    - hermes
+    partial: []
   models:
     recommended: []
     minimum: []
 skills:
 - name: frontend-design
   path: skills/frontend-design/SKILL.md
-  description: Create distinctive, production-grade frontend interfaces with high
-    design quality. Use this skill when the user asks to build web components, pages,
-    artifacts, posters, or applications (examples include websites, landing pages,
-    dashboards, React components, HTML/CSS layouts, or when styling/beautifying any
-    web UI). Generates creative, polished code and UI design that avoids generic AI
-    aesthetics.
+  description: Create distinctive, production-grade frontend interfaces with high design quality. Use
+    this skill when the user asks to build web components, pages, artifacts, posters, or applications
+    (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when
+    styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic
+    AI aesthetics.


### PR DESCRIPTION
## Converter Agent Checklist

### At a glance

| Field | Value |
|---|---|
| Profiles | `@forgecat/anthropics_skills_brand-guidelines@0.0.7`, `@forgecat/anthropics_skills_frontend-design@0.0.6` |
| Source | `https://github.com/anthropics/skills` at `5128e1865d670f5d6c9cef000e6dfc4e951fb5b9` |
| Converter | PR #8 merged as `4c14734e2bce4955c3e242de0ea634c687ac5301` |
| Profile PR | Merged as `fedaf370d569a8af30347981653e4e99350f2b5d`: https://github.com/nota-america/forgecat-agent-profiles/pull/201 |
| History PR | Merged as `7d65e09161e8a9324279bf6ad3e635395b7e02dc`: https://github.com/nota-america/forgecat-profile-converter-history/pull/34 |
| Change | Correct `Forgecat` to `ForgeCat`, update version receipts, and finish Frontend Design metadata and five-platform claims |
| Functional files | `SKILL.md` and `LICENSE.txt` are unchanged |
| Registry | Brand Guidelines `0.0.7` and Frontend Design `0.0.6` are public |
| Overall status | Complete |
| Public release | Non-owner exact Codex install, byte comparison, and cleanup passed for both profiles |

### Review checklist

| Area | Status | Evidence |
|---|---|---|
| PR scope | Pass | This PR changes 11 files in two profile directories. It contains generated metadata and README receipts only. |
| Profile identity | Pass | Both names, folders, source scopes, repository URL, and source commit agree. |
| Source inventory | Pass | Each scope contains one skill and its scoped Apache-2.0 license. Coverage is relocated 2, excluded 0, missing 0. |
| Functional parity | Pass | Source, Registry, and candidate `SKILL.md` and `LICENSE.txt` bytes match. |
| Manifest/schema | Pass | Converter validation and `forgecat validate --strict` pass. Both manifests list all five verified platforms as Tested. |
| README/docs | Pass | Ten generated banners use `ForgeCat`; `Forgecat` occurs zero times. Version receipts are `0.0.7` and `0.0.6`. |
| QA | Pass | Both corrected handoffs passed independent conversion QA before release. |
| Validation | Pass | One-row plans, empty scans, exact Registry clone comparisons, and final release gates pass for both profiles. |
| Brand Registry | Pass | Private `0.0.7`; integrity `sha256-6a9e315ad71d8d6cd4b9f8efba3503e2bbd6b55db8ceb086e699110895ac4620`; shipping SHA `9c72c41c84eb998ed30f60c7870f450a4846b9f8012e1c64d63f447fca35a9d3`. |
| Frontend Registry | Pass | Private `0.0.6`; integrity `sha256-dab7e4eefe2cecb9c50eb5056012190c043da2e77e028f43cf372eef2ce2298c`; shipping SHA `04e14641f5e4643e215aa064e4dc6784868b6a1cfc45c5a3cc2dd26eb93f7402`. |
| Runtime | Pass | Claude Code, Cursor, Codex, OpenClaw, and Hermes passed exact install, direct skill invocation, and cleanup for both profiles. |
| Native artifacts | Pass | Claude Code, Cursor, and Codex artifacts match their exact install receipts. Temporary OpenClaw agents and Hermes profiles were deleted. |
| License/security | Pass | Scoped Apache-2.0 texts are byte-exact to upstream. Strict validation and scan report no findings. Registry rates all four security areas Low. |
| Failed attempts | Recorded | Brand `0.0.6` returned the wrong light background on OpenClaw. The first Brand `0.0.7` OpenClaw call hit model capacity, then an explicitly approved fresh retry passed with `#FAF9F5`. Frontend `0.0.5` was rejected because its generated receipts used the wrong product casing. |
| History | Pass | History PR #34 merged unchanged. It reuses the existing pinned Anthropic source snapshot and records the final versions, hashes, successful canaries, failed attempts, and cleanup. |
| Operator decision | Complete | Both PRs are merged, both exact versions are public, and non-owner distribution receipts passed. |

### Validation run

- `forgecat validate --strict`, `forgecat plan`, and `forgecat scan` passed for both profiles.
- `ruby scripts/check-readme-catalog.rb` passed for 191 profiles and 41 collections.
- `ruby scripts/check-profile-artifacts.rb --changed-only origin/main...HEAD` passed for both changed profiles.
- License evidence, license gate, and license audit tests passed.
- Merged Converter `4c14734` release gates passed against the preserved private runtime ledgers.
- From non-owner `@yoochankim`, exact public Codex installs matched merged native artifacts byte-for-byte and uninstalled cleanly for both profiles.
