### PR TITLE
Fix MCP Builder license and platform metadata

### DIFF
--- a/profiles/anthropics/skills/anthropics_skills_mcp-builder/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_mcp-builder/README.md
@@ -1,6 +1,8 @@
+*written by ForgeCat*
+
 ![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
-# Anthropic Skills — Mcp Builder
+# Anthropic Skills — MCP Builder
 
 Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).
 
@@ -18,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_mcp-builder
 
 ## Skills
 
-- **mcp-builder** — Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK). `skill`
+- **mcp-builder** — Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).
 
 ## Details
 
@@ -26,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_mcp-builder
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.4` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -40,7 +42,9 @@ npx forgecat install @forgecat/anthropics_skills_mcp-builder
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_mcp-builder/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_mcp-builder/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_mcp-builder/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_mcp-builder/README.md
@@ -1,8 +1,8 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
-# Anthropic Skills — Mcp Builder
+# Anthropic Skills — MCP Builder
 
 Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).
 
@@ -20,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_mcp-builder
 
 ## Skills
 
-- **mcp-builder** — Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK). `skill`
+- **mcp-builder** — Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).
 
 ## Details
 
@@ -28,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_mcp-builder
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.0` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -40,9 +40,11 @@ npx forgecat install @forgecat/anthropics_skills_mcp-builder
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
-| Codex | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_mcp-builder/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_mcp-builder/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_mcp-builder/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_mcp-builder/README.md
@@ -1,8 +1,8 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
-# Anthropic Skills — Mcp Builder
+# Anthropic Skills — MCP Builder
 
 Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).
 
@@ -20,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_mcp-builder
 
 ## Skills
 
-- **mcp-builder** — Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK). `skill`
+- **mcp-builder** — Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).
 
 ## Details
 
@@ -28,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_mcp-builder
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.0` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -40,9 +40,11 @@ npx forgecat install @forgecat/anthropics_skills_mcp-builder
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
-| Codex | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_mcp-builder/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_mcp-builder/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_mcp-builder/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_mcp-builder/README.md
@@ -1,8 +1,8 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
-# Anthropic Skills — Mcp Builder
+# Anthropic Skills — MCP Builder
 
 Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).
 
@@ -20,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_mcp-builder
 
 ## Skills
 
-- **mcp-builder** — Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK). `skill`
+- **mcp-builder** — Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).
 
 ## Details
 
@@ -28,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_mcp-builder
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.0` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -40,9 +40,11 @@ npx forgecat install @forgecat/anthropics_skills_mcp-builder
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
-| Codex | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_mcp-builder/for-forgecat/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_mcp-builder/for-forgecat/README.md
@@ -2,7 +2,7 @@
 
 ![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
-# Anthropic Skills — Mcp Builder
+# Anthropic Skills — MCP Builder
 
 Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).
 
@@ -20,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_mcp-builder
 
 ## Skills
 
-- **mcp-builder** — Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK). `skill`
+- **mcp-builder** — Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).
 
 ## Details
 
