### PR TITLE
Fix Slack GIF Creator license and platform metadata

### DIFF
--- a/profiles/anthropics/skills/anthropics_skills_slack-gif-creator/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_slack-gif-creator/README.md
@@ -1,6 +1,8 @@
+*written by ForgeCat*
+
 ![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
-# Anthropic Skills — Slack Gif Creator
+# Anthropic Skills — Slack GIF Creator
 
 Knowledge and utilities for creating animated GIFs optimized for Slack. Provides constraints, validation tools, and animation concepts. Use when users request animated GIFs for Slack like "make me a GIF of X doing Y for Slack."
 
@@ -18,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_slack-gif-creator
 
 ## Skills
 
-- **slack-gif-creator** — Knowledge and utilities for creating animated GIFs optimized for Slack. Provides constraints, validation tools, and animation concepts. Use when users request animated GIFs for Slack like "make me a GIF of X doing Y for Slack." `skill`
+- **slack-gif-creator** — Knowledge and utilities for creating animated GIFs optimized for Slack. Provides constraints, validation tools, and animation concepts. Use when users request animated GIFs for Slack like "make me a GIF of X doing Y for Slack."
 
 ## Details
 
@@ -26,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_slack-gif-creator
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.4` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -40,7 +42,9 @@ npx forgecat install @forgecat/anthropics_skills_slack-gif-creator
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_slack-gif-creator/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_slack-gif-creator/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_slack-gif-creator/for-claude/.forgecat/profiles/@forgecat/anthropics_skills_slack-gif-creator/README.md
@@ -1,8 +1,8 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
-# Anthropic Skills — Slack Gif Creator
+# Anthropic Skills — Slack GIF Creator
 
 Knowledge and utilities for creating animated GIFs optimized for Slack. Provides constraints, validation tools, and animation concepts. Use when users request animated GIFs for Slack like "make me a GIF of X doing Y for Slack."
 
@@ -20,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_slack-gif-creator
 
 ## Skills
 
-- **slack-gif-creator** — Knowledge and utilities for creating animated GIFs optimized for Slack. Provides constraints, validation tools, and animation concepts. Use when users request animated GIFs for Slack like "make me a GIF of X doing Y for Slack." `skill`
+- **slack-gif-creator** — Knowledge and utilities for creating animated GIFs optimized for Slack. Provides constraints, validation tools, and animation concepts. Use when users request animated GIFs for Slack like "make me a GIF of X doing Y for Slack."
 
 ## Details
 
@@ -28,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_slack-gif-creator
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.0` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -40,9 +40,11 @@ npx forgecat install @forgecat/anthropics_skills_slack-gif-creator
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
-| Codex | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_slack-gif-creator/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_slack-gif-creator/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_slack-gif-creator/for-codex/.forgecat/profiles/@forgecat/anthropics_skills_slack-gif-creator/README.md
@@ -1,8 +1,8 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
-# Anthropic Skills — Slack Gif Creator
+# Anthropic Skills — Slack GIF Creator
 
 Knowledge and utilities for creating animated GIFs optimized for Slack. Provides constraints, validation tools, and animation concepts. Use when users request animated GIFs for Slack like "make me a GIF of X doing Y for Slack."
 
@@ -20,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_slack-gif-creator
 
 ## Skills
 
-- **slack-gif-creator** — Knowledge and utilities for creating animated GIFs optimized for Slack. Provides constraints, validation tools, and animation concepts. Use when users request animated GIFs for Slack like "make me a GIF of X doing Y for Slack." `skill`
+- **slack-gif-creator** — Knowledge and utilities for creating animated GIFs optimized for Slack. Provides constraints, validation tools, and animation concepts. Use when users request animated GIFs for Slack like "make me a GIF of X doing Y for Slack."
 
 ## Details
 
@@ -28,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_slack-gif-creator
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.0` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -40,9 +40,11 @@ npx forgecat install @forgecat/anthropics_skills_slack-gif-creator
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
-| Codex | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_slack-gif-creator/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_slack-gif-creator/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_slack-gif-creator/for-cursor/.forgecat/profiles/@forgecat/anthropics_skills_slack-gif-creator/README.md
@@ -1,8 +1,8 @@
 *written by ForgeCat*
 
-![Forgecat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
+![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
-# Anthropic Skills — Slack Gif Creator
+# Anthropic Skills — Slack GIF Creator
 
 Knowledge and utilities for creating animated GIFs optimized for Slack. Provides constraints, validation tools, and animation concepts. Use when users request animated GIFs for Slack like "make me a GIF of X doing Y for Slack."
 
@@ -20,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_slack-gif-creator
 
 ## Skills
 
-- **slack-gif-creator** — Knowledge and utilities for creating animated GIFs optimized for Slack. Provides constraints, validation tools, and animation concepts. Use when users request animated GIFs for Slack like "make me a GIF of X doing Y for Slack." `skill`
+- **slack-gif-creator** — Knowledge and utilities for creating animated GIFs optimized for Slack. Provides constraints, validation tools, and animation concepts. Use when users request animated GIFs for Slack like "make me a GIF of X doing Y for Slack."
 
 ## Details
 
@@ -28,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_slack-gif-creator
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.0` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -40,9 +40,11 @@ npx forgecat install @forgecat/anthropics_skills_slack-gif-creator
 | Platform | Status |
 |---|---|
 | Claude Code | Tested |
-| Cursor | Partial |
-| Codex | Partial |
+| Cursor | Tested |
+| Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_slack-gif-creator/for-forgecat/README.md
+++ b/profiles/anthropics/skills/anthropics_skills_slack-gif-creator/for-forgecat/README.md
@@ -2,7 +2,7 @@
 
 ![ForgeCat](https://raw.githubusercontent.com/nota-america/forgecat-agent-profiles/main/assets/forgecat_banner.png)
 
-# Anthropic Skills — Slack Gif Creator
+# Anthropic Skills — Slack GIF Creator
 
 Knowledge and utilities for creating animated GIFs optimized for Slack. Provides constraints, validation tools, and animation concepts. Use when users request animated GIFs for Slack like "make me a GIF of X doing Y for Slack."
 
@@ -20,7 +20,7 @@ npx forgecat install @forgecat/anthropics_skills_slack-gif-creator
 
 ## Skills
 
-- **slack-gif-creator** — Knowledge and utilities for creating animated GIFs optimized for Slack. Provides constraints, validation tools, and animation concepts. Use when users request animated GIFs for Slack like "make me a GIF of X doing Y for Slack." `skill`
+- **slack-gif-creator** — Knowledge and utilities for creating animated GIFs optimized for Slack. Provides constraints, validation tools, and animation concepts. Use when users request animated GIFs for Slack like "make me a GIF of X doing Y for Slack."
 
 ## Details
 
@@ -28,10 +28,10 @@ npx forgecat install @forgecat/anthropics_skills_slack-gif-creator
 |---|---|
 | Author | Anthropic |
 | Original repository | https://github.com/anthropics/skills |
-| Version | `0.0.4` |
-| Original commit | `5128e18` |
-| License | Complete terms in LICENSE.txt |
-| Source platform | Claude Code |
+| Version | `0.0.5` |
+| Original commit | 5128e1865d670f5d6c9cef000e6dfc4e951fb5b9 |
+| License | Apache-2.0 |
+| Source platform | claude-code |
 
 ## Compatibility
 
@@ -42,7 +42,9 @@ npx forgecat install @forgecat/anthropics_skills_slack-gif-creator
 | Claude Code | Tested |
 | Cursor | Tested |
 | Codex | Tested |
+| OpenClaw | Tested |
+| Hermes | Tested |
 
 ## Dependencies
 
-- None
+- None required to install this profile. Individual skills may require tools or credentials documented in their own `SKILL.md` files.

--- a/profiles/anthropics/skills/anthropics_skills_slack-gif-creator/for-forgecat/profile.yml
+++ b/profiles/anthropics/skills/anthropics_skills_slack-gif-creator/for-forgecat/profile.yml
@@ -1,29 +1,37 @@
-name: "@forgecat/anthropics_skills_slack-gif-creator"
-version: 0.0.4
-description: Knowledge and utilities for creating animated GIFs optimized for Slack.
-  Provides constraints, validation tools, and animation concepts. Use when users request
-  animated GIFs for Slack like "make me a GIF of X doing Y for Slack."
+name: '@forgecat/anthropics_skills_slack-gif-creator'
+description: Knowledge and utilities for creating animated GIFs optimized for Slack. Provides constraints, validation tools, and animation concepts. Use when users request animated GIFs for Slack like "make me a GIF of X doing Y for Slack."
+visibility: public
 repository: https://github.com/anthropics/skills
 license: Apache-2.0
-visibility: public
 sourcePlatform: claude-code
 compatibility:
   platforms:
     tested:
-      - claude-code
-      - cursor
-      - codex
+    - claude-code
+    - cursor
+    - codex
+    - openclaw
+    - hermes
+    partial: []
   models:
     recommended: []
     minimum: []
 skills:
 - name: slack-gif-creator
   path: skills/slack-gif-creator/SKILL.md
-  description: Knowledge and utilities for creating animated GIFs optimized for Slack.
-    Provides constraints, validation tools, and animation concepts. Use when users
-    request animated GIFs for Slack like "make me a GIF of X doing Y for Slack."
+  description: Knowledge and utilities for creating animated GIFs optimized for Slack. Provides constraints,
+    validation tools, and animation concepts. Use when users request animated GIFs for Slack like "make
+    me a GIF of X doing Y for Slack."
   scripts:
   - path: skills/slack-gif-creator/core/easing.py
+    runtime: python
+    description: Easing Functions - Timing functions for smooth animations.
   - path: skills/slack-gif-creator/core/frame_composer.py
+    runtime: python
+    description: Frame Composer - Utilities for composing visual elements into frames.
   - path: skills/slack-gif-creator/core/gif_builder.py
+    runtime: python
+    description: GIF Builder - Core module for assembling frames into GIFs optimized for Slack.
   - path: skills/slack-gif-creator/core/validators.py
+    runtime: python
+    description: Validators - Check if GIFs meet Slack's requirements.


### PR DESCRIPTION
## Summary

This corrects Slack GIF Creator to the source-backed Apache-2.0 license and Claude Code source platform. It also updates the ForgeCat-authored READMEs and records the five platforms verified by the private `0.0.5` canary.

The functional payload is unchanged. All seven upstream files and the three project-native skill trees already matched the exact install receipts. The PR changes six generated metadata and README files.

## Scope

- [ ] New profile
- [x] Existing profile fix
- [x] Platform artifact or compatibility update
- [x] README, metadata, or license correction
- [ ] Repo maintenance

## Source and license

- Source repository: https://github.com/anthropics/skills/tree/5128e1865d670f5d6c9cef000e6dfc4e951fb5b9
- Source path: `skills/slack-gif-creator`
- License evidence: upstream `LICENSE.txt` at the pinned source commit

- [x] I inspected the upstream source repository directly.
- [x] I preserved source attribution in the profile README or metadata.
- [x] I confirmed the license and reflected it in `for-forgecat/profile.yml`.
- [x] I did not add files unrelated to the profile runtime.

## Validation

```text
Coverage: relocated 7, excluded 0, missing 0
Private Registry: @forgecat/anthropics_skills_slack-gif-creator@0.0.5
Integrity: sha256-290723209c30c8d7f800628dfd74a7a1e190ef08c377ccb3a30defa1cd273799
Shipping SHA: dfc2a05370e0df2ddcffc839fc459f0bff5c8360402529fc051faacd283994ef
Claude Code, Cursor, Codex, OpenClaw, Hermes: pass
Project native artifacts: 8 exact installed files per platform
Registry clone and final release gate: pass
```

- [x] `forgecat validate` passes from `for-forgecat/`.
- [x] README install commands and profile metadata agree.
- [x] No secrets, local state, logs, or generated cache files are included.

## Converter agent checklist

| Area | Status | Evidence | Risk / next action | Notes |
|---|---|---|---|---|
| PR scope | Pass | One Slack GIF Creator subtree | Review with the paired History PR | Six generated text files change |
| Profile identity | Pass | Exact scoped name and source pin | None | Existing single-profile topology |
| Source inventory | Pass | Seven source files | None | One skill, one license, four Python utilities, and requirements |
| Converted components | Pass | One skill row | None | Delivered to all five platforms |
| Internal file edits | Pass | Source byte comparison | None | No source-derived byte changed |
| Behavior parity | Pass | Five direct skill probes | None | Every runtime read the installed skill, helpers, and requirements |
| Manifest/schema | Pass | Strict validation and plan | None | All five platforms are tested |
| README/docs | Pass | Catalog check and version rows | None | `ForgeCat` casing verified |
| QA findings | Pass | Independent conversion QA | None | No finding |
| Validation gates | Pass | Handoff, empty scan, release gate | None | No conversion caveat needed |
| Registry/version | Pass | Private `0.0.5`, exact integrity | Keep private until both PRs merge | Public visibility needs separate approval |
| Platform runtime | Pass | Exact install, direct invocation, cleanup | Record runtime scope | Helpers were inspected but not executed |
| Native artifacts | Pass | Eight files per project platform | None | Exact installed-file receipts |
| License/security | Pass | Apache-2.0, all four security axes Low | None | No MCP configuration or permission grant |
| Archive/history | Pass | Paired schema-3 record and snapshot | Merge both before public visibility | Snapshot matches nine shipping files |
| Operator decision | Approved | Echo message `d4e89a27-e613-471e-a734-ed0f0c56654d` | Merge remains separate | Approval covered PR creation and both caveats |

- [x] Tested platforms have matching native `for-<platform>` directories.
- [x] Partial platforms list known limitations.
- [x] Runtime testing exercised the installed skill, not only a generic prompt.
- [x] The same evidence is included in the paired History record.

## Runtime scope

The read-only canary verified the installed GIF construction and validation rules but did not render a GIF. The upstream `requirements.txt` lists `imageio-ffmpeg>=0.4.9`, while the SKILL.md pip example lists pillow, imageio, and numpy. Both source files remain unchanged, and the paired History record preserves this difference.

Registry `0.0.5` remains private. Merging this PR does not authorize public visibility.

Paired record: [History PR #39](https://github.com/nota-america/forgecat-profile-converter-history/pull/39), head `441d23b9536cd97f94210f5b4e8ebe8dafec64f2`.
