### PR TITLE
Fix Internal Comms license and platform metadata

### DIFF
--- a/profiles/anthropics/skills/anthropics_skills_internal-comms/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_internal-comms/README.md
@@ -1,3 +1,5 @@
+*written by ForgeCat*
+
 ![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Anthropic Skills — Internal Comms
@@ -18,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_internal-comms
 
 ## Skills
 
-- **internal-comms** — A set of resources to help me write all kinds of internal communications, using the formats that my company likes to use. Claude should use this skill whenever asked to write some sort of internal communications (status reports, leadership updates, 3P updates, company newsletters, FAQs, incident reports, project updates, etc.). `skill`
+- **internal-comms** — A set of resources to help me write all kinds of internal communications, using the formats that my company likes to use. Claude should use this skill whenever asked to write some sort of internal communications (status reports, leadership updates, 3P updates, company newsletters, FAQs, incident reports, project updates, etc.).
 
 ## Details
 
@@ -26,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_internal-comms
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.4` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -40,7 +42,9 @@ npx forgecat install @forgecat/anthropics_skills_internal-comms
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_internal-comms/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_internal-comms/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_internal-comms/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_internal-comms/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Anthropic Skills — Internal Comms
 
@@ -20,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_internal-comms
 
 ## Skills
 
-- **internal-comms** — A set of resources to help me write all kinds of internal communications, using the formats that my company likes to use. Claude should use this skill whenever asked to write some sort of internal communications (status reports, leadership updates, 3P updates, company newsletters, FAQs, incident reports, project updates, etc.). `skill`
+- **internal-comms** — A set of resources to help me write all kinds of internal communications, using the formats that my company likes to use. Claude should use this skill whenever asked to write some sort of internal communications (status reports, leadership updates, 3P updates, company newsletters, FAQs, incident reports, project updates, etc.).
 
 ## Details
 
@@ -28,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_internal-comms
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.0` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -40,9 +40,11 @@ npx forgecat install @forgecat/anthropics_skills_internal-comms
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
-| Codex | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_internal-comms/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_internal-comms/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_internal-comms/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_internal-comms/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Anthropic Skills — Internal Comms
 
@@ -20,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_internal-comms
 
 ## Skills
 
-- **internal-comms** — A set of resources to help me write all kinds of internal communications, using the formats that my company likes to use. Claude should use this skill whenever asked to write some sort of internal communications (status reports, leadership updates, 3P updates, company newsletters, FAQs, incident reports, project updates, etc.). `skill`
+- **internal-comms** — A set of resources to help me write all kinds of internal communications, using the formats that my company likes to use. Claude should use this skill whenever asked to write some sort of internal communications (status reports, leadership updates, 3P updates, company newsletters, FAQs, incident reports, project updates, etc.).
 
 ## Details
 
@@ -28,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_internal-comms
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.0` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -40,9 +40,11 @@ npx forgecat install @forgecat/anthropics_skills_internal-comms
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
-| Codex | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_internal-comms/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_internal-comms/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_internal-comms/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_internal-comms/README.md
@@ -1,6 +1,6 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
 # Anthropic Skills — Internal Comms
 
@@ -20,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_internal-comms
 
 ## Skills
 
-- **internal-comms** — A set of resources to help me write all kinds of internal communications, using the formats that my company likes to use. Claude should use this skill whenever asked to write some sort of internal communications (status reports, leadership updates, 3P updates, company newsletters, FAQs, incident reports, project updates, etc.). `skill`
+- **internal-comms** — A set of resources to help me write all kinds of internal communications, using the formats that my company likes to use. Claude should use this skill whenever asked to write some sort of internal communications (status reports, leadership updates, 3P updates, company newsletters, FAQs, incident reports, project updates, etc.).
 
 ## Details
 
@@ -28,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_internal-comms
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.0` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -40,9 +40,11 @@ npx forgecat install @forgecat/anthropics_skills_internal-comms
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
-| Codex | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_internal-comms/for-forgecat/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_internal-comms/for-forgecat/README.md
@@ -20,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_internal-comms
 
 ## Skills
 
-- **internal-comms** — A set of resources to help me write all kinds of internal communications, using the formats that my company likes to use. Claude should use this skill whenever asked to write some sort of internal communications (status reports, leadership updates, 3P updates, company newsletters, FAQs, incident reports, project updates, etc.). `skill`
+- **internal-comms** — A set of resources to help me write all kinds of internal communications, using the formats that my company likes to use. Claude should use this skill whenever asked to write some sort of internal communications (status reports, leadership updates, 3P updates, company newsletters, FAQs, incident reports, project updates, etc.).
 
 ## Details
 
@@ -28,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_internal-comms
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.4` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -42,7 +42,9 @@ npx forgecat install @forgecat/anthropics_skills_internal-comms
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_internal-comms/for-forgecat/profile.yml
+++ b/profiles/anthropics/skills/anthropics_skills_internal-comms/for-forgecat/profile.yml
@@ -1,28 +1,25 @@
-name: "@forgecat/anthropics_skills_internal-comms"
-version: 0.0.4
-description: A set of resources to help me write all kinds of internal communications,
-  using the formats that my company likes to use. Claude should use this skill whenever
-  asked to write some sort of internal communications (status reports, leadership
-  updates, 3P updates, company newsletters, FAQs, incident reports, project updates,
-  etc.).
+name: '@forgecat/anthropics_skills_internal-comms'
+description: A set of resources to help me write all kinds of internal communications, using the formats that my company likes to use. Claude should use this skill whenever asked to write some sort of internal communications (status reports, leadership updates, 3P updates, company newsletters, FAQs, incident reports, project updates, etc.).
+visibility: public
 repository: https://github.com/anthropics/skills
 license: Apache-2.0
-visibility: public
 sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:
-      - claude-code
-      - cursor
-      - codex
+    - claude-code
+    - cursor
+    - codex
+    - openclaw
+    - hermes
+    partial: []
   models:
     recommended: []
     minimum: []
 skills:
 - name: internal-comms
   path: skills/internal-comms/SKILL.md
-  description: A set of resources to help me write all kinds of internal communications,
-    using the formats that my company likes to use. Claude should use this skill whenever
-    asked to write some sort of internal communications (status reports, leadership
-    updates, 3P updates, company newsletters, FAQs, incident reports, project updates,
-    etc.).
+  description: A set of resources to help me write all kinds of internal communications, using the formats
+    that my company likes to use. Claude should use this skill whenever asked to write some sort of internal
+    communications (status reports, leadership updates, 3P updates, company newsletters, FAQs, incident
+    reports, project updates, etc.).


### PR DESCRIPTION
## Summary

This corrects Internal Comms to the source-backed Apache-2.0 license and Claude Code source platform. It also updates all ForgeCat-authored READMEs and records the five platforms verified by the private `0.0.5` canary.

All six upstream files are unchanged: `SKILL.md`, `LICENSE.txt`, and four runtime guideline files under `examples/`.

## Scope

- [ ] New profile
- [x] Existing profile fix
- [x] Platform artifact or compatibility update
- [x] README, metadata, or license correction
- [ ] Repo maintenance

## Source and License

- Source repository: https://github.com/anthropics/skills/tree/5128e1865d670f5d6c9cef000e6dfc4e951fb5b9
- Source path: `skills/internal-comms`
- License evidence: upstream `LICENSE.txt` at the pinned source commit

- [x] I inspected the upstream source repository directly.
- [x] I preserved source attribution in the profile README or metadata.
- [x] I confirmed the license and reflected it in `for-forgecat/profile.yml`.
- [x] I did not add files unrelated to the profile runtime.

## Validation

```text
Coverage: relocated 6, excluded 0, missing 0
Private Registry: @forgecat/anthropics_skills_internal-comms@0.0.5
Integrity: sha256-e46b54a0b4ffe18635d5311591e0f73347d93f02c733883e886c4098cf2b2bac
Shipping SHA: 3d59fa9677a6a966b0c3150ecd46ff9099274ef2268da1abdbd2cf287fe47bbd
Claude Code, Cursor, Codex, OpenClaw, Hermes: pass
Project native artifacts: 7 exact installed files per platform
Registry clone and final release gate: pass
```

- [x] `forgecat validate` passes from `for-forgecat/`.
- [x] README install commands and profile metadata agree.
- [x] No secrets, local state, logs, or generated cache files are included.

## Converter agent checklist

| Area | Status | Evidence | Risk / next action | Notes |
|---|---|---|---|---|
| PR scope | Pass | One Internal Comms subtree | Review with the paired History PR | Six text files plus generated metadata |
| Profile identity | Pass | Exact scoped name and source pin | None | Existing single-profile topology |
| Source inventory | Pass | Six source files | None | One skill, one license, four examples |
| Converted components | Pass | One skill row | None | Delivered to all five platforms |
| Internal file edits | Pass | Source byte comparison | None | No source-derived byte changed |
| Behavior parity | Pass | Five direct skill probes | None | Every runtime read `examples/3p-updates.md` |
| Manifest/schema | Pass | Strict validation and plan | None | All five platforms are tested |
| README/docs | Pass | Catalog check and version rows | None | `ForgeCat` casing verified |
| QA findings | Pass | Independent conversion QA | None | No finding |
| Validation gates | Pass | Handoff, empty scan, release gate | None | No accepted caveat needed |
| Registry/version | Pass | Private `0.0.5`, exact integrity | Keep private until both PRs merge | Public visibility needs separate approval |
| Platform runtime | Pass | Exact install, direct invocation, cleanup | None | 3P format rules recovered on all five |
| Native artifacts | Pass | Seven files per project platform | None | Exact installed-file receipts |
| License/security | Pass | Apache-2.0, all four security axes Low | None | No MCP or permission grant |
| Archive/history | Pass | Paired schema-3 record and snapshot | Merge both before public visibility | Snapshot matches eight shipping files |
| Operator decision | Approved | Echo message `373560cd-7c76-42e8-bc88-60d96a531b98` | Merge remains separate | Approval covered PR creation only |

- [x] Tested platforms have matching native `for-<platform>` directories.
- [x] Partial platforms list known limitations.
- [x] Runtime testing exercised the installed skill, not only a generic prompt.
- [x] The same evidence is included in the paired History record.

Registry `0.0.5` remains private. Merging this PR does not authorize public visibility.

Paired record: [History PR #37](https://github.com/nota-america/forgecat-profile-converter-history/pull/37), head `10f9da5a4cd5e1e8b431f76610e897cb7ac61eef`.