@@ -28,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_mcp-builder
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.4` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -42,7 +42,9 @@ npx forgecat install @forgecat/anthropics_skills_mcp-builder
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_mcp-builder/for-forgecat/profile.yml
+++ b/profiles/anthropics/skills/anthropics_skills_mcp-builder/for-forgecat/profile.yml
@@ -1,29 +1,31 @@
-name: "@forgecat/anthropics_skills_mcp-builder"
-version: 0.0.4
-description: Guide for creating high-quality MCP (Model Context Protocol) servers
-  that enable LLMs to interact with external services through well-designed tools.
-  Use when building MCP servers to integrate external APIs or services, whether in
-  Python (FastMCP) or Node/TypeScript (MCP SDK).
+name: '@forgecat/anthropics_skills_mcp-builder'
+description: Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).
+visibility: public
 repository: https://github.com/anthropics/skills
 license: Apache-2.0
-visibility: public
 sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:
-      - claude-code
-      - cursor
-      - codex
+    - claude-code
+    - cursor
+    - codex
+    - openclaw
+    - hermes
+    partial: []
   models:
     recommended: []
     minimum: []
 skills:
 - name: mcp-builder
   path: skills/mcp-builder/SKILL.md
-  description: Guide for creating high-quality MCP (Model Context Protocol) servers
-    that enable LLMs to interact with external services through well-designed tools.
-    Use when building MCP servers to integrate external APIs or services, whether
-    in Python (FastMCP) or Node/TypeScript (MCP SDK).
+  description: Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to
+    interact with external services through well-designed tools. Use when building MCP servers to integrate
+    external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).
   scripts:
   - path: skills/mcp-builder/scripts/connections.py
+    runtime: python
+    description: Lightweight connection handling for MCP servers.
   - path: skills/mcp-builder/scripts/evaluation.py
+    runtime: python
+    description: MCP Server Evaluation Harness


### PR DESCRIPTION
## Summary

This corrects MCP Builder to the source-backed Apache-2.0 license and Claude Code source platform. It also updates the ForgeCat-authored READMEs and records the five platforms verified by the private `0.0.5` canary.

The functional payload is unchanged. All ten upstream files and the three project-native payload trees already matched the exact install receipts. The PR changes six generated metadata and README files.

## Scope

- [ ] New profile
- [x] Existing profile fix
- [x] Platform artifact or compatibility update
- [x] README, metadata, or license correction
- [ ] Repo maintenance

## Source and license

- Source repository: https://github.com/anthropics/skills/tree/5128e1865d670f5d6c9cef000e6dfc4e951fb5b9
- Source path: `skills/mcp-builder`
- License evidence: upstream `LICENSE.txt` at the pinned source commit

- [x] I inspected the upstream source repository directly.
- [x] I preserved source attribution in the profile README or metadata.
- [x] I confirmed the license and reflected it in `for-forgecat/profile.yml`.
- [x] I did not add files unrelated to the profile runtime.

## Validation

```text
Coverage: relocated 10, excluded 0, missing 0
Private Registry: @forgecat/anthropics_skills_mcp-builder@0.0.5
Integrity: sha256-9f955d89ba50da2963554563118148e03104a25579d39bc2c72dd3fedffbe601
Shipping SHA: 198cab2ce4d97613348363af2b1474e3de9ec124b22a4189622d5d4f1bc91ea6
Claude Code, Cursor, Codex, OpenClaw, Hermes: pass
Project native artifacts: 11 exact installed files per platform
Registry clone and final release gate: pass
```

- [x] `forgecat validate` passes from `for-forgecat/`.
- [x] README install commands and profile metadata agree.
- [x] No secrets, local state, logs, or generated cache files are included.

## Converter agent checklist

| Area | Status | Evidence | Risk / next action | Notes |
|---|---|---|---|---|
| PR scope | Pass | One MCP Builder subtree | Review with the paired History PR | Six generated text files change |
| Profile identity | Pass | Exact scoped name and source pin | None | Existing single-profile topology |
| Source inventory | Pass | Ten source files | None | One skill, one license, four guides, two helpers, requirements, and XML |
| Converted components | Pass | One skill row | None | Delivered to all five platforms |
| Internal file edits | Pass | Source byte comparison | None | No source-derived byte changed |
| Behavior parity | Pass | Five direct skill probes | None | Every runtime read the installed guide and helper definitions |
| Manifest/schema | Pass | Strict validation and plan | None | All five platforms are tested |
| README/docs | Pass | Catalog check and version rows | None | `ForgeCat` casing verified |
| QA findings | Pass | Independent conversion QA | None | No finding |
| Validation gates | Pass | Handoff, empty scan, release gate | None | No accepted caveat needed |
| Registry/version | Pass | Private `0.0.5`, exact integrity | Keep private until both PRs merge | Public visibility needs separate approval |
| Platform runtime | Pass | Exact install, direct invocation, cleanup | None | Helpers were inspected but not executed |
| Native artifacts | Pass | Eleven files per project platform | None | Exact installed-file receipts |
| License/security | Pass | Apache-2.0, all four security axes Low | None | No MCP configuration or permission grant |
| Archive/history | Pass | Paired schema-3 record and snapshot | Merge both before public visibility | Snapshot matches twelve shipping files |
| Operator decision | Approved | Echo message `03c83700-1b63-4a11-9de6-cb344172282f` | Merge remains separate | Approval covered PR creation only |

- [x] Tested platforms have matching native `for-<platform>` directories.
- [x] Partial platforms list known limitations.
- [x] Runtime testing exercised the installed skill, not only a generic prompt.
- [x] The same evidence is included in the paired History record.

Registry `0.0.5` remains private. Merging this PR does not authorize public visibility.

Paired record: [History PR #38](https://github.com/nota-america/forgecat-profile-converter-history/pull/38), head `57bd31b96576b13ee5f76914fd8f516084ded2ec`.
